### PR TITLE
Bump aio-theme for search

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/AdobeDocs/commerce-services"
   },
   "dependencies": {
-    "@adobe/gatsby-theme-aio": "4.6.2",
+    "@adobe/gatsby-theme-aio": "4.6.4",
     "gatsby": "4.22.0",
     "react": "^17.0.0",
     "react-dom": "^17.0.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -33,9 +33,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@adobe/gatsby-theme-aio@npm:4.6.2":
-  version: 4.6.2
-  resolution: "@adobe/gatsby-theme-aio@npm:4.6.2"
+"@adobe/gatsby-theme-aio@npm:4.6.4":
+  version: 4.6.4
+  resolution: "@adobe/gatsby-theme-aio@npm:4.6.4"
   dependencies:
     "@adobe/focus-ring-polyfill": ^0.1.5
     "@adobe/gatsby-source-github-file-contributors": ^0.3.1
@@ -125,7 +125,7 @@ __metadata:
     gatsby: ^4.22.0
     react: ^17.0.2
     react-dom: ^17.0.2
-  checksum: 54b9220b915bf1e2dba545b5686baaca382a37330d4956b1cf8c7ccd20e3a0b365c3896672fbd28ee4ca3f0c062660202ba2f2d9d3372cffc70c878b89d572c2
+  checksum: 15b5519b6e5fc332f484afb4cb1d67b4db342e17b03f60df659fabc2d352fce1d122f3dab4bc51c22042d34e56d9f7c734cdc2557ecff2c8ab4d64e864849718
   languageName: node
   linkType: hard
 
@@ -6638,7 +6638,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "commerce-services@workspace:."
   dependencies:
-    "@adobe/gatsby-theme-aio": 4.6.2
+    "@adobe/gatsby-theme-aio": 4.6.4
     gatsby: 4.22.0
     react: ^17.0.0
     react-dom: ^17.0.0


### PR DESCRIPTION
## Description

This pull request bumps the aio-theme to v4.6.4, which added the commerce-service Algolia search index to the site.

According to the Devsite team, although the index exists in Algolia, results won't appear in site search until we update each repo. I can confirm that results don't currently appear on production, but I'm curious to see how bumping the theme in a single commerce repo affects search (if it all). 

When I run a local build of this branch, site search returns results from the commerce-services index. I suspect that merging this will make results from the commerce-services index available when searching from the commerce-services site only on production and not any other context, but I want to test that theory.

## Related Issue

- #28 