### PR TITLE
Add edition metadata for Product Recommendations SDK

### DIFF
--- a/src/pages/product-recommendations/index.md
+++ b/src/pages/product-recommendations/index.md
@@ -1,6 +1,7 @@
 ---
 title: Product Recommendations SDK
 description: Learn how to use the Product Recommendations SDK with Adobe Commerce to fetch recommendations programmatically in the browser.
+edition: ee
 ---
 
 # Product Recommendations SDK


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Add [edition keyword](https://github.com/adobe/aio-theme#edition-keyword) metadata to Product Recommendations SDK.

## Related Issue

#27 

## Motivation and Context

While reviewing https://github.com/magento-commerce/devdocs/pull/3206, I noticed that the Product Recommendations topic has the [`ee_only: true`](https://github.com/magento-commerce/devdocs/pull/3206/files#diff-664c977119786d362cbffcda991da82889c5bddc5c0bb4787502b9a0f7e37f27R4) property set. This PR adds the equivalent property for devsite repos.

## How Has This Been Tested?

GitHub Actions PR validation

## Checklist:

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
