### PR TITLE
[PREX-1524] Added events table to Events Collector topic

### DIFF
--- a/src/pages/shared-services/storefront-events/collector/index.md
+++ b/src/pages/shared-services/storefront-events/collector/index.md
@@ -40,7 +40,7 @@ The list of supported events can differ between eventing frameworks. The followi
 
 ### Event names by framework
 
-| Event| Storefront Events SDK (adobeDataLayer) | Commerce (Snowplow)| AEP/Beacon   |
+| Event| Storefront Events SDK (adobeDataLayer) | Commerce (Snowplow)| Adobe Experience Platform   |
 | --- | --- | --- | --- |
 | add to requisition list      | addToRequisitionList    | ❌    | xdm namespace: commerce<br>xdm type: requisitionListAdds     |
 | cart open     | openCart  | ❌    | xdm namespace: commerce<br>xdm type: productListOpens        |
@@ -71,7 +71,7 @@ The list of supported events can differ between eventing frameworks. The followi
 
 ### Event support by framework
 
-| Event | Luma/PHP  ("Snowplow")  | Luma/PHP Experience Cloud ("Beacon")   | PWA Commerce ("Snowplow")| PWA Experience Cloud ("Beacon")   |
+| Event | Luma/PHP  ("Snowplow")  | Luma/PHP Adobe Experience Platform  | PWA Commerce ("Snowplow")| PWA Adobe Experience Platform  |
 | --- | --- | --- | --- | --- |
 | add to requisition list  | ❌ | PDP<br>PLP<br>Cart<br>Account | ❌ | ❌ |
 | cart open  | ❌ | PDP<br>PLP (Browse)<br>PLP (Search results)<br>Cart  | ❌ | ❌ |

--- a/src/pages/shared-services/storefront-events/collector/index.md
+++ b/src/pages/shared-services/storefront-events/collector/index.md
@@ -42,46 +42,46 @@ The list of supported events can differ between eventing frameworks. The followi
 
 | Event| Storefront Events SDK (adobeDataLayer) | Commerce (Snowplow)| Adobe Experience Platform   |
 | --- | --- | --- | --- |
-| add to requisition list      | addToRequisitionList    | ❌    | xdm namespace: commerce<br>xdm type: requisitionListAdds     |
-| cart open     | openCart  | ❌    | xdm namespace: commerce<br>xdm type: productListOpens        |
-| cart view     | shoppingCartView        | category: shopping-cart<br>action: view| xdm namespace: commerce<br>xdm type: productListViews        |
-| complete checkout   | placeOrder| category: checkout<br>action: place-order       | xdm namespace: commerce<br>xdm type: purchases|
-| create account| createAccount  | ❌    | xdm namespace: userAccount<br>xdm type: createProfile        |
-| create requisition list      | createRequisitionList   | ❌    | xdm namespace: commerce<br>xdm type: requisitionListOpens    |
-| edit account  | editAccount    | ❌    | xdm namespace: userAccount<br>xdm type: updateProfile        |
-| page view     | pageView  | category: ---<br>action: Pageview | xdm namespace: web.webpagedetails<br>xdm type: pageViews     |
-| product adds to cart | addToCart | category: product<br>action: add-to-cart        | xdm namespace: commerce<br>xdm type: productListAdds|
-| product remove from cart     | removeFromCart | ❌    | xdm namespace: commerce<br>xdm type: productListRemovals     |
-| product view  | productPageView| category: product<br>action: view | xdm namespace: commerce<br>xdm type: productViews   |
-| recommendation item add to cart        | recsItemAddToCartClick  | category: recommendation-unit<br>action: rec-add-to-cart-click | ❌  |
-| recommendation item click     | recsItemClick  | category: recommendation-unit<br>action: rec-click    | ❌  |
-| recommendation request sent   | recsRequestSent| category: recommendation-unit<br>action: api-request-sent      | ❌  |
-| recommendation response received       | recsResponseReceived    | category: recommendation-unit<br>action: api-response-received | ❌  |
-| recommendation unit render    | recsUnitRender | category: recommendation-unit<br>action: impression-render     | ❌  |
-| recommendation unit view| recsUnitView   | category: recommendation-unit<br>action: view   | ❌  |
-| remove from requisition list | removeFromRequisitionList     | ❌    | xdm namespace: commerce<br>xdm type: requisitionListRemovals |
-| search category click        | searchCategoryClick     | category: search<br>action: category-click      | ❌  |
-| search product click| searchProductClick      | category: search<br>action: product-click       | ❌  |
-| search request sent | searchRequestSent       | category: search<br>action: api-request-sent    | xdm namespace: ---<br>xdm type: searchRequest |
-| search response received     | searchResponseReceived  | category: search<br>action: api-response-received     | xdm namespace: ---<br>xdm type: searchResponse|
-| search results view | searchResultsView       | category: search<br>action: results-view        | ❌  |
-| sign in       | signIn    | ❌    | xdm namespace: userAccount<br>xdm type: login |
-| sign out      | signOut   | ❌    | xdm namespace: userAccount<br>xdm type: logout|
-| start checkout| initiateCheckout        | category: shopping-cart<br>action: initiate-checkout  | xdm namespace: commerce<br>xdm type: checkouts|
+| add to requisition list      | addToRequisitionList    | ❌    | xdm namespace: commerce<br/>xdm type: requisitionListAdds     |
+| cart open     | openCart  | ❌    | xdm namespace: commerce<br/>xdm type: productListOpens        |
+| cart view     | shoppingCartView        | category: shopping-cart<br/>action: view| xdm namespace: commerce<br/>xdm type: productListViews        |
+| complete checkout   | placeOrder| category: checkout<br/>action: place-order       | xdm namespace: commerce<br/>xdm type: purchases|
+| create account| createAccount  | ❌    | xdm namespace: userAccount<br/>xdm type: createProfile        |
+| create requisition list      | createRequisitionList   | ❌    | xdm namespace: commerce<br/>xdm type: requisitionListOpens    |
+| edit account  | editAccount    | ❌    | xdm namespace: userAccount<br/>xdm type: updateProfile        |
+| page view     | pageView  | category: ---<br/>action: Pageview | xdm namespace: web.webpagedetails<br/>xdm type: pageViews     |
+| product adds to cart | addToCart | category: product<br/>action: add-to-cart        | xdm namespace: commerce<br/>xdm type: productListAdds|
+| product remove from cart     | removeFromCart | ❌    | xdm namespace: commerce<br/>xdm type: productListRemovals     |
+| product view  | productPageView| category: product<br/>action: view | xdm namespace: commerce<br/>xdm type: productViews   |
+| recommendation item add to cart        | recsItemAddToCartClick  | category: recommendation-unit<br/>action: rec-add-to-cart-click | ❌  |
+| recommendation item click     | recsItemClick  | category: recommendation-unit<br/>action: rec-click    | ❌  |
+| recommendation request sent   | recsRequestSent| category: recommendation-unit<br/>action: api-request-sent      | ❌  |
+| recommendation response received       | recsResponseReceived    | category: recommendation-unit<br/>action: api-response-received | ❌  |
+| recommendation unit render    | recsUnitRender | category: recommendation-unit<br/>action: impression-render     | ❌  |
+| recommendation unit view| recsUnitView   | category: recommendation-unit<br/>action: view   | ❌  |
+| remove from requisition list | removeFromRequisitionList     | ❌    | xdm namespace: commerce<br/>xdm type: requisitionListRemovals |
+| search category click        | searchCategoryClick     | category: search<br/>action: category-click      | ❌  |
+| search product click| searchProductClick      | category: search<br/>action: product-click       | ❌  |
+| search request sent | searchRequestSent       | category: search<br/>action: api-request-sent    | xdm namespace: ---<br/>xdm type: searchRequest |
+| search response received     | searchResponseReceived  | category: search<br/>action: api-response-received     | xdm namespace: ---<br/>xdm type: searchResponse|
+| search results view | searchResultsView       | category: search<br/>action: results-view        | ❌  |
+| sign in       | signIn    | ❌    | xdm namespace: userAccount<br/>xdm type: login |
+| sign out      | signOut   | ❌    | xdm namespace: userAccount<br/>xdm type: logout|
+| start checkout| initiateCheckout        | category: shopping-cart<br/>action: initiate-checkout  | xdm namespace: commerce<br/>xdm type: checkouts|
 
 ### Event support by framework
 
 | Event | Luma/PHP  ("Snowplow")  | Luma/PHP Adobe Experience Platform  | PWA Commerce ("Snowplow")| PWA Adobe Experience Platform  |
 | --- | --- | --- | --- | --- |
-| add to requisition list  | ❌ | PDP<br>PLP<br>Cart<br>Account | ❌ | ❌ |
-| cart open  | ❌ | PDP<br>PLP (Browse)<br>PLP (Search results)<br>Cart  | ❌ | ❌ |
-| cart view  | Cart   | Cart   | Cart   | Cart<br>Mini cart|
+| add to requisition list  | ❌ | PDP<br/>PLP<br/>Cart<br/>Account | ❌ | ❌ |
+| cart open  | ❌ | PDP<br/>PLP (Browse)<br/>PLP (Search results)<br/>Cart  | ❌ | ❌ |
+| cart view  | Cart   | Cart   | Cart   | Cart<br/>Mini cart|
 | complete checkout   | Checkout   | Checkout   | Checkout   | Checkout   |
 | create account  | ❌ | Account| ❌ | Account|
-| create requisition list  | ❌ | PDP<br>PLP<br>Cart<br>Account | ❌ | ❌ |
+| create requisition list  | ❌ | PDP<br/>PLP<br/>Cart<br/>Account | ❌ | ❌ |
 | edit account| ❌ | Account| ❌ | Account|
-| page view  | Landing page<br>PDP<br>PLP (Browse)<br>PLP (Search results)<br>Cart<br>Checkout | Landing page<br>PDP<br>PLP (Browse)<br>PLP (Search results)<br>Cart<br>Checkout | Landing page<br>PDP<br>PLP (Browse)<br>PLP (Search results)<br>Cart<br>Checkout | Landing page<br>PDP<br>PLP (Browse)<br>PLP (Search results)<br>Cart<br>Checkout |
-| product add to cart | PDP<br>PLP (Browse)<br>PLP (Search results)<br>Cart  | PDP<br>PLP (Browse)<br>PLP (Search results)<br>Cart  | PDP| PDP|
+| page view  | Landing page<br/>PDP<br/>PLP (Browse)<br/>PLP (Search results)<br/>Cart<br/>Checkout | Landing page<br/>PDP<br/>PLP (Browse)<br/>PLP (Search results)<br/>Cart<br/>Checkout | Landing page<br/>PDP<br/>PLP (Browse)<br/>PLP (Search results)<br/>Cart<br/>Checkout | Landing page<br/>PDP<br/>PLP (Browse)<br/>PLP (Search results)<br/>Cart<br/>Checkout |
+| product add to cart | PDP<br/>PLP (Browse)<br/>PLP (Search results)<br/>Cart  | PDP<br/>PLP (Browse)<br/>PLP (Search results)<br/>Cart  | PDP| PDP|
 | product remove from cart | ❌ | Cart   | ❌ | ❌ |
 | product view| PDP| PDP| PDP| PDP|
 | recs item add to cart| Recs carousel | ❌ | Recs carousel | ❌ |
@@ -93,12 +93,12 @@ The list of supported events can differ between eventing frameworks. The followi
 | remove from requisition list | ❌ | Account| ❌ | ❌ |
 | search category click| Search popover  | ❌ | ❌ | ❌ |
 | search product click| Search popover  | ❌ | ❌ | ❌ |
-| search request sent | Search popover<br>PLP (Browse)<br>PLP (Search results)   | Search popover<br>PLP (Browse)<br>PLP (Search results)   | ❌ | ❌ |
-| search response received<br> | Search popover<br>PLP (Browse)<br>PLP (Search results)   | Search popover<br>PLP (Browse)<br>PLP (Search results)   | ❌ | ❌ |
-| search results view | Search popover<br>PLP (Browse)<br>PLP (Search results)   | ❌ | ❌ | ❌ |
+| search request sent | Search popover<br/>PLP (Browse)<br/>PLP (Search results)   | Search popover<br/>PLP (Browse)<br/>PLP (Search results)   | ❌ | ❌ |
+| search response received<br/> | Search popover<br/>PLP (Browse)<br/>PLP (Search results)   | Search popover<br/>PLP (Browse)<br/>PLP (Search results)   | ❌ | ❌ |
+| search results view | Search popover<br/>PLP (Browse)<br/>PLP (Search results)   | ❌ | ❌ | ❌ |
 | sign in| ❌ | Account| ❌ | Account|
 | sign out   | ❌ | Account| ❌ | ❌ |
-| start checkout  | Cart   | Cart   | Cart   | Cart<br>Mini cart|
+| start checkout  | Cart   | Cart   | Cart   | Cart<br/>Mini cart|
 
 ## Support
 

--- a/src/pages/shared-services/storefront-events/collector/index.md
+++ b/src/pages/shared-services/storefront-events/collector/index.md
@@ -34,42 +34,75 @@ import "@adobe/magento-storefront-event-collector";
 
 The collector then begins listening for events. When these events are fired, the collector runs the associated handler and sends the event along with any relevant information to Adobe Commerce for further processing.
 
-The following table lists supported and unsupported events for Luma/PHP and PWA sites on the Snowplow or Beacon event frameworks.
+## Supported events
 
-| Event| Luma/PHP Commerce |   Luma/PHP Commerce    | PWA   |  PWA     |
+The list of supported events can differ between eventing frameworks. The following tables describe the events supported on each framework and the equivalent event names.
+
+### Event names by framework
+
+| Event| Storefront Events SDK (adobeDataLayer) | Commerce (Snowplow)| AEP/Beacon   |
+| --- | --- | --- | --- |
+| add to requisition list      | addToRequisitionList    | ❌    | xdm namespace: commerce<br>xdm type: requisitionListAdds     |
+| cart open     | openCart  | ❌    | xdm namespace: commerce<br>xdm type: productListOpens        |
+| cart view     | shoppingCartView        | category: shopping-cart<br>action: view| xdm namespace: commerce<br>xdm type: productListViews        |
+| complete checkout   | placeOrder| category: checkout<br>action: place-order       | xdm namespace: commerce<br>xdm type: purchases|
+| create account| createAccount  | ❌    | xdm namespace: userAccount<br>xdm type: createProfile        |
+| create requisition list      | createRequisitionList   | ❌    | xdm namespace: commerce<br>xdm type: requisitionListOpens    |
+| edit account  | editAccount    | ❌    | xdm namespace: userAccount<br>xdm type: updateProfile        |
+| page view     | pageView  | category: ---<br>action: Pageview | xdm namespace: web.webpagedetails<br>xdm type: pageViews     |
+| product adds to cart | addToCart | category: product<br>action: add-to-cart        | xdm namespace: commerce<br>xdm type: productListAdds|
+| product remove from cart     | removeFromCart | ❌    | xdm namespace: commerce<br>xdm type: productListRemovals     |
+| product view  | productPageView| category: product<br>action: view | xdm namespace: commerce<br>xdm type: productViews   |
+| recommendation item add to cart        | recsItemAddToCartClick  | category: recommendation-unit<br>action: rec-add-to-cart-click | ❌  |
+| recommendation item click     | recsItemClick  | category: recommendation-unit<br>action: rec-click    | ❌  |
+| recommendation request sent   | recsRequestSent| category: recommendation-unit<br>action: api-request-sent      | ❌  |
+| recommendation response received       | recsResponseReceived    | category: recommendation-unit<br>action: api-response-received | ❌  |
+| recommendation unit render    | recsUnitRender | category: recommendation-unit<br>action: impression-render     | ❌  |
+| recommendation unit view| recsUnitView   | category: recommendation-unit<br>action: view   | ❌  |
+| remove from requisition list | removeFromRequisitionList     | ❌    | xdm namespace: commerce<br>xdm type: requisitionListRemovals |
+| search category click        | searchCategoryClick     | category: search<br>action: category-click      | ❌  |
+| search product click| searchProductClick      | category: search<br>action: product-click       | ❌  |
+| search request sent | searchRequestSent       | category: search<br>action: api-request-sent    | xdm namespace: ---<br>xdm type: searchRequest |
+| search response received     | searchResponseReceived  | category: search<br>action: api-response-received     | xdm namespace: ---<br>xdm type: searchResponse|
+| search results view | searchResultsView       | category: search<br>action: results-view        | ❌  |
+| sign in       | signIn    | ❌    | xdm namespace: userAccount<br>xdm type: login |
+| sign out      | signOut   | ❌    | xdm namespace: userAccount<br>xdm type: logout|
+| start checkout| initiateCheckout        | category: shopping-cart<br>action: initiate-checkout  | xdm namespace: commerce<br>xdm type: checkouts|
+
+### Event support by framework
+
+| Event | Luma/PHP  ("Snowplow")  | Luma/PHP Experience Cloud ("Beacon")   | PWA Commerce ("Snowplow")| PWA Experience Cloud ("Beacon")   |
 | --- | --- | --- | --- | --- |
-|      | Commerce ("Snowplow")      | Experience Cloud ("Beacon")| Commerce ("Snowplow")      | Experience Cloud ("Beacon")|
-|      |       |       |       |       |
-| [b2b] add to requisition list | ❌     | PDP<br>PLP<br>Cart<br>Account              | ❌     | ❌     |
-| [b2b] create requisition list | ❌     | PDP<br>PLP<br>Cart<br>Account              | ❌     | ❌     |
-| [b2b] delete requisition list | ❌     | Account           | ❌     | ❌     |
-| cart open     | ❌     | PDP<br>PLP (Browse)<br>PLP (Search results)<br>Cart    | ❌     | ❌     |
-| cart view     | Cart  | Cart  | Cart  | Cart<br>Mini cart |
-| complete checkout             | Checkout          | Checkout          | Checkout          | Checkout          |
-| create account| ❌     | Account           | ❌     | Account           |
-| edit account  | ❌     | Account           | ❌     | Account           |
-| page view     | Landing page<br>PDP<br>PLP (Browse)<br>PLP (Search results)<br>Cart<br>Checkout | Landing page<br>PDP<br>PLP (Browse)<br>PLP (Search results)<br>Cart<br>Checkout | Landing page<br>PDP<br>PLP (Browse)<br>PLP (Search results)<br>Cart<br>Checkout | Landing page<br>PDP<br>PLP (Browse)<br>PLP (Search results)<br>Cart<br>Checkout |
-| product add to cart           | PDP<br>PLP (Browse)<br>PLP (Search results)<br>Cart    | PDP<br>PLP (Browse)<br>PLP (Search results)<br>Cart    | PDP   | PDP   |
-| product remove from cart      | ❌     | Cart  | ❌     | ❌     |
-| product view  | PDP   | PDP   | PDP   | PDP   |
-| recs item add to cart         | Recs carousel       | ❌     | Recs carousel       | ❌     |
-| recs item click               | Recs carousel       | ❌     | Recs carousel       | ❌     |
-| recs request sent             | Recs carousel       | ❌     | Recs carousel       | ❌     |
-| recs response received        | Recs carousel       | ❌     | Recs carousel       | ❌     |
-| recs unit render              | Recs carousel       | ❌     | Recs carousel       | ❌     |
-| recs unit view| Recs carousel       | ❌     | Recs carousel       | ❌     |
-| search category click         | Search popover    | ❌     | ❌     | ❌     |
-| search product click          | Search popover    | ❌     | ❌     | ❌     |
-| search request sent           | Search popover<br>PLP (Browse)<br>PLP (Search results) | Search popover<br>PLP (Browse)<br>PLP (Search results) | ❌     | ❌     |
-| search response received      | Search popover<br>PLP (Browse)<br>PLP (Search results) | Search popover<br>PLP (Browse)<br>PLP (Search results) | ❌     | ❌     |
-| search results view           | Search popover<br>PLP (Browse)<br>PLP (Search results) | ❌     | ❌     | ❌     |
-| sign in       | ❌     | Account           | ❌     | Account           |
-| sign out      | ❌     | ❌     | ❌     | ❌     |
-| start checkout| Cart  | Cart  | Cart  | Cart<br>Mini cart |
+| add to requisition list  | ❌ | PDP<br>PLP<br>Cart<br>Account | ❌ | ❌ |
+| cart open  | ❌ | PDP<br>PLP (Browse)<br>PLP (Search results)<br>Cart  | ❌ | ❌ |
+| cart view  | Cart   | Cart   | Cart   | Cart<br>Mini cart|
+| complete checkout   | Checkout   | Checkout   | Checkout   | Checkout   |
+| create account  | ❌ | Account| ❌ | Account|
+| create requisition list  | ❌ | PDP<br>PLP<br>Cart<br>Account | ❌ | ❌ |
+| edit account| ❌ | Account| ❌ | Account|
+| page view  | Landing page<br>PDP<br>PLP (Browse)<br>PLP (Search results)<br>Cart<br>Checkout | Landing page<br>PDP<br>PLP (Browse)<br>PLP (Search results)<br>Cart<br>Checkout | Landing page<br>PDP<br>PLP (Browse)<br>PLP (Search results)<br>Cart<br>Checkout | Landing page<br>PDP<br>PLP (Browse)<br>PLP (Search results)<br>Cart<br>Checkout |
+| product add to cart | PDP<br>PLP (Browse)<br>PLP (Search results)<br>Cart  | PDP<br>PLP (Browse)<br>PLP (Search results)<br>Cart  | PDP| PDP|
+| product remove from cart | ❌ | Cart   | ❌ | ❌ |
+| product view| PDP| PDP| PDP| PDP|
+| recs item add to cart| Recs carousel | ❌ | Recs carousel | ❌ |
+| recs item click | Recs carousel | ❌ | Recs carousel | ❌ |
+| recs request sent   | Recs carousel | ❌ | Recs carousel | ❌ |
+| recs response received   | Recs carousel | ❌ | Recs carousel | ❌ |
+| recs unit render| Recs carousel | ❌ | Recs carousel | ❌ |
+| recs unit view  | Recs carousel | ❌ | Recs carousel | ❌ |
+| remove from requisition list | ❌ | Account| ❌ | ❌ |
+| search category click| Search popover  | ❌ | ❌ | ❌ |
+| search product click| Search popover  | ❌ | ❌ | ❌ |
+| search request sent | Search popover<br>PLP (Browse)<br>PLP (Search results)   | Search popover<br>PLP (Browse)<br>PLP (Search results)   | ❌ | ❌ |
+| search response received<br> | Search popover<br>PLP (Browse)<br>PLP (Search results)   | Search popover<br>PLP (Browse)<br>PLP (Search results)   | ❌ | ❌ |
+| search results view | Search popover<br>PLP (Browse)<br>PLP (Search results)   | ❌ | ❌ | ❌ |
+| sign in| ❌ | Account| ❌ | Account|
+| sign out   | ❌ | Account| ❌ | ❌ |
+| start checkout  | Cart   | Cart   | Cart   | Cart<br>Mini cart|
 
 ## Support
 
 If you have any questions or encounter any issues, reach out here:
 
--  [GitHub](https://github.com/adobe/magento-storefront-event-collector/issues)
--  [Zendesk](https://account.magento.com/customer/account/login/referer/aHR0cHM6Ly9hY2NvdW50Lm1hZ2VudG8uY29tL3plbmRlc2svbG9naW4vaW5kZXgv/)
+- [GitHub](https://github.com/adobe/magento-storefront-event-collector/issues)
+- [Zendesk](https://account.magento.com/customer/account/login/referer/aHR0cHM6Ly9hY2NvdW50Lm1hZ2VudG8uY29tL3plbmRlc2svbG9naW4vaW5kZXgv/)

--- a/src/pages/shared-services/storefront-events/collector/index.md
+++ b/src/pages/shared-services/storefront-events/collector/index.md
@@ -10,7 +10,7 @@ This package listens for and handles events sent from the [Adobe Commerce Events
 
 ## Installation
 
-The collector can be used as a hosted script, or bundled in a JavaScript application. The script version is hosted on [unpkg](https://unpkg.com/@adobe/magento-storefront-event-collector@1.0.0/dist/index.js), and the bundled version is hosted on [npm](https://www.npmjs.com/package/@adobe/magento-storefront-event-collector).
+The collector can be used as a hosted script, or bundled in a JavaScript application. The script version is hosted on [unpkg](https://unpkg.com/@adobe/magento-storefront-event-collector@1.2.1/dist/index.js), and the bundled version is hosted on [npm](https://www.npmjs.com/package/@adobe/magento-storefront-event-collector).
 
 To load the SDK as a script, use the following snippet.
 
@@ -26,31 +26,46 @@ npm install @adobe/magento-storefront-event-collector
 
 ## Quick Start
 
-After loading the collector script, or importing the package as shown below, there is nothing else that needs to be done.
+After loading the collector script, or importing the package as shown below, there is nothing else to configure.
 
 ```bash
 import "@adobe/magento-storefront-event-collector";
 ```
 
-The collector then begins listening for the following events. When any of these events are fired, the collector runs the associated handler and sends the event along with any relevant information to Adobe Commerce for further processing.
+The collector then begins listening for events. When these events are fired, the collector runs the associated handler and sends the event along with any relevant information to Adobe Commerce for further processing.
 
--  `addToCart`
--  `instantPurchase`
--  `pageView`
--  `placeOrder`
--  `productPageView`
--  `recsItemAddToCartClick`
--  `recsItemClick`
--  `recsRequestSent`
--  `recsResponseReceived`
--  `recsUnitRender`
--  `recsUnitView`
--  `searchProductClick`
--  `searchRequestSent`
--  `searchResponseReceived`
--  `searchResultsView`
--  `searchSuggestionClick`
--  `shoppingCartView`
+The following table lists supported and unsupported events for Luma/PHP and PWA sites on the Snowplow or Beacon event frameworks.
+
+| Event| Luma/PHP Commerce |   Luma/PHP Commerce    | PWA   |  PWA     |
+| --- | --- | --- | --- | --- |
+|      | Commerce ("Snowplow")      | Experience Cloud ("Beacon")| Commerce ("Snowplow")      | Experience Cloud ("Beacon")|
+|      |       |       |       |       |
+| [b2b] add to requisition list | ❌     | PDP<br>PLP<br>Cart<br>Account              | ❌     | ❌     |
+| [b2b] create requisition list | ❌     | PDP<br>PLP<br>Cart<br>Account              | ❌     | ❌     |
+| [b2b] delete requisition list | ❌     | Account           | ❌     | ❌     |
+| cart open     | ❌     | PDP<br>PLP (Browse)<br>PLP (Search results)<br>Cart    | ❌     | ❌     |
+| cart view     | Cart  | Cart  | Cart  | Cart<br>Mini cart |
+| complete checkout             | Checkout          | Checkout          | Checkout          | Checkout          |
+| create account| ❌     | Account           | ❌     | Account           |
+| edit account  | ❌     | Account           | ❌     | Account           |
+| page view     | Landing page<br>PDP<br>PLP (Browse)<br>PLP (Search results)<br>Cart<br>Checkout | Landing page<br>PDP<br>PLP (Browse)<br>PLP (Search results)<br>Cart<br>Checkout | Landing page<br>PDP<br>PLP (Browse)<br>PLP (Search results)<br>Cart<br>Checkout | Landing page<br>PDP<br>PLP (Browse)<br>PLP (Search results)<br>Cart<br>Checkout |
+| product add to cart           | PDP<br>PLP (Browse)<br>PLP (Search results)<br>Cart    | PDP<br>PLP (Browse)<br>PLP (Search results)<br>Cart    | PDP   | PDP   |
+| product remove from cart      | ❌     | Cart  | ❌     | ❌     |
+| product view  | PDP   | PDP   | PDP   | PDP   |
+| recs item add to cart         | Recs carousel       | ❌     | Recs carousel       | ❌     |
+| recs item click               | Recs carousel       | ❌     | Recs carousel       | ❌     |
+| recs request sent             | Recs carousel       | ❌     | Recs carousel       | ❌     |
+| recs response received        | Recs carousel       | ❌     | Recs carousel       | ❌     |
+| recs unit render              | Recs carousel       | ❌     | Recs carousel       | ❌     |
+| recs unit view| Recs carousel       | ❌     | Recs carousel       | ❌     |
+| search category click         | Search popover    | ❌     | ❌     | ❌     |
+| search product click          | Search popover    | ❌     | ❌     | ❌     |
+| search request sent           | Search popover<br>PLP (Browse)<br>PLP (Search results) | Search popover<br>PLP (Browse)<br>PLP (Search results) | ❌     | ❌     |
+| search response received      | Search popover<br>PLP (Browse)<br>PLP (Search results) | Search popover<br>PLP (Browse)<br>PLP (Search results) | ❌     | ❌     |
+| search results view           | Search popover<br>PLP (Browse)<br>PLP (Search results) | ❌     | ❌     | ❌     |
+| sign in       | ❌     | Account           | ❌     | Account           |
+| sign out      | ❌     | ❌     | ❌     | ❌     |
+| start checkout| Cart  | Cart  | Cart  | Cart<br>Mini cart |
 
 ## Support
 


### PR DESCRIPTION
## Purpose of this pull request

This pull request (PR) this adds specific event support by framework.

## Affected pages

https://developer.adobe.com/commerce/services/shared-services/storefront-events/collector/#quick-start.

whatsnew
Added event support tables by framework to the [Adobe Commerce Event Framework](https://developer.adobe.com/commerce/services/shared-services/storefront-events/collector/#quick-start) topic.