### PR TITLE
Convert add-to-project-board to reusable workflow

### DIFF
--- a/.github/workflows/add-to-project-board.yml
+++ b/.github/workflows/add-to-project-board.yml
@@ -1,4 +1,3 @@
----
 ##### Aggregate Commerce PRs and Issues into a respective Organizational Project #####
 
 name: Add pull requests and issues to projects
@@ -12,20 +11,6 @@ on:
       - opened
 
 jobs:
-  add-to-project:
-    runs-on: ubuntu-latest
-
-    steps:
-      - name: Add to Commerce PR project
-        if: github.event_name == 'pull_request_target'
-        uses: actions/add-to-project@v0.4.0
-        with:
-          project-url: https://github.com/orgs/AdobeDocs/projects/5 # The organizational project for pull requests
-          github-token: ${{ secrets.COMMERCE_PROJECT_AUTOMATION }}
-      
-      - name: Add to Commerce Issue project
-        if: github.event_name == 'issues'
-        uses: actions/add-to-project@v0.4.0
-        with:
-          project-url: https://github.com/orgs/AdobeDocs/projects/6 # The organizational project for issues
-          github-token: ${{ secrets.COMMERCE_PROJECT_AUTOMATION }}
+  call-workflow-add-to-project:
+    uses: AdobeDocs/commerce-php/.github/workflows/add-to-project_job.yml@main
+    secrets: inherit


### PR DESCRIPTION
## Purpose of this pull request

This pull request converts a workflow _Add pull requests and issues to projects_ for using a reusable workflow at [AdobeDocs/commerce-php/.github/workflows/add-to-project_job.yml](https://github.com/AdobeDocs/commerce-php/blob/main/.github/workflows/add-to-project_job.yml).

## Affected pages

none

## Additional information

Internal ref: COMDOX-515
