### PR TITLE
Add customizable options to Catalog Service schema 

### DIFF
--- a/src/_includes/graphql/catalog-service/product-view.md
+++ b/src/_includes/graphql/catalog-service/product-view.md
@@ -182,7 +182,7 @@ Field | Data Type | Description
 `inStock` | Boolean | Indicates if the option is in stock.
 `isDefault` | Boolean | Indicates whether the option is the default.
 `product` | [`SimpleProductView`](#simpleproductview-type) | Details about a simple product.
-`quantity` | []`SimpleProductView`](#simpleproductview-type) | Default quantity of an option value.
+`quantity` | [`SimpleProductView`](#simpleproductview-type) | Default quantity of an option value.
 `title` | String | The display name of the option value.
 
 ### ProductViewOptionValueSwatch type

--- a/src/_includes/graphql/catalog-service/product-view.md
+++ b/src/_includes/graphql/catalog-service/product-view.md
@@ -93,8 +93,8 @@ The `ProductViewLink` type contains details about product links for related prod
 
 Field | Data Type | Description
 --- | --- | ---
-`product` | `ProductView!` | Details about the product in the link.
 `linkTypes` | [String!]! | Types of links for this product. Can be `crosssell`, `related`, and `upsell`.
+`product` | `ProductView!` | Details about the product in the link.
 
 ### ProductViewMoney type
 
@@ -107,7 +107,7 @@ Field | Data Type | Description
 
 ### ProductViewInputOption type
 
-Product input options provide a way for shoppers to customize a product before adding it to a cart. When specified, the options create a variant of a single SKU. For example, the shopper can provide a custom image or text to personalize a product. A customizable option can include an associated markdown amount that is applied to the product price.
+Product input options provide a way for shoppers to customize a product before adding it to a cart. A product definition can contain details about how the shopper enters customization details. A customizable option can include an associated markup that is applied to the product price. For additional information, see [Product settings - Customizable Options](https://experienceleague.adobe.com/en/docs/commerce-admin/catalog/products/settings/settings-advanced-custom-options).
 
 Field | Data Type | Description
 -- | -- | --

--- a/src/_includes/graphql/catalog-service/product-view.md
+++ b/src/_includes/graphql/catalog-service/product-view.md
@@ -107,7 +107,7 @@ Field | Data Type | Description
 
 ### ProductViewInputOption type
 
-Product input options provide a way for shoppers to customize a product before adding it to a cart. When specified, the options create a variant of a single SKU. For example, the shopper can provide a custom image or text to personalize a product. A customizable option can include an associated markdown amount that is applied to increase or decrease the product price.
+Product input options provide a way for shoppers to customize a product before adding it to a cart. When specified, the options create a variant of a single SKU. For example, the shopper can provide a custom image or text to personalize a product. A customizable option can include an associated markdown amount that is applied to the product price.
 
 Field | Data Type | Description
 -- | -- | --

--- a/src/_includes/graphql/catalog-service/product-view.md
+++ b/src/_includes/graphql/catalog-service/product-view.md
@@ -8,6 +8,7 @@ Field | Data Type | Description
 `externalId`| String | The external ID of the product.
 `id` | ID! | The product ID, generated as a composite key, unique per locale.
 `images(roles: [String])` | [`[ProductViewImage]`](#productviewimage-type`) | A list of images defined for the product.
+`inputOptions` | [`[ProductViewInputOption]`](#productviewinputoption-type) | A list of input options the shopper can supply to customize a product.
 `inStock` | Boolean | Indicates whether the product is in stock.
 `links(linkTypes: [String!])` | [`[ProductViewLink]`](#productviewlink-type) | A list of product links.
 `lowStock` | Boolean | Indicates whether the product stock is low.
@@ -15,7 +16,6 @@ Field | Data Type | Description
 `metaKeyword` | String | A comma-separated list of keywords that are visible only to search engines.
 `metaTitle` | String | A string that is displayed in the title bar and tab of the browser and in search results lists.
 `name` | String | Product name.
-`inputOptions` | [`[ProductViewInputOption]`](#productviewinputoption-type) | A list of input options the shopper can supply to customize a product.
 `shortDescription` | String | A summary of the product.
 `sku` | String | Product SKU.
 `url` | String | Canonical URL of the product.

--- a/src/_includes/graphql/catalog-service/product-view.md
+++ b/src/_includes/graphql/catalog-service/product-view.md
@@ -150,7 +150,7 @@ Field | Data Type | Description
 `multi` | Boolean | Indicates whether the option allows multiple choices.
 `required` | Boolean | Indicates whether the option must be selected.
 `title` | String | The display name of the option.
-`values` | [ProductViewOptionValue Interface] | List of available option values.
+`values` | [`[ProductViewOptionValue!]`](#productviewoptionvalue-Interface) | List of available option values.
 
 ### ProductViewOptionValue interface
 

--- a/src/_includes/graphql/catalog-service/product-view.md
+++ b/src/_includes/graphql/catalog-service/product-view.md
@@ -3,18 +3,19 @@ The `ProductView` return object is an interface that can contain the following f
 Field | Data Type | Description
 --- | --- | ---
 `addToCartAllowed` | Boolean | Indicates whether the product can be added to the cart.
-`attributes(roles: [String])` | [ProductViewAttribute] | A list of merchant-defined attributes designated for the storefront.
+`attributes(roles: [String])` | [`ProductViewAttribute`](#productviewattribute-type) | A list of merchant-defined attributes designated for the storefront.
 `description` | String | The detailed description of the product.
 `externalId`| String | The external ID of the product.
 `id` | ID! | The product ID, generated as a composite key, unique per locale.
-`images(roles: [String])` | [ProductViewImage] | A list of images defined for the product.
+`images(roles: [String])` | [`ProductViewImage`](#productviewimage-type`) | A list of images defined for the product.
 `inStock` | Boolean | Indicates whether the product is in stock.
-`links(linkTypes: [String!])` | [ProductViewLink] | A list of product links.
+`links(linkTypes: [String!])` | [`ProductViewLink`](#productviewlink-type) | A list of product links.
 `lowStock` | Boolean | Indicates whether the product stock is low.
 `metaDescription` | String | A brief overview of the product for search results listings.
 `metaKeyword` | String | A comma-separated list of keywords that are visible only to search engines.
 `metaTitle` | String | A string that is displayed in the title bar and tab of the browser and in search results lists.
 `name` | String | Product name.
+`inputOptions` | [`ProductViewInputOption`](#productviewinputoption-type)
 `shortDescription` | String | A summary of the product.
 `sku` | String | Product SKU.
 `url` | String | Canonical URL of the product.
@@ -27,20 +28,21 @@ The `ComplexProductView` type represents bundle, configurable, and group product
 Field | Data Type | Description
 --- | --- | ---
 `addToCartAllowed` | Boolean | Indicates whether the product can be added to the cart.
-`attributes(roles: [String])` | [ProductViewAttribute] | A list of merchant-defined attributes designated for the storefront.
+`attributes(roles: [String])` | [`ProductViewAttribute`](#productviewattribute-type) | A list of merchant-defined attributes designated for the storefront.
 `description` | String | The detailed description of the product.
 `externalId`| String | The external ID of the product.
 `id` | ID! | The product ID, generated as a composite key, unique per locale.
-`images(roles: [String])` | [ProductViewImage] | A list of images defined for the product.
+`images(roles: [String])` | [`ProductViewImage`](#productviewimage-type) | A list of images defined for the product.
 `inStock` | Boolean | Indicates whether the product is in stock.
-`links(linkTypes: [String!])` | [ProductViewLink] | A list of product links.
+`links(linkTypes: [String!])` | [`ProductViewLink`](#productviewlink-type) | A list of product links.
 `lowStock` | Boolean | Indicates whether the product stock is low.
 `metaDescription` | String | A brief overview of the product for search results listings.
 `metaKeyword` | String | A comma-separated list of keywords that are visible only to search engines.
 `metaTitle` | String | A string that is displayed in the title bar and tab of the browser and in search results lists.
 `name` | String | Product name.
-`options` | [ProductViewOption] | A list of selectable options.
-`priceRange` | ProductViewPriceRange | A range of possible prices for a complex product.
+`inputOptions` | [`ProductViewInputOption`](#productviewinputoption-type) | A list of input options the shopper can supply to customize a product.
+`options` | [`ProductViewOption`](#productviewoption-type) | A list of selectable options.
+`priceRange` | [`ProductViewPriceRange`](#productviewpricerange-type) | A range of possible prices for a complex product.
 `shortDescription` | String | A summary of the product.
 `sku` | String | Product SKU.
 `url` | String | Canonical URL of the product.
@@ -52,8 +54,8 @@ The `Price type` defines the price of a simple product or a part of a price rang
 
 Field | Data Type | Description
 --- | --- | ---
-`adjustments` | [PriceAdjustment] | A list of price adjustments.
-`amount` | ProductViewMoney | Contains the monetary value and currency code of a product.
+`adjustments` | [`PriceAdjustment`](#priceadjustment-type) | A list of price adjustments.
+`amount` | [`ProductViewMoney`](#productviewmoney-type) | Contains the monetary value and currency code of a product.
 
 ### PriceAdjustment type
 
@@ -103,9 +105,44 @@ Field | Data Type | Description
 `currency` | ProductViewCurrency | A three-letter currency code, such as USD or EUR.
 `value` | Float | A number expressing a monetary value.
 
+### ProductViewInputOption type
+
+Product input options provide a way for shoppers to customize a a product before adding it to a cart. They are based on a variation of a single SKU. For example, the shopper can provide a custom image or text to personalize a product. These input options can be associated with a price increase or decrease if a markdown amount is supplied.
+
+Field | Data Type | Description
+-- | -- | --
+`id` | ID | The ID of the option value.
+`title` | String | The display name of the option value.
+`required` | Boolean | Indicates whether the option must be supplied.
+`type` | String | The type of control for entering the input option, for example `textfield`, `textarea`, `date`, `date_time`, `time`, `file`.
+`markupAmount` | Float | Amount to add or subtract from the product price when the option is configured.
+`suffix` | String | SKU suffix added to the customized product.
+`sortOrder` | Int | Indicates the order in which the option is displayed if multiple input options are configured.
+`range` |[`ProductViewInputOptionRange`](#productviewinputoptionrange-type)| Value limits associated with an input option, for example allowed characters or file size.
+`imageSize` | ProductViewInputOptionRange | Dimensions of an image associated with the input option.
+`fileExtensions` | String | A comma separated list of accepted file types for the input option if it has an associated file, for example `png, jpg`.
+
+### ProductViewInputOptionRange type
+
+Lists the value range associated with a ProductViewInputOption. For example, if the input option is a text field, the range represents the number of characters
+
+Field | Data Type | Description
+-- | -- | --
+`from` | Float | Minimum value accepted for the option input
+`to` | Float | Maximum value accepted for the option input
+
+### ProductViewInputOptionImageSize type
+
+Lists the image dimensions for an image associated with a ProductViewInputOption.
+
+Field | Data Type | Description
+-- | -- | --
+`width` |  Int | Width of image provided for an input option
+`height` | Int | Height of image provided for an input option
+
 ### ProductViewOption type
 
-Product options provide a way to configure products by making selections of particular option values. Selecting one or many options will point to a specific simple product.
+Product options provide a way to configure products by making selections of particular option values predefined for the product. Selecting one or many options points to a specific simple product.
 
 Field | Data Type | Description
 --- | --- | ---
@@ -113,7 +150,7 @@ Field | Data Type | Description
 `multi` | Boolean | Indicates whether the option allows multiple choices.
 `required` | Boolean | Indicates whether the option must be selected.
 `title` | String | The display name of the option.
-`values` | [ProductViewOptionValue!] | List of available option values.
+`values` | [ProductViewOptionValue Interface] | List of available option values.
 
 ### ProductViewOptionValue interface
 
@@ -144,8 +181,8 @@ Field | Data Type | Description
 `id` | ID | The ID of an option value.
 `inStock` | Boolean | Indicates if the option is in stock.
 `isDefault` | Boolean | Indicates whether the option is the default.
-`product` | SimpleProductView | Details about a simple product.
-`quantity` | SimpleProductView | Default quantity of an option value.
+`product` | [`SimpleProductView`](#simpleproductview-type) | Details about a simple product.
+`quantity` | []`SimpleProductView`](#simpleproductview-type) | Default quantity of an option value.
 `title` | String | The display name of the option value.
 
 ### ProductViewOptionValueSwatch type
@@ -187,12 +224,13 @@ Field | Data Type | Description
 --- | --- | ---
 `addToCartAllowed` | Boolean | Indicates whether the product can be added to the cart.
 `attributes(roles: [String])` | [ProductViewAttribute] | A list of merchant-defined attributes designated for the storefront.
+`inputOptions
 `description` | String | The detailed description of the product.
 `externalId`| String | The external ID of the product.
 `id` | ID! | The product ID, generated as a composite key, unique per locale.
-`images(roles: [String])` | [ProductViewImage] | A list of images defined for the product.
+`images(roles: [String])` | [`ProductViewImage`](#productviewimage-type) | A list of images defined for the product.
 `inStock` | Boolean | Indicates whether the product is in stock.
-`links(linkTypes: [String!])` | [ProductViewLink] | A list of product links.
+`links(linkTypes: [String!])` | [`ProductViewLink`](#productviewlink-type) | A list of product links.
 `lowStock` | Boolean | Indicates whether the product stock is low.
 `metaDescription` | String | A brief overview of the product for search results listings.
 `metaKeyword` | String | A comma-separated list of keywords that are visible only to search engines.

--- a/src/_includes/graphql/catalog-service/product-view.md
+++ b/src/_includes/graphql/catalog-service/product-view.md
@@ -3,19 +3,19 @@ The `ProductView` return object is an interface that can contain the following f
 Field | Data Type | Description
 --- | --- | ---
 `addToCartAllowed` | Boolean | Indicates whether the product can be added to the cart.
-`attributes(roles: [String])` | [`ProductViewAttribute`](#productviewattribute-type) | A list of merchant-defined attributes designated for the storefront.
+`attributes(roles: [String])` | [`[ProductViewAttribute]`](#productviewattribute-type) | A list of merchant-defined attributes designated for the storefront.
 `description` | String | The detailed description of the product.
 `externalId`| String | The external ID of the product.
 `id` | ID! | The product ID, generated as a composite key, unique per locale.
-`images(roles: [String])` | [`ProductViewImage`](#productviewimage-type`) | A list of images defined for the product.
+`images(roles: [String])` | [`[ProductViewImage]`](#productviewimage-type`) | A list of images defined for the product.
 `inStock` | Boolean | Indicates whether the product is in stock.
-`links(linkTypes: [String!])` | [`ProductViewLink`](#productviewlink-type) | A list of product links.
+`links(linkTypes: [String!])` | [`[ProductViewLink]`](#productviewlink-type) | A list of product links.
 `lowStock` | Boolean | Indicates whether the product stock is low.
 `metaDescription` | String | A brief overview of the product for search results listings.
 `metaKeyword` | String | A comma-separated list of keywords that are visible only to search engines.
 `metaTitle` | String | A string that is displayed in the title bar and tab of the browser and in search results lists.
 `name` | String | Product name.
-`inputOptions` | [`ProductViewInputOption`](#productviewinputoption-type)
+`inputOptions` | [`[ProductViewInputOption]`](#productviewinputoption-type) | A list of input options the shopper can supply to customize a product.
 `shortDescription` | String | A summary of the product.
 `sku` | String | Product SKU.
 `url` | String | Canonical URL of the product.
@@ -28,20 +28,20 @@ The `ComplexProductView` type represents bundle, configurable, and group product
 Field | Data Type | Description
 --- | --- | ---
 `addToCartAllowed` | Boolean | Indicates whether the product can be added to the cart.
-`attributes(roles: [String])` | [`ProductViewAttribute`](#productviewattribute-type) | A list of merchant-defined attributes designated for the storefront.
+`attributes(roles: [String])` | [`[ProductViewAttribute]`](#productviewattribute-type) | A list of merchant-defined attributes designated for the storefront.
 `description` | String | The detailed description of the product.
 `externalId`| String | The external ID of the product.
 `id` | ID! | The product ID, generated as a composite key, unique per locale.
-`images(roles: [String])` | [`ProductViewImage`](#productviewimage-type) | A list of images defined for the product.
+`images(roles: [String])` | [`[ProductViewImage]`](#productviewimage-type) | A list of images defined for the product.
+`inputOptions` | [`[ProductViewInputOption]`](#productviewinputoption-type) | A list of input options the shopper can supply to customize a product.
 `inStock` | Boolean | Indicates whether the product is in stock.
-`links(linkTypes: [String!])` | [`ProductViewLink`](#productviewlink-type) | A list of product links.
+`links(linkTypes: [String!])` | [`[ProductViewLink]`](#productviewlink-type) | A list of product links.
 `lowStock` | Boolean | Indicates whether the product stock is low.
 `metaDescription` | String | A brief overview of the product for search results listings.
 `metaKeyword` | String | A comma-separated list of keywords that are visible only to search engines.
 `metaTitle` | String | A string that is displayed in the title bar and tab of the browser and in search results lists.
 `name` | String | Product name.
-`inputOptions` | [`ProductViewInputOption`](#productviewinputoption-type) | A list of input options the shopper can supply to customize a product.
-`options` | [`ProductViewOption`](#productviewoption-type) | A list of selectable options.
+`options` | [`[ProductViewOption]`](#productviewoption-type) | A list of selectable options.
 `priceRange` | [`ProductViewPriceRange`](#productviewpricerange-type) | A range of possible prices for a complex product.
 `shortDescription` | String | A summary of the product.
 `sku` | String | Product SKU.
@@ -54,7 +54,7 @@ The `Price type` defines the price of a simple product or a part of a price rang
 
 Field | Data Type | Description
 --- | --- | ---
-`adjustments` | [`PriceAdjustment`](#priceadjustment-type) | A list of price adjustments.
+`adjustments` | [`[PriceAdjustment]`](#priceadjustment-type) | A list of price adjustments.
 `amount` | [`ProductViewMoney`](#productviewmoney-type) | Contains the monetary value and currency code of a product.
 
 ### PriceAdjustment type
@@ -93,7 +93,7 @@ The `ProductViewLink` type contains details about product links for related prod
 
 Field | Data Type | Description
 --- | --- | ---
-`product` | ProductView! | Details about the product in the link.
+`product` | `ProductView!` | Details about the product in the link.
 `linkTypes` | [String!]! | Types of links for this product. Can be `crosssell`, `related`, and `upsell`.
 
 ### ProductViewMoney type
@@ -111,34 +111,34 @@ Product input options provide a way for shoppers to customize a product before a
 
 Field | Data Type | Description
 -- | -- | --
-`id` | ID | The ID of the option value.
-`title` | String | The display name of the option value.
-`required` | Boolean | Indicates whether the option must be supplied.
-`type` | String | The type of control for entering the input option, for example `textfield`, `textarea`, `date`, `date_time`, `time`, `file`.
-`markupAmount` | Float | Amount to add or subtract from the product price when the option is configured.
-`suffix` | String | SKU suffix added to the customized product.
-`sortOrder` | Int | Indicates the order in which the option is displayed if multiple input options are configured.
-`range` |[`ProductViewInputOptionRange`](#productviewinputoptionrange-type)| Value limits associated with an input option, for example allowed characters or file size.
-`imageSize` | ProductViewInputOptionRange | Dimensions of an image associated with the input option.
 `fileExtensions` | String | A comma separated list of accepted file types for the input option if it has an associated file, for example `png, jpg`.
+`id` | ID | The ID of the option value.
+`imageSize` | [`ProductViewInputOptionImageSize`](#productviewimagesize-type) | Dimensions of an image associated with the input option.
+`markupAmount` | Float | Amount to add or subtract from the product price when the option is configured.
+`range` |[`ProductViewInputOptionRange`](#productviewinputoptionrange-type)| Value limits associated with an input option, for example allowed characters or file size.
+`required` | Boolean | Indicates whether the option must be supplied.
+`sortOrder` | Int | Indicates the order in which the option is displayed if multiple input options are configured.
+`suffix` | String | SKU suffix added to the customized product.
+`title` | String | The display name of the option value.
+`type` | String | The type of control for entering the input option, for example `textfield`, `textarea`, `date`, `date_time`, `time`, `file`.
 
 ### ProductViewInputOptionRange type
 
-Lists the value range associated with a ProductViewInputOption. For example, if the input option is a text field, the range represents the number of characters
+Lists the value range associated with a `[ProductViewInputOption]`. For example, if the input option is a text field, the range represents the number of characters.
 
 Field | Data Type | Description
 -- | -- | --
-`from` | Float | Minimum value accepted for the option input
-`to` | Float | Maximum value accepted for the option input
+`from` | Float | Minimum value accepted for the option input.
+`to` | Float | Maximum value accepted for the option input.
 
 ### ProductViewInputOptionImageSize type
 
-Lists the image dimensions for an image associated with a ProductViewInputOption.
+Lists the image dimensions for an image associated with a `[ProductViewInputOption]`.
 
 Field | Data Type | Description
 -- | -- | --
-`width` |  Int | Width of image provided for an input option
-`height` | Int | Height of image provided for an input option
+`height` | Int | Height of image provided for an input option.
+`width` |  Int | Width of image provided for an input option.
 
 ### ProductViewOption type
 
@@ -223,20 +223,20 @@ The `SimpleProductView` type represents all product types, except bundle, config
 Field | Data Type | Description
 --- | --- | ---
 `addToCartAllowed` | Boolean | Indicates whether the product can be added to the cart.
-`attributes(roles: [String])` | [ProductViewAttribute] | A list of merchant-defined attributes designated for the storefront.
-`inputOptions
+`attributes(roles: [String])` | [`[ProductViewAttribute]`](#productviewattribute-type) | A list of merchant-defined attributes designated for the storefront.
 `description` | String | The detailed description of the product.
 `externalId`| String | The external ID of the product.
 `id` | ID! | The product ID, generated as a composite key, unique per locale.
-`images(roles: [String])` | [`ProductViewImage`](#productviewimage-type) | A list of images defined for the product.
+`images(roles: [String])` | [`[ProductViewImage]`](#productviewimage-type) | A list of images defined for the product.
+`inputOptions` | [`[ProductViewInputOption]`](#productviewinputoption-type) | A list of input options the shopper can supply to customize a product.
 `inStock` | Boolean | Indicates whether the product is in stock.
-`links(linkTypes: [String!])` | [`ProductViewLink`](#productviewlink-type) | A list of product links.
+`links(linkTypes: [String!])` | [`[ProductViewLink]`](#productviewlink-type) | A list of product links.
 `lowStock` | Boolean | Indicates whether the product stock is low.
 `metaDescription` | String | A brief overview of the product for search results listings.
 `metaKeyword` | String | A comma-separated list of keywords that are visible only to search engines.
 `metaTitle` | String | A string that is displayed in the title bar and tab of the browser and in search results lists.
 `name` | String | Product name.
-`price` | ProductViewPrice | Base product price view.
+`price` | [`ProductViewPrice`](#productviewprice-type) | Base product price view.
 `shortDescription` | String | A summary of the product.
 `sku` | String | Product SKU.
 `url` | String | Canonical URL of the product.

--- a/src/_includes/graphql/catalog-service/product-view.md
+++ b/src/_includes/graphql/catalog-service/product-view.md
@@ -107,7 +107,7 @@ Field | Data Type | Description
 
 ### ProductViewInputOption type
 
-Product input options provide a way for shoppers to customize a product before adding it to a cart. When specified, the options create a variant of a single SKU. For example, the shopper can provide a custom image or text to personalize a product. A customization option can include an associated markdown amount that is applied to increase or decrease the product price.
+Product input options provide a way for shoppers to customize a product before adding it to a cart. When specified, the options create a variant of a single SKU. For example, the shopper can provide a custom image or text to personalize a product. A customizable option can include an associated markdown amount that is applied to increase or decrease the product price.
 
 Field | Data Type | Description
 -- | -- | --

--- a/src/_includes/graphql/catalog-service/product-view.md
+++ b/src/_includes/graphql/catalog-service/product-view.md
@@ -107,7 +107,7 @@ Field | Data Type | Description
 
 ### ProductViewInputOption type
 
-Product input options provide a way for shoppers to customize a a product before adding it to a cart. They are based on a variation of a single SKU. For example, the shopper can provide a custom image or text to personalize a product. These input options can be associated with a price increase or decrease if a markdown amount is supplied.
+Product input options provide a way for shoppers to customize a product before adding it to a cart. When specified, the options create a variant of a single SKU. For example, the shopper can provide a custom image or text to personalize a product. A customization option can include an associated markdown amount that is applied to increase or decrease the product price.
 
 Field | Data Type | Description
 -- | -- | --

--- a/src/_includes/graphql/catalog-service/product-view.md
+++ b/src/_includes/graphql/catalog-service/product-view.md
@@ -107,7 +107,7 @@ Field | Data Type | Description
 
 ### ProductViewInputOption type
 
-Product input options provide a way for shoppers to customize a product before adding it to a cart. A product definition can contain details about how the shopper enters customization details. A customizable option can include an associated markup that is applied to the product price. For additional information, see [Product settings - Customizable Options](https://experienceleague.adobe.com/en/docs/commerce-admin/catalog/products/settings/settings-advanced-custom-options).
+Product input options provide details about how a shopper can enter customization details for a product. For example, for product personalization the input options might provide the fields for the shopper to add an image or text for a monogram. The input option can include an associated `markupAmount` that is applied to the product price. For additional information, see [Product settings - Customizable Options](https://experienceleague.adobe.com/en/docs/commerce-admin/catalog/products/settings/settings-advanced-custom-options).
 
 Field | Data Type | Description
 -- | -- | --

--- a/src/pages/graphql/catalog-service/index.md
+++ b/src/pages/graphql/catalog-service/index.md
@@ -9,10 +9,11 @@ keywords:
 
 # Catalog Service for Adobe Commerce
 
-The Catalog Service for Adobe Commerce extension contributes to a services-only GraphQL schema that contains queries that return specialized catalog data that is not available in the core schema. The queries in this schema allow Commerce merchants to quickly and fully render product-related content on the storefront, including product detail pages and product list pages.
+The Catalog Service for Adobe Commerce extension contributes to a services-only GraphQL schema that contains queries that return specialized catalog data that is not available in the [core GraphQL schema](https://developer.adobe.com/commerce/webapi/graphql/schema/). The queries in this schema allow Commerce merchants to quickly and fully render product-related content on the storefront, including product detail pages and product list pages.
 
 Catalog Service provides the following queries:
 
+*  [`categories`](categories.md)
 *  [`products`](products.md)
 *  [`refineProduct`](refine-product.md)
 

--- a/src/pages/graphql/catalog-service/products.md
+++ b/src/pages/graphql/catalog-service/products.md
@@ -79,6 +79,24 @@ query {
             value
             roles
         }
+        inputOptions {
+            id
+            title
+            required
+            type
+            markupAmount
+            suffix
+            sortOrder
+            range {
+                from
+                to
+            }
+            imageSize {
+                width
+                height
+            }
+            fileExtensions
+        }
         ... on SimpleProductView {
             price {
                 final {
@@ -237,6 +255,26 @@ query {
                         ]
                     }
                 ],
+                  "inputOptions": [
+                    {
+                    "id": "Y29uZmlndXJhYmxlLzIzNC8yNzg=",
+                    "title": "Input Option",
+                    "required": false,
+                    "type": "CUSTOM",
+                    "markupAmount": 12.45,
+                    "suffix": "suffix",
+                    "sortOrder": 1,
+                    "range": {
+                        "from": 1.01,
+                        "to": 12.01
+                    },
+                    "imageSize": {
+                        "width": 2,
+                        "height": 2
+                    },
+                    "fileExtensions": "fileExtensions"
+                    }
+                ],
                 "price": {
                     "final": {
                         "amount": {
@@ -332,6 +370,23 @@ query {
             roles
         }
         ... on ComplexProductView {
+            inputOptions {
+                id
+                title
+                required
+                type
+                markupAmount
+                suffix
+                sortOrder
+                range {
+                    from
+                    to
+                }
+                imageSize {
+                    width
+                    height
+                }
+                fileExtensions
             options {
                 id
                 title
@@ -369,7 +424,7 @@ query {
                                 roles
                             }
                         }
-                    }                    
+                    }
                 }
             }
             priceRange {
@@ -406,7 +461,7 @@ query {
             }
         }
     }
-}
+  }
 ```
 
 **Response:**
@@ -445,6 +500,26 @@ query {
                         "roles": []
                     }
                 ],
+                    "inputOptions": [
+                        {
+                        "id": "Y29uZmlndXJhYmxlLzIzNC8yNzg=",
+                        "title": "Input Option",
+                        "required": false,
+                        "type": "CUSTOM",
+                        "markupAmount": 12.45,
+                        "suffix": "suffix",
+                        "sortOrder": 1,
+                        "range": {
+                            "from": 1.01,
+                            "to": 12.01
+                        },
+                        "imageSize": {
+                            "width": 2,
+                            "height": 2
+                        },
+                        "fileExtensions": "fileExtensions"
+                        }
+                    ],
                 "attributes": [
                     {
                         "name": "climate",

--- a/src/pages/graphql/catalog-service/products.md
+++ b/src/pages/graphql/catalog-service/products.md
@@ -23,9 +23,14 @@ Use the Live Search [`productSearch` query](../live-search/product-search.md) to
 
 The `ProductView` output object is significantly different than the core `products` query `Products` output object. Key differences include:
 
-*  Products are either simple or complex. Simple, virtual, downloadable, and gift card products map to `SimpleProductView`. All other product types map to `ComplexProductView`. Simple products have defined prices. Complex products have price ranges. Since complex products are comprised of multiple simple products, they have access to simple product prices.
+* Products are either simple or complex. Simple, virtual, downloadable, and gift card products map to `SimpleProductView`. All other product types map to `ComplexProductView`.
 
-*  Merchant-defined attributes are exposed in a top-level container and indicate their storefront roles. Roles include Show on PDP, Show on PLP, and Show on Search Results.
+  * Simple products have defined prices.
+  * Complex products have price ranges. Since complex products are comprised of multiple simple products, they have access to simple product prices.
+
+* Both simple and complex products can have merchant-defined input options that allow shoppers to customize a product by adding text, date, an image, or a file, for example adding text for engraving. These options can have an associated markup that is applied to the product price. These options are exposed in a top-level `inputOptions` container ([`[ProductViewInputOption]`](#productviewinputoption-type)).
+
+*  Merchant-defined attributes are exposed in a top-level `attributes` container [`[ProductViewAttribute]`](#productviewattribute-type) and indicate their storefront roles. Roles include Show on PDP, Show on PLP, and Show on Search Results.
 
 *  Images are also accessible as a top-level container and can be filtered by their role. An image can have an `image`, `small_image`, or `thumbnail` role.
 
@@ -139,10 +144,10 @@ query {
                 "description": "<p>Make the most of your limited workout window with our Dual-Handle Cardio Ball. The 15-lb ball maximizes the effort-impact to your abdominal, upper arm and lower-body muscles. It features a handle on each side for a firm, secure grip.</p>\r\n<ul>\r\n<li>Durable plastic shell with sand fill.\r\n<li>Two handles.\r\n<li>15 lbs.\r\n</ul>",
                 "shortDescription": "",
                 "addToCartAllowed": true,
-                "url": "http://master-7rqtwti-ima6q5tyxltfe.eu-4.magentosite.cloud/dual-handle-cardio-ball.html",
+                "url": "http://example.com/dual-handle-cardio-ball.html",
                 "images": [
                     {
-                        "url": "http://master-7rqtwti-ima6q5tyxltfe.eu-4.magentosite.cloud/media/catalog/product/u/g/ug07-bk-0.jpg",
+                        "url": "http://example.com/media/catalog/product/u/g/ug07-bk-0.jpg",
                         "label": "Image",
                         "roles": [
                             "image",
@@ -151,7 +156,7 @@ query {
                         ]
                     },
                     {
-                        "url": "http://master-7rqtwti-ima6q5tyxltfe.eu-4.magentosite.cloud/media/catalog/product/u/g/ug07-bk-0_alt1.jpg",
+                        "url": "http://example.com/media/catalog/product/u/g/ug07-bk-0_alt1.jpg",
                         "label": "Image",
                         "roles": []
                     }
@@ -255,25 +260,63 @@ query {
                         ]
                     }
                 ],
-                  "inputOptions": [
+                "inputOptions": [
                     {
-                    "id": "Y29uZmlndXJhYmxlLzIzNC8yNzg=",
-                    "title": "Input Option",
-                    "required": false,
-                    "type": "CUSTOM",
-                    "markupAmount": 12.45,
-                    "suffix": "suffix",
-                    "sortOrder": 1,
-                    "range": {
-                        "from": 1.01,
-                        "to": 12.01
+                        "required": false,
+                        "id": "Y3VzdG9tLW9wdGlvbi8xOQ==",
+                        "title": "Customizable Option - area",
+                        "type": "area",
+                        "range": {
+                            "from": 0.0,
+                            "to": 255.0
+                        },
+                        "fileExtensions": "",
+                        "sortOrder": 1,
+                        "suffix": "test-e2e-configurable-smoke138330433-opt-area",
+                        "markupAmount": 126.0
                     },
-                    "imageSize": {
-                        "width": 2,
-                        "height": 2
+                    {
+                        "required": false,
+                        "id": "Y3VzdG9tLW9wdGlvbi8yMA==",
+                        "title": "Customizable Option - field",
+                        "type": "field",
+                        "range": {
+                            "from": 0.0,
+                            "to": 255.0
+                        },
+                        "fileExtensions": "",
+                        "sortOrder": 2,
+                        "suffix": "test-e2e-configurable-smoke138330433-opt-field",
+                        "markupAmount": 126.0
                     },
-                    "fileExtensions": "fileExtensions"
-                    }
+                    {
+                        "required": false,
+                        "id": "Y3VzdG9tLW9wdGlvbi8yMQ==",
+                        "title": "Customizable Option - file",
+                        "type": "file",
+                        "range": {
+                            "from": 0.0,
+                            "to": 0.0
+                        },
+                        "fileExtensions": "jpg, png",
+                        "sortOrder": 3,
+                        "suffix": "test-e2e-configurable-smoke138330433-opt-file",
+                        "markupAmount": 126.0
+                    },
+                    {
+                        "required": false,
+                        "id": "Y3VzdG9tLW9wdGlvbi8yMg==",
+                        "title": "Customizable Option - date",
+                        "type": "date",
+                        "range": {
+                            "from": 0.0,
+                            "to": 0.0
+                        },
+                        "fileExtensions": "",
+                        "sortOrder": 4,
+                        "suffix": "test-e2e-configurable-smoke138330433-opt-date",
+                        "markupAmount": 126.0
+                    },
                 ],
                 "price": {
                     "final": {
@@ -352,7 +395,7 @@ query {
     products(skus: ["MH07"]) {
         __typename
         id
-        sk
+        sku
         name
         description
         shortDescription
@@ -370,23 +413,24 @@ query {
             roles
         }
         ... on ComplexProductView {
-            inputOptions {
-                id
-                title
-                required
-                type
-                markupAmount
-                suffix
-                sortOrder
-                range {
-                    from
-                    to
-                }
-                imageSize {
-                    width
-                    height
-                }
-                fileExtensions
+        inputOptions {
+            id
+            title
+            required
+            type
+            markupAmount
+            suffix
+            sortOrder
+            range {
+                from
+                to
+            }
+            imageSize {
+                width
+                height
+            }
+            fileExtensions
+            }
             options {
                 id
                 title
@@ -478,10 +522,10 @@ query {
                 "description": "<p>Gray and black color blocking sets you apart as the Hero Hoodie keeps you warm on the bus, campus or cold mean streets. Slanted outsize front pockets keep your style real . . . convenient.</p>\r\n<p>&bull; Full-zip gray and black hoodie.<br />&bull; Ribbed hem.<br />&bull; Standard fit.<br />&bull; Drawcord hood cinch.<br />&bull; Water-resistant coating.</p>",
                 "shortDescription": "",
                 "addToCartAllowed": true,
-                "url": "http://master-7rqtwti-ima6q5tyxltfe.eu-4.magentosite.cloud/hero-hoodie.html",
+                "url": "http://example.com/hero-hoodie.html",
                 "images": [
                     {
-                        "url": "http://master-7rqtwti-ima6q5tyxltfe.eu-4.magentosite.cloud/media/catalog/product/m/h/mh07-gray_main_2.jpg",
+                        "url": "http://example.com/media/catalog/product/m/h/mh07-gray_main_2.jpg",
                         "label": "",
                         "roles": [
                             "image",
@@ -490,36 +534,102 @@ query {
                         ]
                     },
                     {
-                        "url": "http://master-7rqtwti-ima6q5tyxltfe.eu-4.magentosite.cloud/media/catalog/product/m/h/mh07-gray_alt1_2.jpg",
+                        "url": "http://example.com/media/catalog/product/m/h/mh07-gray_alt1_2.jpg",
                         "label": "",
                         "roles": []
                     },
                     {
-                        "url": "http://master-7rqtwti-ima6q5tyxltfe.eu-4.magentosite.cloud/media/catalog/product/m/h/mh07-gray_back_2.jpg",
+                        "url": "http://example.com/media/catalog/product/m/h/mh07-gray_back_2.jpg",
                         "label": "",
                         "roles": []
                     }
                 ],
-                    "inputOptions": [
-                        {
-                        "id": "Y29uZmlndXJhYmxlLzIzNC8yNzg=",
-                        "title": "Input Option",
+              "inputOptions": [
+                    {
                         "required": false,
-                        "type": "CUSTOM",
-                        "markupAmount": 12.45,
-                        "suffix": "suffix",
-                        "sortOrder": 1,
+                        "id": "Y3VzdG9tLW9wdGlvbi8xOQ==",
+                        "title": "Customizable Option - area",
+                        "type": "area",
                         "range": {
-                            "from": 1.01,
-                            "to": 12.01
+                            "from": 0.0,
+                            "to": 255.0
                         },
-                        "imageSize": {
-                            "width": 2,
-                            "height": 2
+                        "fileExtensions": "",
+                        "sortOrder": 1,
+                        "suffix": "test-e2e-configurable-smoke138330433-opt-area",
+                        "markupAmount": 126.0
+                    },
+                    {
+                        "required": false,
+                        "id": "Y3VzdG9tLW9wdGlvbi8yMA==",
+                        "title": "Customizable Option - field",
+                        "type": "field",
+                        "range": {
+                            "from": 0.0,
+                            "to": 255.0
                         },
-                        "fileExtensions": "fileExtensions"
-                        }
-                    ],
+                        "fileExtensions": "",
+                        "sortOrder": 2,
+                        "suffix": "test-e2e-configurable-smoke138330433-opt-field",
+                        "markupAmount": 126.0
+                    },
+                    {
+                        "required": false,
+                        "id": "Y3VzdG9tLW9wdGlvbi8yMQ==",
+                        "title": "Customizable Option - file",
+                        "type": "file",
+                        "range": {
+                            "from": 0.0,
+                            "to": 0.0
+                        },
+                        "fileExtensions": "jpg, png",
+                        "sortOrder": 3,
+                        "suffix": "test-e2e-configurable-smoke138330433-opt-file",
+                        "markupAmount": 126.0
+                    },
+                    {
+                        "required": false,
+                        "id": "Y3VzdG9tLW9wdGlvbi8yMg==",
+                        "title": "Customizable Option - date",
+                        "type": "date",
+                        "range": {
+                            "from": 0.0,
+                            "to": 0.0
+                        },
+                        "fileExtensions": "",
+                        "sortOrder": 4,
+                        "suffix": "test-e2e-configurable-smoke138330433-opt-date",
+                        "markupAmount": 126.0
+                    },
+                    {
+                        "required": false,
+                        "id": "Y3VzdG9tLW9wdGlvbi8yMw==",
+                        "title": "Customizable Option - date_time",
+                        "type": "date_time",
+                        "range": {
+                            "from": 0.0,
+                            "to": 0.0
+                        },
+                        "fileExtensions": "",
+                        "sortOrder": 5,
+                        "suffix": "test-e2e-configurable-smoke138330433-opt-date_time",
+                        "markupAmount": 126.0
+                    },
+                    {
+                        "required": false,
+                        "id": "Y3VzdG9tLW9wdGlvbi8yNA==",
+                        "title": "Customizable Option - time",
+                        "type": "time",
+                        "range": {
+                            "from": 0.0,
+                            "to": 0.0
+                        },
+                        "fileExtensions": "",
+                        "sortOrder": 6,
+                        "suffix": "test-e2e-configurable-smoke138330433-opt-time",
+                        "markupAmount": 126.0
+                    }
+                ],
                 "attributes": [
                     {
                         "name": "climate",

--- a/src/pages/graphql/catalog-service/products.md
+++ b/src/pages/graphql/catalog-service/products.md
@@ -28,9 +28,9 @@ The `ProductView` output object is significantly different than the core `produc
   * Simple products have defined prices.
   * Complex products have price ranges. Since complex products are comprised of multiple simple products, they have access to simple product prices.
 
-* Both simple and complex products can have merchant-defined input options that allow shoppers to customize a product by adding text, date, an image, or a file, for example adding text for engraving. These options can have an associated markup that is applied to the product price. These options are exposed in a top-level `inputOptions` container ([`[ProductViewInputOption]`](#productviewinputoption-type)).
+* Both simple and complex products can have merchant-defined input options that allow shoppers to customize a product by adding text, date, an image, or a file, for example adding text for engraving. These options can have an associated markup that is applied to the product price. These options are exposed in a top-level `inputOptions` container `[ProductViewInputOption]`.
 
-*  Merchant-defined attributes are exposed in a top-level `attributes` container [`[ProductViewAttribute]`](#productviewattribute-type) and indicate their storefront roles. Roles include Show on PDP, Show on PLP, and Show on Search Results.
+*  Merchant-defined attributes are exposed in a top-level `attributes` container `[ProductViewAttribute]` and indicate their storefront roles. Roles include Show on PDP, Show on PLP, and Show on Search Results.
 
 *  Images are also accessible as a top-level container and can be filtered by their role. An image can have an `image`, `small_image`, or `thumbnail` role.
 


### PR DESCRIPTION
## Purpose of this pull request

Added customizable options field descriptions to product and refine product queries, and added the inputOptions data to the query and response output. 

## Affected pages

<!-- REQUIRED List the affected pages on developer.adobe.com (URLs). Not necessary for large numbers of files. -->

- [products query](https://developer.adobe.com/commerce/services/graphql/catalog-service/products/)
- [refineProducts query](https://developer.adobe.com/commerce/services/graphql/catalog-service/products/)

To do:

- [ ] Technical review -- Check the updated query and response changes for customization options and provide updates if necessary.  Would it be better to add a new query specifically for the customization options use case?

## Links to Magento Open Source code

https://git.corp.adobe.com/magento-datalake/catalog-storefront-api-service/pull/152
