### PR TITLE
Add required `api-key` value for Catalog Service productSearch query

### DIFF
--- a/src/_includes/graphql/catalog-service/headers.md
+++ b/src/_includes/graphql/catalog-service/headers.md
@@ -1,6 +1,6 @@
 Header | Description
 --- | ---
-`Magento-Customer-Group` | This value is available in the `customer_group_data_exporter` database table.
+`Magento-Customer-Group` | This value is available in the `scopes_customergroup_data_exporter` database table.
 `Magento-Environment-Id` | This value is displayed at **System** > **Commerce Services Connector** > **SaaS Identifier** > **Data Space ID** or can be obtained by running the `bin/magento config:show services_connector/services_id/environment_id` command.
 `Magento-Store-Code`| The code assigned to the store associated with the active store view. For example, `main_website_store`.
 `Magento-Store-View-Code`| The code assigned to the active store view. For example, `default`.

--- a/src/_includes/graphql/catalog-service/headers.md
+++ b/src/_includes/graphql/catalog-service/headers.md
@@ -5,11 +5,4 @@ Header | Description
 `Magento-Store-Code`| The code assigned to the store associated with the active store view. For example, `main_website_store`.
 `Magento-Store-View-Code`| The code assigned to the active store view. For example, `default`.
 `Magento-Website-Code`| The code assigned to the website associated with the active store view. For example, `base`.
-`X-Api-Key` |  Header | Description
---- | ---
-`Magento-Customer-Group` | This value is available in the `customer_group_data_exporter` database table.
-`Magento-Environment-Id` | This value is displayed at **System** > **Commerce Services Connector** > **SaaS Identifier** > **Data Space ID** or can be obtained by running the `bin/magento config:show services_connector/services_id/environment_id` command.
-`Magento-Store-Code`| The code assigned to the store associated with the active store view. For example, `main_website_store`.
-`Magento-Store-View-Code`| The code assigned to the active store view. For example, `default`.
-`Magento-Website-Code`| The code assigned to the website associated with the active store view. For example, `base`.
 `X-Api-Key` | Set this value to the [unique API key](https://experienceleague.adobe.com/en/docs/commerce-merchant-services/user-guides/integration-services/saas#genapikey) generated for your Commerce environment.

--- a/src/_includes/graphql/catalog-service/headers.md
+++ b/src/_includes/graphql/catalog-service/headers.md
@@ -13,4 +13,3 @@ Header | Description
 `Magento-Store-View-Code`| The code assigned to the active store view. For example, `default`.
 `Magento-Website-Code`| The code assigned to the website associated with the active store view. For example, `base`.
 `X-Api-Key` | Set this value to the [unique API key](https://experienceleague.adobe.com/en/docs/commerce-merchant-services/user-guides/integration-services/saas#genapikey) generated for your Commerce environment.
-

--- a/src/_includes/graphql/catalog-service/headers.md
+++ b/src/_includes/graphql/catalog-service/headers.md
@@ -5,4 +5,12 @@ Header | Description
 `Magento-Store-Code`| The code assigned to the store associated with the active store view. For example, `main_website_store`.
 `Magento-Store-View-Code`| The code assigned to the active store view. For example, `default`.
 `Magento-Website-Code`| The code assigned to the website associated with the active store view. For example, `base`.
-`X-Api-Key` |  A unique key that is generated during the onboarding process.
+`X-Api-Key` |  Header | Description
+--- | ---
+`Magento-Customer-Group` | This value is available in the `customer_group_data_exporter` database table.
+`Magento-Environment-Id` | This value is displayed at **System** > **Commerce Services Connector** > **SaaS Identifier** > **Data Space ID** or can be obtained by running the `bin/magento config:show services_connector/services_id/environment_id` command.
+`Magento-Store-Code`| The code assigned to the store associated with the active store view. For example, `main_website_store`.
+`Magento-Store-View-Code`| The code assigned to the active store view. For example, `default`.
+`Magento-Website-Code`| The code assigned to the website associated with the active store view. For example, `base`.
+`X-Api-Key` |  set this value to the [unique API key](https://experienceleague.adobe.com/en/docs/commerce-merchant-services/user-guides/integration-services/saas#genapikey) generated for your Commerce environment.
+

--- a/src/_includes/graphql/catalog-service/headers.md
+++ b/src/_includes/graphql/catalog-service/headers.md
@@ -12,5 +12,5 @@ Header | Description
 `Magento-Store-Code`| The code assigned to the store associated with the active store view. For example, `main_website_store`.
 `Magento-Store-View-Code`| The code assigned to the active store view. For example, `default`.
 `Magento-Website-Code`| The code assigned to the website associated with the active store view. For example, `base`.
-`X-Api-Key` |  set this value to the [unique API key](https://experienceleague.adobe.com/en/docs/commerce-merchant-services/user-guides/integration-services/saas#genapikey) generated for your Commerce environment.
+`X-Api-Key` | Set this value to the [unique API key](https://experienceleague.adobe.com/en/docs/commerce-merchant-services/user-guides/integration-services/saas#genapikey) generated for your Commerce environment.
 

--- a/src/_includes/graphql/catalog-service/headers.md
+++ b/src/_includes/graphql/catalog-service/headers.md
@@ -1,6 +1,6 @@
 Header | Description
 --- | ---
-`Magento-Customer-Group` | This value is available in the `scopes_customergroup_data_exporter` database table.
+`Magento-Customer-Group` | This value is available in the `customer_group_data_exporter` database table.
 `Magento-Environment-Id` | This value is displayed at **System** > **Commerce Services Connector** > **SaaS Identifier** > **Data Space ID** or can be obtained by running the `bin/magento config:show services_connector/services_id/environment_id` command.
 `Magento-Store-Code`| The code assigned to the store associated with the active store view. For example, `main_website_store`.
 `Magento-Store-View-Code`| The code assigned to the active store view. For example, `default`.

--- a/src/pages/graphql/live-search/product-search.md
+++ b/src/pages/graphql/live-search/product-search.md
@@ -408,7 +408,7 @@ Header name| Description
 `Magento-Store-Code` | The code assigned to the store associated with the active store view. For example, `main_website_store`.
 `Magento-Store-View-Code` | The code assigned to the active store view. For example, `default`.
 `Magento-Website-Code` | The code assigned to the website associated with the active store view. For example, `base`.
-`X-Api-Key` | This value must be set to `search_gql`.
+`X-Api-Key` | For Live Search queries, set this value to `search_gql`. For Catalog Service queries, set this value to the [unique API key](https://experienceleague.adobe.com/en/docs/commerce-merchant-services/user-guides/integration-services/saas#genapikey) generated for your Commerce environment.
 
 ## Example usage
 


### PR DESCRIPTION
## Purpose of this pull request

Add required `api-key` header value for Catalog Service productsearch query.

## Affected pages

[productSearch Query](https://developer.adobe.com/commerce/services/graphql/live-search/product-search/)
