### PR TITLE
Updates for Customer Group required header description

### DIFF
--- a/src/_includes/graphql/catalog-service/headers.md
+++ b/src/_includes/graphql/catalog-service/headers.md
@@ -1,6 +1,6 @@
 Header | Description
 --- | ---
-`Magento-Customer-Group` | Specify the [the customer group code](#find-the-customer-group-code) for the API request.
+`Magento-Customer-Group` | Specify the [customer group code](#find-the-customer-group-code) for the API request.
 `Magento-Environment-Id` | This value is displayed at **System** > **Commerce Services Connector** > **SaaS Identifier** > **Data Space ID** or can be obtained by running the `bin/magento config:show services_connector/services_id/environment_id` command.
 `Magento-Store-Code`| The code assigned to the store associated with the active store view. For example, `main_website_store`.
 `Magento-Store-View-Code`| The code assigned to the active store view. For example, `default`.

--- a/src/_includes/graphql/catalog-service/headers.md
+++ b/src/_includes/graphql/catalog-service/headers.md
@@ -1,25 +1,8 @@
 Header | Description
 --- | ---
-`Magento-Customer-Group` | Specify the `customerGroupCode` for the API request. This code is the encrypted value of the `Customer Group Id` which determines discounts and tax class for pricing context. For B2B implementations, the `Customer Group ID` also determines the Shared Catalog context. For details, see [Determine value for `Magento-Customer-Group`](#determine-value-for-the-customer-group-header).
+`Magento-Customer-Group` | Specify the [customerGroupCode](#find-the-customergroupcode) for the API request.
 `Magento-Environment-Id` | This value is displayed at **System** > **Commerce Services Connector** > **SaaS Identifier** > **Data Space ID** or can be obtained by running the `bin/magento config:show services_connector/services_id/environment_id` command.
 `Magento-Store-Code`| The code assigned to the store associated with the active store view. For example, `main_website_store`.
 `Magento-Store-View-Code`| The code assigned to the active store view. For example, `default`.
 `Magento-Website-Code`| The code assigned to the website associated with the active store view. For example, `base`.
 `X-Api-Key` | Set this value to the [unique API key](https://experienceleague.adobe.com/en/docs/commerce-merchant-services/user-guides/integration-services/saas#genapikey) generated for your Commerce environment.
-
-###  Determine value for the Customer Group header
-
-For the `Magento-Customer-Group` header use one of the following values for a default Commerce implementation based on your requirements:
-
-| Customer Group | Default ID | customerGroupCode value |
-|----------------|------------|-------------------|
-| NOT LOGGED IN  | 0          | `b6589fc6ab0dc82cf12099d1c2d40ab994e8410c`
-| General        | 1          | `356a192b7913b04c54574d18c28d46e6395428ab`
-| Wholesale      | 2          | `da4b9237bacccdf19c0760cab7aec4a8359010b0`
-| Retailer       | 3          | `customerGroupCode":"77de68daecd823babbb58edb1c8e14d7106e83bb","name":"Retailer"
-
-For B2B implementations, the `customerGroupCode` value is the encrypted `Customer Group ID` associated with the Shared Catalog, `sha1(<customer_group_id>)`.
-
->[!NOTE]
->
->Find a list of available Customer Group IDs from the Admin (**[!UICONTROL Customers]** > **[!UICONTROL Customer Groups]**). For more information, see [Customer Groups](https://experienceleague.adobe.com/en/docs/commerce-admin/customers/customer-groups) and [Shared Catalogs](https://experienceleague.adobe.com/en/docs/commerce-admin/b2b/shared-catalogs/catalog-shared) in the _Merchant Guide_.

--- a/src/_includes/graphql/catalog-service/headers.md
+++ b/src/_includes/graphql/catalog-service/headers.md
@@ -1,8 +1,25 @@
 Header | Description
 --- | ---
-`Magento-Customer-Group` | This value is available in the `customer_group_data_exporter` database table.
+`Magento-Customer-Group` | Specify the `customerGroupCode` for the API request. This code is the encrypted value of the `Customer Group Id` which determines discounts and tax class for pricing context. For B2B implementations, the `Customer Group ID` also determines the Shared Catalog context. For details, see [Determine value for `Magento-Customer-Group`](#determine-value-for-the-customer-group-header).
 `Magento-Environment-Id` | This value is displayed at **System** > **Commerce Services Connector** > **SaaS Identifier** > **Data Space ID** or can be obtained by running the `bin/magento config:show services_connector/services_id/environment_id` command.
 `Magento-Store-Code`| The code assigned to the store associated with the active store view. For example, `main_website_store`.
 `Magento-Store-View-Code`| The code assigned to the active store view. For example, `default`.
 `Magento-Website-Code`| The code assigned to the website associated with the active store view. For example, `base`.
 `X-Api-Key` | Set this value to the [unique API key](https://experienceleague.adobe.com/en/docs/commerce-merchant-services/user-guides/integration-services/saas#genapikey) generated for your Commerce environment.
+
+###  Determine value for the Customer Group header
+
+For the `Magento-Customer-Group` header use one of the following values for a default Commerce implementation based on your requirements:
+
+| Customer Group | Default ID | customerGroupCode value |
+|----------------|------------|-------------------|
+| NOT LOGGED IN  | 0          | `b6589fc6ab0dc82cf12099d1c2d40ab994e8410c`
+| General        | 1          | `356a192b7913b04c54574d18c28d46e6395428ab`
+| Wholesale      | 2          | `da4b9237bacccdf19c0760cab7aec4a8359010b0`
+| Retailer       | 3          | `customerGroupCode":"77de68daecd823babbb58edb1c8e14d7106e83bb","name":"Retailer"
+
+For B2B implementations, the `customerGroupCode` value is the encrypted `Customer Group ID` associated with the Shared Catalog, `sha1(<customer_group_id>)`.
+
+>[!NOTE]
+>
+>Find a list of available Customer Group IDs from the Admin (**[!UICONTROL Customers]** > **[!UICONTROL Customer Groups]**). For more information, see [Customer Groups](https://experienceleague.adobe.com/en/docs/commerce-admin/customers/customer-groups) and [Shared Catalogs](https://experienceleague.adobe.com/en/docs/commerce-admin/b2b/shared-catalogs/catalog-shared) in the _Merchant Guide_.

--- a/src/_includes/graphql/catalog-service/headers.md
+++ b/src/_includes/graphql/catalog-service/headers.md
@@ -1,6 +1,6 @@
 Header | Description
 --- | ---
-`Magento-Customer-Group` | Specify the [customerGroupCode](#find-the-customergroupcode) for the API request.
+`Magento-Customer-Group` | Specify the [the customer group code](#find-the-customer-group-code) for the API request.
 `Magento-Environment-Id` | This value is displayed at **System** > **Commerce Services Connector** > **SaaS Identifier** > **Data Space ID** or can be obtained by running the `bin/magento config:show services_connector/services_id/environment_id` command.
 `Magento-Store-Code`| The code assigned to the store associated with the active store view. For example, `main_website_store`.
 `Magento-Store-View-Code`| The code assigned to the active store view. For example, `default`.

--- a/src/_includes/graphql/customer-group-code.md
+++ b/src/_includes/graphql/customer-group-code.md
@@ -1,0 +1,18 @@
+The `customerGroupCode` is the encrypted value of the `Customer Group Id` which determines discounts and tax class for pricing context. For B2B implementations, the `Customer Group Id` also determines the Shared Catalog context.
+
+Use one of the following values for a default customer group based on your requirements.
+
+Customer Group | customerGroupCode
+---------------| -----------------
+**NOT LOGGED IN** | `b6589fc6ab0dc82cf12099d1c2d40ab994e8410c`
+**General** | `356a192b7913b04c54574d18c28d46e6395428ab`
+**Wholesale** | `da4b9237bacccdf19c0760cab7aec4a8359010b0`
+**Retailer** |`77de68daecd823babbb58edb1c8e14d7106e83bb`
+
+For custom groups, use the encrypted value of the Id, `sha1(<customer_group_id>)`
+
+For B2B implementations, use the encrypted value of the `Customer Group Id` associated with the Shared Catalog, `sha1(<customer_group_id>)`.
+
+<InlineAlert variant="info" slots="text"/>
+
+Find a list of available Customer Group Ids from the Admin (**Customers** > **Customer Groups**). For details, see [Customer Groups](https://experienceleague.adobe.com/en/docs/commerce-admin/customers/customer-groups) and [Shared Catalogs](https://experienceleague.adobe.com/en/docs/commerce-admin/b2b/shared-catalogs/catalog-shared) in the _Merchant Guide_.

--- a/src/_includes/graphql/customer-group-code.md
+++ b/src/_includes/graphql/customer-group-code.md
@@ -1,17 +1,17 @@
-The `customerGroupCode` is the encrypted value of the `Customer Group Id` which determines discounts and tax class for pricing context. For B2B implementations, the `Customer Group Id` also determines the Shared Catalog context.
+The Customer Group code is the encrypted value of the `Customer Group Id` which determines discounts and tax class for pricing context. For B2B implementations, the `Customer Group Id` also determines the Shared Catalog context.
 
-Use one of the following values for a default customer group based on your requirements.
+Use one of the following codes for a default customer group based on your requirements.
 
-Customer Group | customerGroupCode
+Customer Group | Code
 ---------------| -----------------
 **NOT LOGGED IN** | `b6589fc6ab0dc82cf12099d1c2d40ab994e8410c`
 **General** | `356a192b7913b04c54574d18c28d46e6395428ab`
 **Wholesale** | `da4b9237bacccdf19c0760cab7aec4a8359010b0`
 **Retailer** |`77de68daecd823babbb58edb1c8e14d7106e83bb`
 
-For custom groups, use the encrypted value of the ID, `sha1(<customer_group_id>)`.
+For custom groups, the customer group code is the encrypted value of the ID, `sha1(<customer_group_id>)`.
 
-For B2B implementations, use the encrypted value of the customer group ID associated with the shared catalog, `sha1(<customer_group_id>)`.
+For B2B implementations, the customer group code is the encrypted value of the customer group ID associated with the shared catalog, `sha1(<customer_group_id>)`.
 
 <InlineAlert variant="info" slots="text"/>
 

--- a/src/_includes/graphql/customer-group-code.md
+++ b/src/_includes/graphql/customer-group-code.md
@@ -1,4 +1,4 @@
-The Customer Group code is the encrypted value of the `Customer Group Id` which determines discounts and tax class for pricing context. For B2B implementations, the `Customer Group Id` also determines the Shared Catalog context.
+The customer group code is the encrypted value of the customer group ID, which determines discounts and tax class for pricing contexts. For B2B implementations, the customer group ID also determines the Shared Catalog context.
 
 Use one of the following codes for a default customer group based on your requirements.
 
@@ -9,7 +9,7 @@ Customer Group | Code
 **Wholesale** | `da4b9237bacccdf19c0760cab7aec4a8359010b0`
 **Retailer** |`77de68daecd823babbb58edb1c8e14d7106e83bb`
 
-For custom groups, the customer group code is the encrypted value of the ID, `sha1(<customer_group_id>)`.
+For merchant-defined groups, the customer group code is the encrypted value of the ID, `sha1(<customer_group_id>)`.
 
 For B2B implementations, the customer group code is the encrypted value of the customer group ID associated with the shared catalog, `sha1(<customer_group_id>)`.
 

--- a/src/_includes/graphql/customer-group-code.md
+++ b/src/_includes/graphql/customer-group-code.md
@@ -9,10 +9,10 @@ Customer Group | customerGroupCode
 **Wholesale** | `da4b9237bacccdf19c0760cab7aec4a8359010b0`
 **Retailer** |`77de68daecd823babbb58edb1c8e14d7106e83bb`
 
-For custom groups, use the encrypted value of the Id, `sha1(<customer_group_id>)`
+For custom groups, use the encrypted value of the ID, `sha1(<customer_group_id>)`.
 
-For B2B implementations, use the encrypted value of the `Customer Group Id` associated with the Shared Catalog, `sha1(<customer_group_id>)`.
+For B2B implementations, use the encrypted value of the customer group ID associated with the shared catalog, `sha1(<customer_group_id>)`.
 
 <InlineAlert variant="info" slots="text"/>
 
-Find a list of available Customer Group Ids from the Admin (**Customers** > **Customer Groups**). For details, see [Customer Groups](https://experienceleague.adobe.com/en/docs/commerce-admin/customers/customer-groups) and [Shared Catalogs](https://experienceleague.adobe.com/en/docs/commerce-admin/b2b/shared-catalogs/catalog-shared) in the _Merchant Guide_.
+Find a list of available customer group IDs from the Admin (**Customers** > **Customer Groups**). For details, see [Customer Groups](https://experienceleague.adobe.com/en/docs/commerce-admin/customers/customer-groups) and [Shared Catalogs](https://experienceleague.adobe.com/en/docs/commerce-admin/b2b/shared-catalogs/catalog-shared) in the _Merchant Guide_.

--- a/src/pages/graphql/catalog-service/categories.md
+++ b/src/pages/graphql/catalog-service/categories.md
@@ -44,6 +44,12 @@ import Headers from '/src/_includes/graphql/catalog-service/headers.md'
 
 <Headers />
 
+###  Find the customerGroupCode
+
+import CustomerGroup from '/src/_includes/graphql/customer-group-code.md'
+
+<CustomerGroup />
+
 ## Example usage
 
 The following query returns a category tree.
@@ -120,7 +126,6 @@ categories(ids: ["11"], roles: ["show_in_menu", "active"], subtree: {
       "urlKey":"jackets-men",
       "parentId":"12",
       "children":[
-         
       ]
    },
    {
@@ -136,7 +141,6 @@ categories(ids: ["11"], roles: ["show_in_menu", "active"], subtree: {
       "urlKey":"pants-men",
       "parentId":"13",
       "children":[
-         
       ]
    },
    {
@@ -152,7 +156,6 @@ categories(ids: ["11"], roles: ["show_in_menu", "active"], subtree: {
       "urlKey":"tanks-men",
       "parentId":"12",
       "children":[
-         
       ]
    },
    {
@@ -168,7 +171,6 @@ categories(ids: ["11"], roles: ["show_in_menu", "active"], subtree: {
       "urlKey":"hoodies-and-sweatshirts-men",
       "parentId":"12",
       "children":[
-         
       ]
    },
    {
@@ -184,7 +186,7 @@ categories(ids: ["11"], roles: ["show_in_menu", "active"], subtree: {
       "urlKey":"shorts-men",
       "parentId":"13",
       "children":[
-         
+
       ]
    }
 ]

--- a/src/pages/graphql/catalog-service/categories.md
+++ b/src/pages/graphql/catalog-service/categories.md
@@ -44,7 +44,7 @@ import Headers from '/src/_includes/graphql/catalog-service/headers.md'
 
 <Headers />
 
-###  Find the customerGroupCode
+###  Find the customer group code
 
 import CustomerGroup from '/src/_includes/graphql/customer-group-code.md'
 

--- a/src/pages/graphql/catalog-service/products.md
+++ b/src/pages/graphql/catalog-service/products.md
@@ -53,6 +53,12 @@ import Docs from '/src/_includes/graphql/catalog-service/headers.md'
 
 <Docs />
 
+###  Find the customerGroupCode
+
+import CustomerGroupCode from '/src/_includes/graphql/customer-group-code.md'
+
+<CustomerGroup />
+
 ## Example usage
 
 The [Commerce API playground](https://experienceleague.adobe.com/developer/commerce/storefront/playgrounds/commerce-services/) provides a sample `products` query that you can run against a live instance of Adobe Commerce with Luma sample data. Note that the responses may vary, depending on the configuration of the Commerce instance.

--- a/src/pages/graphql/catalog-service/products.md
+++ b/src/pages/graphql/catalog-service/products.md
@@ -53,7 +53,7 @@ import Docs from '/src/_includes/graphql/catalog-service/headers.md'
 
 <Docs />
 
-###  Find the customerGroupCode
+###  Find the customer group code
 
 import CustomerGroupCode from '/src/_includes/graphql/customer-group-code.md'
 

--- a/src/pages/graphql/catalog-service/refine-product.md
+++ b/src/pages/graphql/catalog-service/refine-product.md
@@ -32,6 +32,12 @@ import Docs from '/src/_includes/graphql/catalog-service/headers.md'
 
 <Docs />
 
+###  Find the customerGroupCode
+
+import CustomerGroupCode from '/src/_includes/graphql/customer-group-code.md'
+
+<CustomerGroup />
+
 ## Example usage
 
 ### Return details about a partially selected complex product

--- a/src/pages/graphql/catalog-service/refine-product.md
+++ b/src/pages/graphql/catalog-service/refine-product.md
@@ -32,7 +32,7 @@ import Docs from '/src/_includes/graphql/catalog-service/headers.md'
 
 <Docs />
 
-###  Find the customerGroupCode
+###  Find the customer group code
 
 import CustomerGroupCode from '/src/_includes/graphql/customer-group-code.md'
 

--- a/src/pages/graphql/live-search/product-search.md
+++ b/src/pages/graphql/live-search/product-search.md
@@ -403,12 +403,18 @@ You must specify the following HTTP headers to run this query.
 
 Header name| Description
 --- | -----
-`Magento-Customer-Group` | (**Catalog Service Only**) Specify the `customerGroupCode` for the API request. This code is the encrypted value of the `Customer Group Id` which determines the discount and tax class for pricing context. For B2B implementations, the Customer Group ID also determines the Shared catalog context. See the Catalog Service [products query](../catalog-service/products.md#required-headers) for details.
+`Magento-Customer-Group` | (**Catalog Service Only**) Specify the [customerGroupCode](#find-the-customergroupcode) for the API request.
 `Magento-Environment-Id` | This value is displayed at **Stores** > **Configuration** > **Services** > **Magento Services** > **SaaS Environment** or can be obtained by running the `bin/magento config:show services_connector/services_id/environment_id` command.
 `Magento-Store-Code` | The code assigned to the store associated with the active store view. For example, `main_website_store`.
 `Magento-Store-View-Code` | The code assigned to the active store view. For example, `default`.
 `Magento-Website-Code` | The code assigned to the website associated with the active store view. For example, `base`.
 `X-Api-Key` | For Live Search queries, set this value to `search_gql`. For Catalog Service queries, set this value to the [unique API key](https://experienceleague.adobe.com/en/docs/commerce-merchant-services/user-guides/integration-services/saas#genapikey) generated for your Commerce environment.
+
+###  Find the customerGroupCode
+
+import CustomerGroupCode from '/src/_includes/graphql/customer-group-code.md'
+
+<CustomerGroupCode />
 
 ## Example usage
 

--- a/src/pages/graphql/live-search/product-search.md
+++ b/src/pages/graphql/live-search/product-search.md
@@ -402,8 +402,8 @@ Catalog Service and Product Recommendations:
 You must specify the following HTTP headers to run this query.
 
 Header name| Description
---- | ---
-`Magento-Customer-Group` | (**Catalog Service Only**) This value is available in the `customer_group_data_exporter` database table.
+--- | -----
+`Magento-Customer-Group` | (**Catalog Service Only**) Specify the `customerGroupCode` for the API request. This code is the encrypted value of the `Customer Group Id` which determines the discount and tax class for pricing context. For B2B implementations, the Customer Group ID also determines the Shared catalog context. See the Catalog Service [products query](../catalog-service/products.md#required-headers) for details.
 `Magento-Environment-Id` | This value is displayed at **Stores** > **Configuration** > **Services** > **Magento Services** > **SaaS Environment** or can be obtained by running the `bin/magento config:show services_connector/services_id/environment_id` command.
 `Magento-Store-Code` | The code assigned to the store associated with the active store view. For example, `main_website_store`.
 `Magento-Store-View-Code` | The code assigned to the active store view. For example, `default`.

--- a/src/pages/graphql/live-search/product-search.md
+++ b/src/pages/graphql/live-search/product-search.md
@@ -403,14 +403,14 @@ You must specify the following HTTP headers to run this query.
 
 Header name| Description
 --- | -----
-`Magento-Customer-Group` | (**Catalog Service Only**) Specify the [customerGroupCode](#find-the-customergroupcode) for the API request.
+`Magento-Customer-Group` | (**Catalog Service Only**) Specify the [customer group code](#find-the-customer-group-code) for the API request.
 `Magento-Environment-Id` | This value is displayed at **Stores** > **Configuration** > **Services** > **Magento Services** > **SaaS Environment** or can be obtained by running the `bin/magento config:show services_connector/services_id/environment_id` command.
 `Magento-Store-Code` | The code assigned to the store associated with the active store view. For example, `main_website_store`.
 `Magento-Store-View-Code` | The code assigned to the active store view. For example, `default`.
 `Magento-Website-Code` | The code assigned to the website associated with the active store view. For example, `base`.
 `X-Api-Key` | For Live Search queries, set this value to `search_gql`. For Catalog Service queries, set this value to the [unique API key](https://experienceleague.adobe.com/en/docs/commerce-merchant-services/user-guides/integration-services/saas#genapikey) generated for your Commerce environment.
 
-###  Find the customerGroupCode
+###  Find the customer group code
 
 import CustomerGroupCode from '/src/_includes/graphql/customer-group-code.md'
 

--- a/src/pages/graphql/recommendations/recommendations.md
+++ b/src/pages/graphql/recommendations/recommendations.md
@@ -27,6 +27,12 @@ import Docs from '/src/_includes/graphql/catalog-service/headers.md'
 
 <Docs />
 
+###  Find the customerGroupCode
+
+import CustomerGroupCode from '/src/_includes/graphql/customer-group-code.md'
+
+<CustomerGroupCode />
+
 ## Syntax
 
 ```graphql

--- a/src/pages/graphql/recommendations/recommendations.md
+++ b/src/pages/graphql/recommendations/recommendations.md
@@ -27,7 +27,7 @@ import Docs from '/src/_includes/graphql/catalog-service/headers.md'
 
 <Docs />
 
-###  Find the customerGroupCode
+###  Find the customer group code
 
 import CustomerGroupCode from '/src/_includes/graphql/customer-group-code.md'
 


### PR DESCRIPTION
## Purpose of this pull request

Updates description for `Magento-Customer-Group` header required for Catalog Service and Product Recommendations API requests.

[DATA-6141](https://jira.corp.adobe.com/browse/DATA-6141)


Preview of updated information rendered in the Required Header table and explanation of finding `customerGroupCode`.

<img width="566" alt="image" src="https://github.com/user-attachments/assets/374568b8-7984-4172-823f-6317867a2e72">

<img width="581" alt="image" src="https://github.com/user-attachments/assets/c029f17b-6217-466b-868f-31c19b2ee2e9">







## Affected pages

- https://developer.adobe.com/commerce/services/graphql/catalog-service/products/#required-headers
- https://developer.adobe.com/commerce/services/graphql/recommendations/recommendations/#required-headers
- https://developer.adobe.com/commerce/services/graphql/live-search/product-search/#required-headers

