### PR TITLE
Fix include reference for Catalog Service topics

### DIFF
--- a/src/pages/graphql/catalog-service/categories.md
+++ b/src/pages/graphql/catalog-service/categories.md
@@ -46,9 +46,9 @@ import Headers from '/src/_includes/graphql/catalog-service/headers.md'
 
 ###  Find the customer group code
 
-import CustomerGroup from '/src/_includes/graphql/customer-group-code.md'
+import CustomerGroupCode from '/src/_includes/graphql/customer-group-code.md'
 
-<CustomerGroup />
+<CustomerGroupCode />
 
 ## Example usage
 

--- a/src/pages/graphql/catalog-service/refine-product.md
+++ b/src/pages/graphql/catalog-service/refine-product.md
@@ -36,7 +36,7 @@ import Docs from '/src/_includes/graphql/catalog-service/headers.md'
 
 import CustomerGroupCode from '/src/_includes/graphql/customer-group-code.md'
 
-<CustomerGroup />
+<CustomerGroupCode />
 
 ## Example usage
 


### PR DESCRIPTION
## Purpose of this pull request

Fixes the include file reference that provides information about finding the customer group code for Catalog Service refine and products queries. 

## Affected pages

https://developer.adobe.com/commerce/services/graphql/catalog-service/refine-product/
https://developer.adobe.com/commerce/services/graphql/catalog-service/products/
