### PR TITLE
Adding link to live search guide

### DIFF
--- a/src/pages/graphql/live-search/product-search.md
+++ b/src/pages/graphql/live-search/product-search.md
@@ -12,6 +12,8 @@ keywords:
 
 This article discusses the `productSearch` query that is available in the Live Search and Catalog Service extension. While similar in structure and functionality, there are differences in what they output.
 
+See [Boundaries and Limits](https://experienceleague.adobe.com/en/docs/commerce-merchant-services/live-search/boundaries-limits) for the latest recommendations for creating performant queries.
+
 ## Syntax
 
 ```graphql


### PR DESCRIPTION
## Purpose of this pull request

This pull request (PR) adds a link to the boundaries and limits page in the live search guide.

## Affected pages

<!-- REQUIRED List the affected pages on developer.adobe.com (URLs). Not necessary for large numbers of files. -->

- https://developer.adobe.com/commerce/services/graphql/live-search/product-search/
