### PR TITLE
Run staging workflow only for the ccdm-publish-to-staging branch

### DIFF
--- a/.github/workflows/stage.yml
+++ b/.github/workflows/stage.yml
@@ -13,6 +13,7 @@
           default: ''
   jobs:
     set-state:
+      if: ${{ github.ref == 'refs/heads/ccdm-publish-to-staging' }}
       runs-on: ubuntu-latest
       outputs:
         clean_cache: ${{ contains(github.event.inputs.clean, 'yes') }}


### PR DESCRIPTION
## Purpose of this pull request

This pull request (PR) changes workflow to restrict the manual running of the Staging GH Action to the ccdm-publish-to-staging branch.

Internal ticket: COMDOX-1100