### PR TITLE
Fix github-pages workflow in private repos

### DIFF
--- a/.github/workflows/github-pages.yml
+++ b/.github/workflows/github-pages.yml
@@ -20,7 +20,7 @@ jobs:
         run: yarn build
         env:
           NODE_OPTIONS: "--max-old-space-size=8192"
-          PREFIX_PATHS: false # works like --prefix-paths flag for 'gatsby build'
+          PREFIX_PATHS: ${{ !github.event.repository.private }} # If the repository is private or internal, the site will be built with no prefix path
           PATH_PREFIX: ${{ github.event.repository.name }}
           ADOBE_LAUNCH_SRC: ${{ secrets.AIO_ADOBE_LAUNCH_SRC }}
           ADOBE_LAUNCH_SRC_INCLUDE_IN_DEVELOPMENT: ${{ secrets.ADOBE_LAUNCH_SRC_INCLUDE_IN_DEVELOPMENT }}

--- a/.github/workflows/github-pages.yml
+++ b/.github/workflows/github-pages.yml
@@ -20,7 +20,7 @@ jobs:
         run: yarn build
         env:
           NODE_OPTIONS: "--max-old-space-size=8192"
-          PREFIX_PATHS: true # works like --prefix-paths flag for 'gatsby build'
+          PREFIX_PATHS: false # works like --prefix-paths flag for 'gatsby build'
           PATH_PREFIX: ${{ github.event.repository.name }}
           ADOBE_LAUNCH_SRC: ${{ secrets.AIO_ADOBE_LAUNCH_SRC }}
           ADOBE_LAUNCH_SRC_INCLUDE_IN_DEVELOPMENT: ${{ secrets.ADOBE_LAUNCH_SRC_INCLUDE_IN_DEVELOPMENT }}

--- a/.gitignore
+++ b/.gitignore
@@ -44,3 +44,6 @@ local-test.yml
 # yalc
 .yalc
 yalc.lock
+
+# other
+tmp/*


### PR DESCRIPTION
## Purpose of this pull request

This pull request (PR) updates the github-pages workflow to allow deployments to the private GitHub Pages site.

_Disclaimer: This solution won't work for public Pages in private repos._

## Affected pages

<!-- REQUIRED List the affected pages on developer.adobe.com (URLs). Not necessary for large numbers of files. -->

- none

