### PR TITLE
DCAT-2152: Price should not be persisted for Configurable Product type

### DIFF
--- a/src/openapi/data-ingestion-schema-v1.yaml
+++ b/src/openapi/data-ingestion-schema-v1.yaml
@@ -787,7 +787,7 @@ paths:
         
         <h3>Configurable Products</h3>
         Configurable product price is calculated based on the price of the selected product variant.
-        Any price passed for a configurable product SKU will be ignored.
+        > Please do not send prices for configurable products SKUs directly as it may lead to incorrect prices calculation for such products.
 
       operationId: PricesPut
       parameters:

--- a/src/openapi/data-ingestion-schema-v1.yaml
+++ b/src/openapi/data-ingestion-schema-v1.yaml
@@ -787,7 +787,7 @@ paths:
         
         <h3>Configurable Products</h3>
         Configurable product price is calculated based on the price of the selected product variant.
-        > Please do not send prices for configurable products SKUs directly as it may lead to incorrect prices calculation for such products.
+        > Do not send prices for configurable products SKUs directly as it can cause incorrect price calculations for these products.
 
       operationId: PricesPut
       parameters:


### PR DESCRIPTION
## Purpose of this pull request

This pull request (PR) created to update information about configurable product prices calculation

## Affected pages

<!-- REQUIRED List the affected pages on developer.adobe.com (URLs). Not necessary for large numbers of files. -->

- https://developer-stage.adobe.com/commerce/services/composable-catalog/data-ingestion/api-reference/#operation/PricesPut

<!--
If you are fixing a GitHub issue, using the GitHub keyword format (https://help.github.com/en/articles/closing-issues-using-keywords#closing-an-issue-in-a-different-repository) closes the issue when this pull request is merged. Example: `Fixes #1234`.
`main` is the default branch. Merged pull requests to `main` go live on the site automatically. Any requested changes to content on the `main` branch must be related to the released codebase. Any content related to future releases goes in the `develop` branch.
See Contribution guidelines (https://github.com/AdobeDocs/commerce-services/blob/main/.github/CONTRIBUTING.md) for more information.
-->
