### PR TITLE
Add 'back to top' to GraphQL API docs

### DIFF
--- a/spectaql/comdox-theme/views/partials/graphql/_query-or-mutation-or-subscription.hbs
+++ b/spectaql/comdox-theme/views/partials/graphql/_query-or-mutation-or-subscription.hbs
@@ -1,0 +1,82 @@
+<section id="{{./htmlId}}"
+  class="operation operation-{{#if isQuery}}query{{else if isMutation}}mutation{{else if isSubscription}}subscription{{else}}unknown{{/if}}"
+  data-traverse-target="{{./htmlId}}">
+  {{# unless @first }}
+    {{#if parentHtmlId }}
+      <div class="operation-group-name">
+        <a href="#group-{{./parentHtmlId}}">{{./parentName}}</a>
+      </div>
+    {{/if}}
+  {{/unless}}
+
+  <h2 class="operation-heading {{#if (and isDeprecated (not @root.info.x-hideIsDeprecated)) }}operation-deprecated{{/if}}">
+    {{md (codify name) stripParagraph="true"}}
+  </h2>
+
+  {{#if (and deprecationReason (not @root.info.x-hideDeprecationReason))}}
+    <div class="doc-row">
+      <div class="doc-copy">
+        <div class="doc-copy-section">
+          <div class="deprecation-reason">
+            {{ md deprecationReason stripParagraph=true }}
+          </div>
+        </div>
+      </div>
+    </div>
+  {{/if}}
+
+  {{#if description}}
+    <div class="doc-row">
+      <div class="doc-copy">
+        <div class="operation-description doc-copy-section">
+          <h5>Description</h5>
+          {{ md (interpolateReferences description) }}
+        </div>
+      </div>
+    </div>
+  {{/if}}
+
+  <div class="doc-row">
+    <div class="doc-copy">
+      {{#if response}}
+        <div class="operation-response doc-copy-section">
+          <h5>Response</h5>
+          <p>
+            Returns
+            {{! If it's got items, then it's an array, and we don't care about the indefiniteArticle }}
+            {{#unless response.isArray }}
+              {{ indefiniteArticle response.underlyingType.name }}
+            {{/unless}}
+            {{~ md (mdTypeLink . codify=true) stripParagraph=true }}
+          </p>
+        </div>
+      {{/if}}
+      {{>graphql/_query-or-mutation-arguments}}
+    </div>
+
+    <div class="doc-examples">
+      {{#if (firstTruthy query mutation subscription)}}
+        <h4 class="example-heading">Example</h4>
+
+        <div class="example-section example-section-is-code operation-query-example">
+          <h5>Query</h5>
+          {{printGraphQL (firstTruthy query mutation subscription)}}
+        </div>
+
+        {{#if variables}}
+          <div class="example-section example-section-is-code operation-variables-example">
+            <h5>Variables</h5>
+            {{printJSON variables}}
+          </div>
+        {{/if}}
+        {{#if response.data}}
+          <div class="example-section example-section-is-code operation-response-example">
+            <h5>Response</h5>
+            {{printJSON response.data}}
+          </div>
+        {{/if}}
+      {{/if}}
+    </div>
+    <a href="#top">back to top</a>
+  </div>
+</section>

--- a/spectaql/comdox-theme/views/partials/graphql/type.hbs
+++ b/spectaql/comdox-theme/views/partials/graphql/type.hbs
@@ -1,0 +1,33 @@
+<section id="{{./htmlId}}"
+  class="definition definition-{{ kebabCase ./kind defaultValue='unknown' }}"
+  data-traverse-target="{{./htmlId}}">
+  {{#unless @first }}
+    {{#if parentHtmlId }}
+      <div class="definition-group-name">
+        <a href="#group-{{parentHtmlId}}">{{./parentName}}</a>
+      </div>
+    {{/if}}
+  {{/unless}}
+  {{#if name}}
+    <h2 class="definition-heading">{{name}}{{!--  - {{kind}} --}}</h2>
+  {{/if}}
+
+  <div class="doc-row">
+    {{#if (equal ./kind "SCALAR")}}
+      {{>graphql/kinds/scalar .}}
+    {{else if (equal ./kind "OBJECT")}}
+      {{>graphql/kinds/object .}}
+    {{else if (equal ./kind "ENUM")}}
+      {{>graphql/kinds/enum .}}
+    {{else if (equal ./kind "INPUT_OBJECT")}}
+      {{>graphql/kinds/input-object .}}
+    {{else if (equal ./kind "UNION")}}
+      {{>graphql/kinds/union .}}
+    {{else if (equal ./kind "INTERFACE")}}
+      {{>graphql/kinds/interface .}}
+    {{else}}
+      {{ log "unknown type.hbs" . }}
+    {{/if}}
+    <a href="#top">back to top</a>
+  </div>
+</section>

--- a/spectaql/config-admin.yml
+++ b/spectaql/config-admin.yml
@@ -64,7 +64,7 @@ spectaql:
   # "spectaql": Outputs the same HTML structure as the "default" theme, but with some CSS enhancements
   #
   # Default: "default"
-  # themeDir: ./spectaql/adobe-theme
+  themeDir: spectaql/comdox-theme
   theme: spectaql
 
   # If you're embedding SpectaQL's output, and you've got something like a Nav Bar that

--- a/spectaql/config-storefront.yml
+++ b/spectaql/config-storefront.yml
@@ -64,7 +64,7 @@ spectaql:
   # "spectaql": Outputs the same HTML structure as the "default" theme, but with some CSS enhancements
   #
   # Default: "default"
-  # themeDir: ./spectaql/adobe-theme
+  themeDir: spectaql/comdox-theme
   theme: spectaql
 
   # If you're embedding SpectaQL's output, and you've got something like a Nav Bar that

--- a/static/graphql-api/admin-api/index.html
+++ b/static/graphql-api/admin-api/index.html
@@ -27,6 +27,7 @@
               </h5>
               <ul class="nav-group-section-items">
                 <li><a href="#query-analytics">analytics</a></li>
+                <li><a href="#query-catalogStorefront">catalogStorefront</a></li>
                 <li><a href="#query-categories">categories</a></li>
                 <li><a href="#query-categoriesByName">categoriesByName</a></li>
                 <li><a href="#query-categoryRuleDetail">categoryRuleDetail</a></li>
@@ -36,12 +37,16 @@
                 <li><a href="#query-channel">channel</a></li>
                 <li><a href="#query-channels">channels</a></li>
                 <li><a href="#query-defaultQueryRule">defaultQueryRule</a></li>
+                <li><a href="#query-eventing">eventing</a></li>
                 <li><a href="#query-facetsConfiguration">facetsConfiguration</a></li>
+                <li><a href="#query-liveSearch">liveSearch</a></li>
                 <li><a href="#query-pageUnits">pageUnits</a></li>
                 <li><a href="#query-policies">policies</a></li>
                 <li><a href="#query-policy">policy</a></li>
                 <li><a href="#query-productAttributeMetadata">productAttributeMetadata</a></li>
                 <li><a href="#query-queryRules">queryRules</a></li>
+                <li><a href="#query-recommendations">recommendations</a></li>
+                <li><a href="#query-scopes">scopes</a></li>
                 <li><a href="#query-storeConfiguration">storeConfiguration</a></li>
                 <li><a href="#query-subcategoryOverrides">subcategoryOverrides</a></li>
                 <li><a href="#query-synonyms">synonyms</a></li>
@@ -92,7 +97,9 @@
             <li><a href="#definition-BatchChannelResponse">BatchChannelResponse</a></li>
             <li><a href="#definition-BatchPolicyResponse">BatchPolicyResponse</a></li>
             <li><a href="#definition-BatchUnitResponse">BatchUnitResponse</a></li>
+            <li><a href="#definition-BigDecimal">BigDecimal</a></li>
             <li><a href="#definition-Boolean">Boolean</a></li>
+            <li><a href="#definition-CatalogStorefront">CatalogStorefront</a></li>
             <li><a href="#definition-CategoriesResponse">CategoriesResponse</a></li>
             <li><a href="#definition-Category">Category</a></li>
             <li><a href="#definition-CategoryRule">CategoryRule</a></li>
@@ -106,6 +113,7 @@
             <li><a href="#definition-ChannelScopeResponse">ChannelScopeResponse</a></li>
             <li><a href="#definition-ConditionRequest">ConditionRequest</a></li>
             <li><a href="#definition-ConditionResponse">ConditionResponse</a></li>
+            <li><a href="#definition-CountFromTo">CountFromTo</a></li>
             <li><a href="#definition-CreateChannelRequest">CreateChannelRequest</a></li>
             <li><a href="#definition-CreatePolicyRequest">CreatePolicyRequest</a></li>
             <li><a href="#definition-CreateUnitRequest">CreateUnitRequest</a></li>
@@ -117,8 +125,10 @@
             <li><a href="#definition-Event">Event</a></li>
             <li><a href="#definition-EventAction">EventAction</a></li>
             <li><a href="#definition-EventActionInput">EventActionInput</a></li>
+            <li><a href="#definition-EventCounts">EventCounts</a></li>
             <li><a href="#definition-EventInput">EventInput</a></li>
             <li><a href="#definition-EventTargetType">EventTargetType</a></li>
+            <li><a href="#definition-Eventing">Eventing</a></li>
             <li><a href="#definition-FacetAggregationRange">FacetAggregationRange</a></li>
             <li><a href="#definition-FacetAggregationRangeInput">FacetAggregationRangeInput</a></li>
             <li><a href="#definition-FacetConfigAggregationType">FacetConfigAggregationType</a></li>
@@ -133,6 +143,7 @@
             <li><a href="#definition-FilterRuleType">FilterRuleType</a></li>
             <li><a href="#definition-Float">Float</a></li>
             <li><a href="#definition-ID">ID</a></li>
+            <li><a href="#definition-Image">Image</a></li>
             <li><a href="#definition-IndexLanguageConfiguration">IndexLanguageConfiguration</a></li>
             <li><a href="#definition-IndexLanguageConfigurationInput">IndexLanguageConfigurationInput</a></li>
             <li><a href="#definition-Int">Int</a></li>
@@ -143,6 +154,7 @@
             <li><a href="#definition-Language">Language</a></li>
             <li><a href="#definition-LanguageAnalyzer">LanguageAnalyzer</a></li>
             <li><a href="#definition-LanguageAnalyzerInput">LanguageAnalyzerInput</a></li>
+            <li><a href="#definition-LiveSearch">LiveSearch</a></li>
             <li><a href="#definition-ManualPriceBucketConfiguration">ManualPriceBucketConfiguration</a></li>
             <li><a href="#definition-ManualPriceBucketConfigurationInput">ManualPriceBucketConfigurationInput</a></li>
             <li><a href="#definition-MetadataBooleanCondition">MetadataBooleanCondition</a></li>
@@ -158,11 +170,17 @@
             <li><a href="#definition-OperatorResponse">OperatorResponse</a></li>
             <li><a href="#definition-PolicyResponse">PolicyResponse</a></li>
             <li><a href="#definition-PopularSkuResponse">PopularSkuResponse</a></li>
+            <li><a href="#definition-Price">Price</a></li>
             <li><a href="#definition-PriceBucketConfiguration">PriceBucketConfiguration</a></li>
             <li><a href="#definition-PriceBucketConfigurationInput">PriceBucketConfigurationInput</a></li>
             <li><a href="#definition-PriceBucketType">PriceBucketType</a></li>
+            <li><a href="#definition-PriceWrapper">PriceWrapper</a></li>
             <li><a href="#definition-ProductAttributeMetadataQueryResponse">ProductAttributeMetadataQueryResponse</a></li>
             <li><a href="#definition-ProductAttributeMetadataResponse">ProductAttributeMetadataResponse</a></li>
+            <li><a href="#definition-ProductDetail">ProductDetail</a></li>
+            <li><a href="#definition-ProductList">ProductList</a></li>
+            <li><a href="#definition-ProductOverride">ProductOverride</a></li>
+            <li><a href="#definition-ProductRow">ProductRow</a></li>
             <li><a href="#definition-QueryCondition">QueryCondition</a></li>
             <li><a href="#definition-QueryConditionGroup">QueryConditionGroup</a></li>
             <li><a href="#definition-QueryConditionGroupInput">QueryConditionGroupInput</a></li>
@@ -179,10 +197,13 @@
             <li><a href="#definition-RangeValue">RangeValue</a></li>
             <li><a href="#definition-RangeValueRequest">RangeValueRequest</a></li>
             <li><a href="#definition-RankingType">RankingType</a></li>
+            <li><a href="#definition-Recommendations">Recommendations</a></li>
             <li><a href="#definition-RuleStatusType">RuleStatusType</a></li>
             <li><a href="#definition-RuleType">RuleType</a></li>
+            <li><a href="#definition-Scope">Scope</a></li>
             <li><a href="#definition-SearchAnalyticsQueryResponse">SearchAnalyticsQueryResponse</a></li>
             <li><a href="#definition-SearchMerchandisingRule">SearchMerchandisingRule</a></li>
+            <li><a href="#definition-Since">Since</a></li>
             <li><a href="#definition-StoreConfiguration">StoreConfiguration</a></li>
             <li><a href="#definition-StoreConfigurationInput">StoreConfigurationInput</a></li>
             <li><a href="#definition-StoreConfigurationMutationResponse">StoreConfigurationMutationResponse</a></li>
@@ -342,6 +363,76 @@ Authorization: Bearer &lt;YOUR_TOKEN_HERE&gt;</code></pre>
                 </html>
               </div>
             </div>
+            <a href="#top">back to top</a>
+          </div>
+        </section>
+        <section id="query-catalogStorefront" class="operation operation-query" data-traverse-target="query-catalogStorefront">
+          <div class="operation-group-name">
+            <a href="#group-Operations-Queries">Queries</a>
+          </div>
+          <h2 class="operation-heading ">
+            <code>catalogStorefront</code>
+          </h2>
+          <div class="doc-row">
+            <div class="doc-copy">
+              <div class="operation-description doc-copy-section">
+                <h5>Description</h5>
+                <p>Provides data sync information for products indexed for Catalog Storefront Service</p>
+              </div>
+            </div>
+          </div>
+          <div class="doc-row">
+            <div class="doc-copy">
+              <div class="operation-response doc-copy-section">
+                <h5>Response</h5>
+                <p> Returns a <a href="#definition-CatalogStorefront"><code>CatalogStorefront!</code></a>
+                </p>
+              </div>
+            </div>
+            <div class="doc-examples">
+              <h4 class="example-heading">Example</h4>
+              <div class="example-section example-section-is-code operation-query-example">
+                <h5>Query</h5>
+                <html>
+                  <head></head>
+                  <body><pre><code class="hljs language-gql"><span class="hljs-symbol"><span class="hljs-keyword">query</span> catalogStorefront <span class="hljs-tag">{
+  <span class="hljs-symbol">catalogStorefront <span class="hljs-tag">{
+    <span class="hljs-symbol">count</span>
+    <span class="hljs-symbol">countFromTo <span class="hljs-tag">{
+      <span class="hljs-type">...CountFromToFragment</span>
+    }</span></span>
+    <span class="hljs-symbol">productDetail <span class="hljs-tag">{
+      <span class="hljs-type">...ProductDetailFragment</span>
+    }</span></span>
+    <span class="hljs-symbol">productList <span class="hljs-tag">{
+      <span class="hljs-type">...ProductListFragment</span>
+    }</span></span>
+  }</span></span>
+}</span></span>
+</code></pre>
+                  </body>
+                </html>
+              </div>
+              <div class="example-section example-section-is-code operation-response-example">
+                <h5>Response</h5>
+                <html>
+                  <head></head>
+                  <body><pre><code class="hljs language-json"><span class="hljs-punctuation">{</span>
+  <span class="hljs-attr">"data"</span><span class="hljs-punctuation">:</span> <span class="hljs-punctuation">{</span>
+    <span class="hljs-attr">"catalogStorefront"</span><span class="hljs-punctuation">:</span> <span class="hljs-punctuation">{</span>
+      <span class="hljs-attr">"count"</span><span class="hljs-punctuation">:</span> <span class="hljs-number">123</span><span class="hljs-punctuation">,</span>
+      <span class="hljs-attr">"countFromTo"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">CountFromTo</span><span class="hljs-punctuation">,</span>
+      <span class="hljs-attr">"productDetail"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">ProductDetail</span><span class="hljs-punctuation">,</span>
+      <span class="hljs-attr">"productList"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">ProductList</span>
+    <span class="hljs-punctuation">}</span>
+  <span class="hljs-punctuation">}</span>
+<span class="hljs-punctuation">}</span>
+</code></pre>
+                  </body>
+                </html>
+              </div>
+            </div>
+            <a href="#top">back to top</a>
           </div>
         </section>
         <section id="query-categories" class="operation operation-query" data-traverse-target="query-categories">
@@ -437,6 +528,7 @@ Authorization: Bearer &lt;YOUR_TOKEN_HERE&gt;</code></pre>
                 </html>
               </div>
             </div>
+            <a href="#top">back to top</a>
           </div>
         </section>
         <section id="query-categoriesByName" class="operation operation-query" data-traverse-target="query-categoriesByName">
@@ -502,7 +594,7 @@ Authorization: Bearer &lt;YOUR_TOKEN_HERE&gt;</code></pre>
                 <h5>Variables</h5>
                 <html>
                   <head></head>
-                  <body><pre><code class="hljs language-json"><span class="hljs-punctuation">{</span><span class="hljs-attr">"name"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"abc123"</span><span class="hljs-punctuation">}</span>
+                  <body><pre><code class="hljs language-json"><span class="hljs-punctuation">{</span><span class="hljs-attr">"name"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"xyz789"</span><span class="hljs-punctuation">}</span>
 </code></pre>
                   </body>
                 </html>
@@ -517,6 +609,7 @@ Authorization: Bearer &lt;YOUR_TOKEN_HERE&gt;</code></pre>
                 </html>
               </div>
             </div>
+            <a href="#top">back to top</a>
           </div>
         </section>
         <section id="query-categoryRuleDetail" class="operation operation-query" data-traverse-target="query-categoryRuleDetail">
@@ -595,7 +688,7 @@ Authorization: Bearer &lt;YOUR_TOKEN_HERE&gt;</code></pre>
                 <h5>Variables</h5>
                 <html>
                   <head></head>
-                  <body><pre><code class="hljs language-json"><span class="hljs-punctuation">{</span><span class="hljs-attr">"path"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"abc123"</span><span class="hljs-punctuation">}</span>
+                  <body><pre><code class="hljs language-json"><span class="hljs-punctuation">{</span><span class="hljs-attr">"path"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"xyz789"</span><span class="hljs-punctuation">}</span>
 </code></pre>
                   </body>
                 </html>
@@ -607,18 +700,18 @@ Authorization: Bearer &lt;YOUR_TOKEN_HERE&gt;</code></pre>
                   <body><pre><code class="hljs language-json"><span class="hljs-punctuation">{</span>
   <span class="hljs-attr">"data"</span><span class="hljs-punctuation">:</span> <span class="hljs-punctuation">{</span>
     <span class="hljs-attr">"categoryRuleDetail"</span><span class="hljs-punctuation">:</span> <span class="hljs-punctuation">{</span>
-      <span class="hljs-attr">"applyToSubcategories"</span><span class="hljs-punctuation">:</span> <span class="hljs-literal"><span class="hljs-keyword">true</span></span><span class="hljs-punctuation">,</span>
-      <span class="hljs-attr">"categoryId"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"xyz789"</span><span class="hljs-punctuation">,</span>
-      <span class="hljs-attr">"categoryName"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"abc123"</span><span class="hljs-punctuation">,</span>
-      <span class="hljs-attr">"children"</span><span class="hljs-punctuation">:</span> <span class="hljs-punctuation">[</span><span class="hljs-string">"abc123"</span><span class="hljs-punctuation">]</span><span class="hljs-punctuation">,</span>
+      <span class="hljs-attr">"applyToSubcategories"</span><span class="hljs-punctuation">:</span> <span class="hljs-literal"><span class="hljs-keyword">false</span></span><span class="hljs-punctuation">,</span>
+      <span class="hljs-attr">"categoryId"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"abc123"</span><span class="hljs-punctuation">,</span>
+      <span class="hljs-attr">"categoryName"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"xyz789"</span><span class="hljs-punctuation">,</span>
+      <span class="hljs-attr">"children"</span><span class="hljs-punctuation">:</span> <span class="hljs-punctuation">[</span><span class="hljs-string">"xyz789"</span><span class="hljs-punctuation">]</span><span class="hljs-punctuation">,</span>
       <span class="hljs-attr">"events"</span><span class="hljs-punctuation">:</span> <span class="hljs-punctuation">[</span><span class="hljs-string">Event</span><span class="hljs-punctuation">]</span><span class="hljs-punctuation">,</span>
-      <span class="hljs-attr">"level"</span><span class="hljs-punctuation">:</span> <span class="hljs-number">987</span><span class="hljs-punctuation">,</span>
-      <span class="hljs-attr">"parentId"</span><span class="hljs-punctuation">:</span> <span class="hljs-number">123</span><span class="hljs-punctuation">,</span>
-      <span class="hljs-attr">"parentRuleId"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"abc123"</span><span class="hljs-punctuation">,</span>
+      <span class="hljs-attr">"level"</span><span class="hljs-punctuation">:</span> <span class="hljs-number">123</span><span class="hljs-punctuation">,</span>
+      <span class="hljs-attr">"parentId"</span><span class="hljs-punctuation">:</span> <span class="hljs-number">987</span><span class="hljs-punctuation">,</span>
+      <span class="hljs-attr">"parentRuleId"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"xyz789"</span><span class="hljs-punctuation">,</span>
       <span class="hljs-attr">"path"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"abc123"</span><span class="hljs-punctuation">,</span>
       <span class="hljs-attr">"rankingType"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"MOST_ADDED_TO_CART"</span><span class="hljs-punctuation">,</span>
-      <span class="hljs-attr">"ruleId"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"abc123"</span><span class="hljs-punctuation">,</span>
-      <span class="hljs-attr">"ruleUpdated"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"xyz789"</span><span class="hljs-punctuation">,</span>
+      <span class="hljs-attr">"ruleId"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"xyz789"</span><span class="hljs-punctuation">,</span>
+      <span class="hljs-attr">"ruleUpdated"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"abc123"</span><span class="hljs-punctuation">,</span>
       <span class="hljs-attr">"trendingWindow"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"FOURTEEN"</span><span class="hljs-punctuation">,</span>
       <span class="hljs-attr">"urlPath"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"xyz789"</span>
     <span class="hljs-punctuation">}</span>
@@ -629,6 +722,7 @@ Authorization: Bearer &lt;YOUR_TOKEN_HERE&gt;</code></pre>
                 </html>
               </div>
             </div>
+            <a href="#top">back to top</a>
           </div>
         </section>
         <section id="query-categoryRules" class="operation operation-query" data-traverse-target="query-categoryRules">
@@ -710,7 +804,7 @@ Authorization: Bearer &lt;YOUR_TOKEN_HERE&gt;</code></pre>
                   <head></head>
                   <body><pre><code class="hljs language-json"><span class="hljs-punctuation">{</span>
   <span class="hljs-attr">"level"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">RangeInput</span><span class="hljs-punctuation">,</span>
-  <span class="hljs-attr">"parentPath"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"xyz789"</span>
+  <span class="hljs-attr">"parentPath"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"abc123"</span>
 <span class="hljs-punctuation">}</span>
 </code></pre>
                   </body>
@@ -730,6 +824,7 @@ Authorization: Bearer &lt;YOUR_TOKEN_HERE&gt;</code></pre>
                 </html>
               </div>
             </div>
+            <a href="#top">back to top</a>
           </div>
         </section>
         <section id="query-categoryRulesDeleteCount" class="operation operation-query" data-traverse-target="query-categoryRulesDeleteCount">
@@ -794,7 +889,7 @@ Authorization: Bearer &lt;YOUR_TOKEN_HERE&gt;</code></pre>
                 <h5>Variables</h5>
                 <html>
                   <head></head>
-                  <body><pre><code class="hljs language-json"><span class="hljs-punctuation">{</span><span class="hljs-attr">"categoryRuleId"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"xyz789"</span><span class="hljs-punctuation">}</span>
+                  <body><pre><code class="hljs language-json"><span class="hljs-punctuation">{</span><span class="hljs-attr">"categoryRuleId"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"abc123"</span><span class="hljs-punctuation">}</span>
 </code></pre>
                   </body>
                 </html>
@@ -803,12 +898,13 @@ Authorization: Bearer &lt;YOUR_TOKEN_HERE&gt;</code></pre>
                 <h5>Response</h5>
                 <html>
                   <head></head>
-                  <body><pre><code class="hljs language-json"><span class="hljs-punctuation">{</span><span class="hljs-attr">"data"</span><span class="hljs-punctuation">:</span> <span class="hljs-punctuation">{</span><span class="hljs-attr">"categoryRulesDeleteCount"</span><span class="hljs-punctuation">:</span> <span class="hljs-punctuation">{</span><span class="hljs-attr">"categoryRulesDeleteCount"</span><span class="hljs-punctuation">:</span> <span class="hljs-number">987</span><span class="hljs-punctuation">}</span><span class="hljs-punctuation">}</span><span class="hljs-punctuation">}</span>
+                  <body><pre><code class="hljs language-json"><span class="hljs-punctuation">{</span><span class="hljs-attr">"data"</span><span class="hljs-punctuation">:</span> <span class="hljs-punctuation">{</span><span class="hljs-attr">"categoryRulesDeleteCount"</span><span class="hljs-punctuation">:</span> <span class="hljs-punctuation">{</span><span class="hljs-attr">"categoryRulesDeleteCount"</span><span class="hljs-punctuation">:</span> <span class="hljs-number">123</span><span class="hljs-punctuation">}</span><span class="hljs-punctuation">}</span><span class="hljs-punctuation">}</span>
 </code></pre>
                   </body>
                 </html>
               </div>
             </div>
+            <a href="#top">back to top</a>
           </div>
         </section>
         <section id="query-categoryTreeByPath" class="operation operation-query" data-traverse-target="query-categoryTreeByPath">
@@ -874,7 +970,7 @@ Authorization: Bearer &lt;YOUR_TOKEN_HERE&gt;</code></pre>
                 <h5>Variables</h5>
                 <html>
                   <head></head>
-                  <body><pre><code class="hljs language-json"><span class="hljs-punctuation">{</span><span class="hljs-attr">"path"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"xyz789"</span><span class="hljs-punctuation">}</span>
+                  <body><pre><code class="hljs language-json"><span class="hljs-punctuation">{</span><span class="hljs-attr">"path"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"abc123"</span><span class="hljs-punctuation">}</span>
 </code></pre>
                   </body>
                 </html>
@@ -895,6 +991,7 @@ Authorization: Bearer &lt;YOUR_TOKEN_HERE&gt;</code></pre>
                 </html>
               </div>
             </div>
+            <a href="#top">back to top</a>
           </div>
         </section>
         <section id="query-channel" class="operation operation-query" data-traverse-target="query-channel">
@@ -1108,7 +1205,7 @@ Authorization: Bearer &lt;YOUR_TOKEN_HERE&gt;</code></pre>
                 <h5>Variables</h5>
                 <html>
                   <head></head>
-                  <body><pre><code class="hljs language-json"><span class="hljs-punctuation">{</span><span class="hljs-attr">"channelId"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"abc123"</span><span class="hljs-punctuation">}</span>
+                  <body><pre><code class="hljs language-json"><span class="hljs-punctuation">{</span><span class="hljs-attr">"channelId"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"xyz789"</span><span class="hljs-punctuation">}</span>
 </code></pre>
                   </body>
                 </html>
@@ -1135,6 +1232,7 @@ Authorization: Bearer &lt;YOUR_TOKEN_HERE&gt;</code></pre>
                 </html>
               </div>
             </div>
+            <a href="#top">back to top</a>
           </div>
         </section>
         <section id="query-channels" class="operation operation-query" data-traverse-target="query-channels">
@@ -1333,13 +1431,13 @@ Authorization: Bearer &lt;YOUR_TOKEN_HERE&gt;</code></pre>
   <span class="hljs-attr">"data"</span><span class="hljs-punctuation">:</span> <span class="hljs-punctuation">{</span>
     <span class="hljs-attr">"channels"</span><span class="hljs-punctuation">:</span> <span class="hljs-punctuation">[</span>
       <span class="hljs-punctuation">{</span>
-        <span class="hljs-attr">"channelId"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"xyz789"</span><span class="hljs-punctuation">,</span>
+        <span class="hljs-attr">"channelId"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"abc123"</span><span class="hljs-punctuation">,</span>
         <span class="hljs-attr">"createdAt"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"abc123"</span><span class="hljs-punctuation">,</span>
-        <span class="hljs-attr">"name"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"abc123"</span><span class="hljs-punctuation">,</span>
+        <span class="hljs-attr">"name"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"xyz789"</span><span class="hljs-punctuation">,</span>
         <span class="hljs-attr">"policies"</span><span class="hljs-punctuation">:</span> <span class="hljs-punctuation">[</span><span class="hljs-string">PolicyResponse</span><span class="hljs-punctuation">]</span><span class="hljs-punctuation">,</span>
         <span class="hljs-attr">"policyIds"</span><span class="hljs-punctuation">:</span> <span class="hljs-punctuation">[</span><span class="hljs-string">"abc123"</span><span class="hljs-punctuation">]</span><span class="hljs-punctuation">,</span>
         <span class="hljs-attr">"scopes"</span><span class="hljs-punctuation">:</span> <span class="hljs-punctuation">[</span><span class="hljs-string">ChannelScopeResponse</span><span class="hljs-punctuation">]</span><span class="hljs-punctuation">,</span>
-        <span class="hljs-attr">"updatedAt"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"xyz789"</span>
+        <span class="hljs-attr">"updatedAt"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"abc123"</span>
       <span class="hljs-punctuation">}</span>
     <span class="hljs-punctuation">]</span>
   <span class="hljs-punctuation">}</span>
@@ -1349,6 +1447,7 @@ Authorization: Bearer &lt;YOUR_TOKEN_HERE&gt;</code></pre>
                 </html>
               </div>
             </div>
+            <a href="#top">back to top</a>
           </div>
         </section>
         <section id="query-defaultQueryRule" class="operation operation-query" data-traverse-target="query-defaultQueryRule">
@@ -1407,6 +1506,70 @@ Authorization: Bearer &lt;YOUR_TOKEN_HERE&gt;</code></pre>
                 </html>
               </div>
             </div>
+            <a href="#top">back to top</a>
+          </div>
+        </section>
+        <section id="query-eventing" class="operation operation-query" data-traverse-target="query-eventing">
+          <div class="operation-group-name">
+            <a href="#group-Operations-Queries">Queries</a>
+          </div>
+          <h2 class="operation-heading ">
+            <code>eventing</code>
+          </h2>
+          <div class="doc-row">
+            <div class="doc-copy">
+              <div class="operation-description doc-copy-section">
+                <h5>Description</h5>
+                <p>Provides storefront eventing aggregation data flow information</p>
+              </div>
+            </div>
+          </div>
+          <div class="doc-row">
+            <div class="doc-copy">
+              <div class="operation-response doc-copy-section">
+                <h5>Response</h5>
+                <p> Returns an <a href="#definition-Eventing"><code>Eventing!</code></a>
+                </p>
+              </div>
+            </div>
+            <div class="doc-examples">
+              <h4 class="example-heading">Example</h4>
+              <div class="example-section example-section-is-code operation-query-example">
+                <h5>Query</h5>
+                <html>
+                  <head></head>
+                  <body><pre><code class="hljs language-gql"><span class="hljs-symbol"><span class="hljs-keyword">query</span> eventing <span class="hljs-tag">{
+  <span class="hljs-symbol">eventing <span class="hljs-tag">{
+    <span class="hljs-symbol">countsByDay <span class="hljs-tag">{
+      <span class="hljs-type">...EventCountsFragment</span>
+    }</span></span>
+    <span class="hljs-symbol">countsByHour <span class="hljs-tag">{
+      <span class="hljs-type">...EventCountsFragment</span>
+    }</span></span>
+  }</span></span>
+}</span></span>
+</code></pre>
+                  </body>
+                </html>
+              </div>
+              <div class="example-section example-section-is-code operation-response-example">
+                <h5>Response</h5>
+                <html>
+                  <head></head>
+                  <body><pre><code class="hljs language-json"><span class="hljs-punctuation">{</span>
+  <span class="hljs-attr">"data"</span><span class="hljs-punctuation">:</span> <span class="hljs-punctuation">{</span>
+    <span class="hljs-attr">"eventing"</span><span class="hljs-punctuation">:</span> <span class="hljs-punctuation">{</span>
+      <span class="hljs-attr">"countsByDay"</span><span class="hljs-punctuation">:</span> <span class="hljs-punctuation">[</span><span class="hljs-string">EventCounts</span><span class="hljs-punctuation">]</span><span class="hljs-punctuation">,</span>
+      <span class="hljs-attr">"countsByHour"</span><span class="hljs-punctuation">:</span> <span class="hljs-punctuation">[</span><span class="hljs-string">EventCounts</span><span class="hljs-punctuation">]</span>
+    <span class="hljs-punctuation">}</span>
+  <span class="hljs-punctuation">}</span>
+<span class="hljs-punctuation">}</span>
+</code></pre>
+                  </body>
+                </html>
+              </div>
+            </div>
+            <a href="#top">back to top</a>
           </div>
         </section>
         <section id="query-facetsConfiguration" class="operation operation-query" data-traverse-target="query-facetsConfiguration">
@@ -1466,6 +1629,76 @@ Authorization: Bearer &lt;YOUR_TOKEN_HERE&gt;</code></pre>
                 </html>
               </div>
             </div>
+            <a href="#top">back to top</a>
+          </div>
+        </section>
+        <section id="query-liveSearch" class="operation operation-query" data-traverse-target="query-liveSearch">
+          <div class="operation-group-name">
+            <a href="#group-Operations-Queries">Queries</a>
+          </div>
+          <h2 class="operation-heading ">
+            <code>liveSearch</code>
+          </h2>
+          <div class="doc-row">
+            <div class="doc-copy">
+              <div class="operation-description doc-copy-section">
+                <h5>Description</h5>
+                <p>Provides data sync information for products indexed for Live Search</p>
+              </div>
+            </div>
+          </div>
+          <div class="doc-row">
+            <div class="doc-copy">
+              <div class="operation-response doc-copy-section">
+                <h5>Response</h5>
+                <p> Returns a <a href="#definition-LiveSearch"><code>LiveSearch!</code></a>
+                </p>
+              </div>
+            </div>
+            <div class="doc-examples">
+              <h4 class="example-heading">Example</h4>
+              <div class="example-section example-section-is-code operation-query-example">
+                <h5>Query</h5>
+                <html>
+                  <head></head>
+                  <body><pre><code class="hljs language-gql"><span class="hljs-symbol"><span class="hljs-keyword">query</span> liveSearch <span class="hljs-tag">{
+  <span class="hljs-symbol">liveSearch <span class="hljs-tag">{
+    <span class="hljs-symbol">count</span>
+    <span class="hljs-symbol">productDetail <span class="hljs-tag">{
+      <span class="hljs-type">...ProductDetailFragment</span>
+    }</span></span>
+    <span class="hljs-symbol">productList <span class="hljs-tag">{
+      <span class="hljs-type">...ProductListFragment</span>
+    }</span></span>
+    <span class="hljs-symbol">since <span class="hljs-tag">{
+      <span class="hljs-type">...SinceFragment</span>
+    }</span></span>
+  }</span></span>
+}</span></span>
+</code></pre>
+                  </body>
+                </html>
+              </div>
+              <div class="example-section example-section-is-code operation-response-example">
+                <h5>Response</h5>
+                <html>
+                  <head></head>
+                  <body><pre><code class="hljs language-json"><span class="hljs-punctuation">{</span>
+  <span class="hljs-attr">"data"</span><span class="hljs-punctuation">:</span> <span class="hljs-punctuation">{</span>
+    <span class="hljs-attr">"liveSearch"</span><span class="hljs-punctuation">:</span> <span class="hljs-punctuation">{</span>
+      <span class="hljs-attr">"count"</span><span class="hljs-punctuation">:</span> <span class="hljs-number">123</span><span class="hljs-punctuation">,</span>
+      <span class="hljs-attr">"productDetail"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">ProductDetail</span><span class="hljs-punctuation">,</span>
+      <span class="hljs-attr">"productList"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">ProductList</span><span class="hljs-punctuation">,</span>
+      <span class="hljs-attr">"since"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">Since</span>
+    <span class="hljs-punctuation">}</span>
+  <span class="hljs-punctuation">}</span>
+<span class="hljs-punctuation">}</span>
+</code></pre>
+                  </body>
+                </html>
+              </div>
+            </div>
+            <a href="#top">back to top</a>
           </div>
         </section>
         <section id="query-pageUnits" class="operation operation-query" data-traverse-target="query-pageUnits">
@@ -1560,15 +1793,15 @@ Authorization: Bearer &lt;YOUR_TOKEN_HERE&gt;</code></pre>
     <span class="hljs-attr">"pageUnits"</span><span class="hljs-punctuation">:</span> <span class="hljs-punctuation">[</span>
       <span class="hljs-punctuation">{</span>
         <span class="hljs-attr">"createdAt"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"abc123"</span><span class="hljs-punctuation">,</span>
-        <span class="hljs-attr">"displayNumber"</span><span class="hljs-punctuation">:</span> <span class="hljs-number">123</span><span class="hljs-punctuation">,</span>
+        <span class="hljs-attr">"displayNumber"</span><span class="hljs-punctuation">:</span> <span class="hljs-number">987</span><span class="hljs-punctuation">,</span>
         <span class="hljs-attr">"displayOrder"</span><span class="hljs-punctuation">:</span> <span class="hljs-number">123</span><span class="hljs-punctuation">,</span>
         <span class="hljs-attr">"filterRules"</span><span class="hljs-punctuation">:</span> <span class="hljs-punctuation">[</span><span class="hljs-string">FilterRuleResponse</span><span class="hljs-punctuation">]</span><span class="hljs-punctuation">,</span>
-        <span class="hljs-attr">"id"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"xyz789"</span><span class="hljs-punctuation">,</span>
+        <span class="hljs-attr">"id"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"abc123"</span><span class="hljs-punctuation">,</span>
         <span class="hljs-attr">"metrics"</span><span class="hljs-punctuation">:</span> <span class="hljs-punctuation">[</span><span class="hljs-string">Metrics</span><span class="hljs-punctuation">]</span><span class="hljs-punctuation">,</span>
-        <span class="hljs-attr">"pagePlacement"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"abc123"</span><span class="hljs-punctuation">,</span>
+        <span class="hljs-attr">"pagePlacement"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"xyz789"</span><span class="hljs-punctuation">,</span>
         <span class="hljs-attr">"pageType"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"CART"</span><span class="hljs-punctuation">,</span>
-        <span class="hljs-attr">"storefrontLabel"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"abc123"</span><span class="hljs-punctuation">,</span>
-        <span class="hljs-attr">"unitName"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"xyz789"</span><span class="hljs-punctuation">,</span>
+        <span class="hljs-attr">"storefrontLabel"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"xyz789"</span><span class="hljs-punctuation">,</span>
+        <span class="hljs-attr">"unitName"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"abc123"</span><span class="hljs-punctuation">,</span>
         <span class="hljs-attr">"unitStatus"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"ACTIVE"</span><span class="hljs-punctuation">,</span>
         <span class="hljs-attr">"unitType"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"ADD_TO_CART_CONVERSION_RATE"</span><span class="hljs-punctuation">,</span>
         <span class="hljs-attr">"updatedAt"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"abc123"</span>
@@ -1581,6 +1814,7 @@ Authorization: Bearer &lt;YOUR_TOKEN_HERE&gt;</code></pre>
                 </html>
               </div>
             </div>
+            <a href="#top">back to top</a>
           </div>
         </section>
         <section id="query-policies" class="operation operation-query" data-traverse-target="query-policies">
@@ -1713,10 +1947,10 @@ Authorization: Bearer &lt;YOUR_TOKEN_HERE&gt;</code></pre>
     <span class="hljs-attr">"policies"</span><span class="hljs-punctuation">:</span> <span class="hljs-punctuation">[</span>
       <span class="hljs-punctuation">{</span>
         <span class="hljs-attr">"actions"</span><span class="hljs-punctuation">:</span> <span class="hljs-punctuation">[</span><span class="hljs-string">ActionResponse</span><span class="hljs-punctuation">]</span><span class="hljs-punctuation">,</span>
-        <span class="hljs-attr">"createdAt"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"abc123"</span><span class="hljs-punctuation">,</span>
+        <span class="hljs-attr">"createdAt"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"xyz789"</span><span class="hljs-punctuation">,</span>
         <span class="hljs-attr">"mandatory"</span><span class="hljs-punctuation">:</span> <span class="hljs-literal"><span class="hljs-keyword">true</span></span><span class="hljs-punctuation">,</span>
         <span class="hljs-attr">"name"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"abc123"</span><span class="hljs-punctuation">,</span>
-        <span class="hljs-attr">"policyId"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"abc123"</span><span class="hljs-punctuation">,</span>
+        <span class="hljs-attr">"policyId"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"xyz789"</span><span class="hljs-punctuation">,</span>
         <span class="hljs-attr">"updatedAt"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"xyz789"</span>
       <span class="hljs-punctuation">}</span>
     <span class="hljs-punctuation">]</span>
@@ -1727,6 +1961,7 @@ Authorization: Bearer &lt;YOUR_TOKEN_HERE&gt;</code></pre>
                 </html>
               </div>
             </div>
+            <a href="#top">back to top</a>
           </div>
         </section>
         <section id="query-policy" class="operation operation-query" data-traverse-target="query-policy">
@@ -1906,7 +2141,7 @@ Authorization: Bearer &lt;YOUR_TOKEN_HERE&gt;</code></pre>
                 <h5>Variables</h5>
                 <html>
                   <head></head>
-                  <body><pre><code class="hljs language-json"><span class="hljs-punctuation">{</span><span class="hljs-attr">"policyId"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"abc123"</span><span class="hljs-punctuation">}</span>
+                  <body><pre><code class="hljs language-json"><span class="hljs-punctuation">{</span><span class="hljs-attr">"policyId"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"xyz789"</span><span class="hljs-punctuation">}</span>
 </code></pre>
                   </body>
                 </html>
@@ -1919,10 +2154,10 @@ Authorization: Bearer &lt;YOUR_TOKEN_HERE&gt;</code></pre>
   <span class="hljs-attr">"data"</span><span class="hljs-punctuation">:</span> <span class="hljs-punctuation">{</span>
     <span class="hljs-attr">"policy"</span><span class="hljs-punctuation">:</span> <span class="hljs-punctuation">{</span>
       <span class="hljs-attr">"actions"</span><span class="hljs-punctuation">:</span> <span class="hljs-punctuation">[</span><span class="hljs-string">ActionResponse</span><span class="hljs-punctuation">]</span><span class="hljs-punctuation">,</span>
-      <span class="hljs-attr">"createdAt"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"abc123"</span><span class="hljs-punctuation">,</span>
-      <span class="hljs-attr">"mandatory"</span><span class="hljs-punctuation">:</span> <span class="hljs-literal"><span class="hljs-keyword">true</span></span><span class="hljs-punctuation">,</span>
-      <span class="hljs-attr">"name"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"xyz789"</span><span class="hljs-punctuation">,</span>
-      <span class="hljs-attr">"policyId"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"abc123"</span><span class="hljs-punctuation">,</span>
+      <span class="hljs-attr">"createdAt"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"xyz789"</span><span class="hljs-punctuation">,</span>
+      <span class="hljs-attr">"mandatory"</span><span class="hljs-punctuation">:</span> <span class="hljs-literal"><span class="hljs-keyword">false</span></span><span class="hljs-punctuation">,</span>
+      <span class="hljs-attr">"name"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"abc123"</span><span class="hljs-punctuation">,</span>
+      <span class="hljs-attr">"policyId"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"xyz789"</span><span class="hljs-punctuation">,</span>
       <span class="hljs-attr">"updatedAt"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"abc123"</span>
     <span class="hljs-punctuation">}</span>
   <span class="hljs-punctuation">}</span>
@@ -1932,6 +2167,7 @@ Authorization: Bearer &lt;YOUR_TOKEN_HERE&gt;</code></pre>
                 </html>
               </div>
             </div>
+            <a href="#top">back to top</a>
           </div>
         </section>
         <section id="query-productAttributeMetadata" class="operation operation-query" data-traverse-target="query-productAttributeMetadata">
@@ -2031,6 +2267,7 @@ Authorization: Bearer &lt;YOUR_TOKEN_HERE&gt;</code></pre>
                 </html>
               </div>
             </div>
+            <a href="#top">back to top</a>
           </div>
         </section>
         <section id="query-queryRules" class="operation operation-query" data-traverse-target="query-queryRules">
@@ -2085,6 +2322,127 @@ Authorization: Bearer &lt;YOUR_TOKEN_HERE&gt;</code></pre>
                 </html>
               </div>
             </div>
+            <a href="#top">back to top</a>
+          </div>
+        </section>
+        <section id="query-recommendations" class="operation operation-query" data-traverse-target="query-recommendations">
+          <div class="operation-group-name">
+            <a href="#group-Operations-Queries">Queries</a>
+          </div>
+          <h2 class="operation-heading ">
+            <code>recommendations</code>
+          </h2>
+          <div class="doc-row">
+            <div class="doc-copy">
+              <div class="operation-description doc-copy-section">
+                <h5>Description</h5>
+                <p>Provides data sync information for products indexed for Product Recommendations</p>
+              </div>
+            </div>
+          </div>
+          <div class="doc-row">
+            <div class="doc-copy">
+              <div class="operation-response doc-copy-section">
+                <h5>Response</h5>
+                <p> Returns a <a href="#definition-Recommendations"><code>Recommendations!</code></a>
+                </p>
+              </div>
+            </div>
+            <div class="doc-examples">
+              <h4 class="example-heading">Example</h4>
+              <div class="example-section example-section-is-code operation-query-example">
+                <h5>Query</h5>
+                <html>
+                  <head></head>
+                  <body><pre><code class="hljs language-gql"><span class="hljs-symbol"><span class="hljs-keyword">query</span> recommendations <span class="hljs-tag">{
+  <span class="hljs-symbol">recommendations <span class="hljs-tag">{
+    <span class="hljs-symbol">count</span>
+    <span class="hljs-symbol">productDetail <span class="hljs-tag">{
+      <span class="hljs-type">...ProductDetailFragment</span>
+    }</span></span>
+    <span class="hljs-symbol">productList <span class="hljs-tag">{
+      <span class="hljs-type">...ProductListFragment</span>
+    }</span></span>
+    <span class="hljs-symbol">since <span class="hljs-tag">{
+      <span class="hljs-type">...SinceFragment</span>
+    }</span></span>
+  }</span></span>
+}</span></span>
+</code></pre>
+                  </body>
+                </html>
+              </div>
+              <div class="example-section example-section-is-code operation-response-example">
+                <h5>Response</h5>
+                <html>
+                  <head></head>
+                  <body><pre><code class="hljs language-json"><span class="hljs-punctuation">{</span>
+  <span class="hljs-attr">"data"</span><span class="hljs-punctuation">:</span> <span class="hljs-punctuation">{</span>
+    <span class="hljs-attr">"recommendations"</span><span class="hljs-punctuation">:</span> <span class="hljs-punctuation">{</span>
+      <span class="hljs-attr">"count"</span><span class="hljs-punctuation">:</span> <span class="hljs-number">987</span><span class="hljs-punctuation">,</span>
+      <span class="hljs-attr">"productDetail"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">ProductDetail</span><span class="hljs-punctuation">,</span>
+      <span class="hljs-attr">"productList"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">ProductList</span><span class="hljs-punctuation">,</span>
+      <span class="hljs-attr">"since"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">Since</span>
+    <span class="hljs-punctuation">}</span>
+  <span class="hljs-punctuation">}</span>
+<span class="hljs-punctuation">}</span>
+</code></pre>
+                  </body>
+                </html>
+              </div>
+            </div>
+            <a href="#top">back to top</a>
+          </div>
+        </section>
+        <section id="query-scopes" class="operation operation-query" data-traverse-target="query-scopes">
+          <div class="operation-group-name">
+            <a href="#group-Operations-Queries">Queries</a>
+          </div>
+          <h2 class="operation-heading ">
+            <code>scopes</code>
+          </h2>
+          <div class="doc-row">
+            <div class="doc-copy">
+              <div class="operation-description doc-copy-section">
+                <h5>Description</h5>
+                <p>Retrieves composable catalog scope information such as locales</p>
+              </div>
+            </div>
+          </div>
+          <div class="doc-row">
+            <div class="doc-copy">
+              <div class="operation-response doc-copy-section">
+                <h5>Response</h5>
+                <p> Returns <a href="#definition-Scope"><code>[Scope]!</code></a>
+                </p>
+              </div>
+            </div>
+            <div class="doc-examples">
+              <h4 class="example-heading">Example</h4>
+              <div class="example-section example-section-is-code operation-query-example">
+                <h5>Query</h5>
+                <html>
+                  <head></head>
+                  <body><pre><code class="hljs language-gql"><span class="hljs-symbol"><span class="hljs-keyword">query</span> scopes <span class="hljs-tag">{
+  <span class="hljs-symbol">scopes <span class="hljs-tag">{
+    <span class="hljs-symbol">locale</span>
+  }</span></span>
+}</span></span>
+</code></pre>
+                  </body>
+                </html>
+              </div>
+              <div class="example-section example-section-is-code operation-response-example">
+                <h5>Response</h5>
+                <html>
+                  <head></head>
+                  <body><pre><code class="hljs language-json"><span class="hljs-punctuation">{</span><span class="hljs-attr">"data"</span><span class="hljs-punctuation">:</span> <span class="hljs-punctuation">{</span><span class="hljs-attr">"scopes"</span><span class="hljs-punctuation">:</span> <span class="hljs-punctuation">[</span><span class="hljs-punctuation">{</span><span class="hljs-attr">"locale"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"xyz789"</span><span class="hljs-punctuation">}</span><span class="hljs-punctuation">]</span><span class="hljs-punctuation">}</span><span class="hljs-punctuation">}</span>
+</code></pre>
+                  </body>
+                </html>
+              </div>
+            </div>
+            <a href="#top">back to top</a>
           </div>
         </section>
         <section id="query-storeConfiguration" class="operation operation-query" data-traverse-target="query-storeConfiguration">
@@ -2143,6 +2501,7 @@ Authorization: Bearer &lt;YOUR_TOKEN_HERE&gt;</code></pre>
                 </html>
               </div>
             </div>
+            <a href="#top">back to top</a>
           </div>
         </section>
         <section id="query-subcategoryOverrides" class="operation operation-query" data-traverse-target="query-subcategoryOverrides">
@@ -2230,7 +2589,7 @@ Authorization: Bearer &lt;YOUR_TOKEN_HERE&gt;</code></pre>
                 <html>
                   <head></head>
                   <body><pre><code class="hljs language-json"><span class="hljs-punctuation">{</span>
-  <span class="hljs-attr">"pageNumber"</span><span class="hljs-punctuation">:</span> <span class="hljs-number">123</span><span class="hljs-punctuation">,</span>
+  <span class="hljs-attr">"pageNumber"</span><span class="hljs-punctuation">:</span> <span class="hljs-number">987</span><span class="hljs-punctuation">,</span>
   <span class="hljs-attr">"pageSize"</span><span class="hljs-punctuation">:</span> <span class="hljs-number">123</span><span class="hljs-punctuation">,</span>
   <span class="hljs-attr">"path"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"xyz789"</span>
 <span class="hljs-punctuation">}</span>
@@ -2246,7 +2605,7 @@ Authorization: Bearer &lt;YOUR_TOKEN_HERE&gt;</code></pre>
   <span class="hljs-attr">"data"</span><span class="hljs-punctuation">:</span> <span class="hljs-punctuation">{</span>
     <span class="hljs-attr">"subcategoryOverrides"</span><span class="hljs-punctuation">:</span> <span class="hljs-punctuation">{</span>
       <span class="hljs-attr">"categoryRules"</span><span class="hljs-punctuation">:</span> <span class="hljs-punctuation">[</span><span class="hljs-string">CategoryRule</span><span class="hljs-punctuation">]</span><span class="hljs-punctuation">,</span>
-      <span class="hljs-attr">"totalCount"</span><span class="hljs-punctuation">:</span> <span class="hljs-number">123</span>
+      <span class="hljs-attr">"totalCount"</span><span class="hljs-punctuation">:</span> <span class="hljs-number">987</span>
     <span class="hljs-punctuation">}</span>
   <span class="hljs-punctuation">}</span>
 <span class="hljs-punctuation">}</span>
@@ -2255,6 +2614,7 @@ Authorization: Bearer &lt;YOUR_TOKEN_HERE&gt;</code></pre>
                 </html>
               </div>
             </div>
+            <a href="#top">back to top</a>
           </div>
         </section>
         <section id="query-synonyms" class="operation operation-query" data-traverse-target="query-synonyms">
@@ -2313,6 +2673,7 @@ Authorization: Bearer &lt;YOUR_TOKEN_HERE&gt;</code></pre>
                 </html>
               </div>
             </div>
+            <a href="#top">back to top</a>
           </div>
         </section>
         <section id="query-unit" class="operation operation-query" data-traverse-target="query-unit">
@@ -2393,7 +2754,7 @@ Authorization: Bearer &lt;YOUR_TOKEN_HERE&gt;</code></pre>
                 <h5>Variables</h5>
                 <html>
                   <head></head>
-                  <body><pre><code class="hljs language-json"><span class="hljs-punctuation">{</span><span class="hljs-attr">"id"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"xyz789"</span><span class="hljs-punctuation">}</span>
+                  <body><pre><code class="hljs language-json"><span class="hljs-punctuation">{</span><span class="hljs-attr">"id"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"abc123"</span><span class="hljs-punctuation">}</span>
 </code></pre>
                   </body>
                 </html>
@@ -2406,15 +2767,15 @@ Authorization: Bearer &lt;YOUR_TOKEN_HERE&gt;</code></pre>
   <span class="hljs-attr">"data"</span><span class="hljs-punctuation">:</span> <span class="hljs-punctuation">{</span>
     <span class="hljs-attr">"unit"</span><span class="hljs-punctuation">:</span> <span class="hljs-punctuation">{</span>
       <span class="hljs-attr">"createdAt"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"abc123"</span><span class="hljs-punctuation">,</span>
-      <span class="hljs-attr">"displayNumber"</span><span class="hljs-punctuation">:</span> <span class="hljs-number">987</span><span class="hljs-punctuation">,</span>
-      <span class="hljs-attr">"displayOrder"</span><span class="hljs-punctuation">:</span> <span class="hljs-number">987</span><span class="hljs-punctuation">,</span>
+      <span class="hljs-attr">"displayNumber"</span><span class="hljs-punctuation">:</span> <span class="hljs-number">123</span><span class="hljs-punctuation">,</span>
+      <span class="hljs-attr">"displayOrder"</span><span class="hljs-punctuation">:</span> <span class="hljs-number">123</span><span class="hljs-punctuation">,</span>
       <span class="hljs-attr">"filterRules"</span><span class="hljs-punctuation">:</span> <span class="hljs-punctuation">[</span><span class="hljs-string">FilterRuleResponse</span><span class="hljs-punctuation">]</span><span class="hljs-punctuation">,</span>
-      <span class="hljs-attr">"id"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"xyz789"</span><span class="hljs-punctuation">,</span>
+      <span class="hljs-attr">"id"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"abc123"</span><span class="hljs-punctuation">,</span>
       <span class="hljs-attr">"metrics"</span><span class="hljs-punctuation">:</span> <span class="hljs-punctuation">[</span><span class="hljs-string">Metrics</span><span class="hljs-punctuation">]</span><span class="hljs-punctuation">,</span>
-      <span class="hljs-attr">"pagePlacement"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"xyz789"</span><span class="hljs-punctuation">,</span>
+      <span class="hljs-attr">"pagePlacement"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"abc123"</span><span class="hljs-punctuation">,</span>
       <span class="hljs-attr">"pageType"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"CART"</span><span class="hljs-punctuation">,</span>
       <span class="hljs-attr">"storefrontLabel"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"xyz789"</span><span class="hljs-punctuation">,</span>
-      <span class="hljs-attr">"unitName"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"xyz789"</span><span class="hljs-punctuation">,</span>
+      <span class="hljs-attr">"unitName"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"abc123"</span><span class="hljs-punctuation">,</span>
       <span class="hljs-attr">"unitStatus"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"ACTIVE"</span><span class="hljs-punctuation">,</span>
       <span class="hljs-attr">"unitType"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"ADD_TO_CART_CONVERSION_RATE"</span><span class="hljs-punctuation">,</span>
       <span class="hljs-attr">"updatedAt"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"abc123"</span>
@@ -2426,6 +2787,7 @@ Authorization: Bearer &lt;YOUR_TOKEN_HERE&gt;</code></pre>
                 </html>
               </div>
             </div>
+            <a href="#top">back to top</a>
           </div>
         </section>
         <section id="query-units" class="operation operation-query" data-traverse-target="query-units">
@@ -2490,19 +2852,19 @@ Authorization: Bearer &lt;YOUR_TOKEN_HERE&gt;</code></pre>
   <span class="hljs-attr">"data"</span><span class="hljs-punctuation">:</span> <span class="hljs-punctuation">{</span>
     <span class="hljs-attr">"units"</span><span class="hljs-punctuation">:</span> <span class="hljs-punctuation">[</span>
       <span class="hljs-punctuation">{</span>
-        <span class="hljs-attr">"createdAt"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"abc123"</span><span class="hljs-punctuation">,</span>
-        <span class="hljs-attr">"displayNumber"</span><span class="hljs-punctuation">:</span> <span class="hljs-number">123</span><span class="hljs-punctuation">,</span>
-        <span class="hljs-attr">"displayOrder"</span><span class="hljs-punctuation">:</span> <span class="hljs-number">123</span><span class="hljs-punctuation">,</span>
+        <span class="hljs-attr">"createdAt"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"xyz789"</span><span class="hljs-punctuation">,</span>
+        <span class="hljs-attr">"displayNumber"</span><span class="hljs-punctuation">:</span> <span class="hljs-number">987</span><span class="hljs-punctuation">,</span>
+        <span class="hljs-attr">"displayOrder"</span><span class="hljs-punctuation">:</span> <span class="hljs-number">987</span><span class="hljs-punctuation">,</span>
         <span class="hljs-attr">"filterRules"</span><span class="hljs-punctuation">:</span> <span class="hljs-punctuation">[</span><span class="hljs-string">FilterRuleResponse</span><span class="hljs-punctuation">]</span><span class="hljs-punctuation">,</span>
         <span class="hljs-attr">"id"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"xyz789"</span><span class="hljs-punctuation">,</span>
         <span class="hljs-attr">"metrics"</span><span class="hljs-punctuation">:</span> <span class="hljs-punctuation">[</span><span class="hljs-string">Metrics</span><span class="hljs-punctuation">]</span><span class="hljs-punctuation">,</span>
         <span class="hljs-attr">"pagePlacement"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"abc123"</span><span class="hljs-punctuation">,</span>
         <span class="hljs-attr">"pageType"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"CART"</span><span class="hljs-punctuation">,</span>
-        <span class="hljs-attr">"storefrontLabel"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"xyz789"</span><span class="hljs-punctuation">,</span>
+        <span class="hljs-attr">"storefrontLabel"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"abc123"</span><span class="hljs-punctuation">,</span>
         <span class="hljs-attr">"unitName"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"xyz789"</span><span class="hljs-punctuation">,</span>
         <span class="hljs-attr">"unitStatus"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"ACTIVE"</span><span class="hljs-punctuation">,</span>
         <span class="hljs-attr">"unitType"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"ADD_TO_CART_CONVERSION_RATE"</span><span class="hljs-punctuation">,</span>
-        <span class="hljs-attr">"updatedAt"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"abc123"</span>
+        <span class="hljs-attr">"updatedAt"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"xyz789"</span>
       <span class="hljs-punctuation">}</span>
     <span class="hljs-punctuation">]</span>
   <span class="hljs-punctuation">}</span>
@@ -2512,6 +2874,7 @@ Authorization: Bearer &lt;YOUR_TOKEN_HERE&gt;</code></pre>
                 </html>
               </div>
             </div>
+            <a href="#top">back to top</a>
           </div>
         </section>
         <h1 id="group-Operations-Mutations" class="group-heading" data-traverse-target="group-Operations-Mutations">Mutations</h1>
@@ -2691,6 +3054,7 @@ Authorization: Bearer &lt;YOUR_TOKEN_HERE&gt;</code></pre>
                 </html>
               </div>
             </div>
+            <a href="#top">back to top</a>
           </div>
         </section>
         <section id="mutation-batchPolicy" class="operation operation-mutation" data-traverse-target="mutation-batchPolicy">
@@ -2869,7 +3233,7 @@ Authorization: Bearer &lt;YOUR_TOKEN_HERE&gt;</code></pre>
                   <body><pre><code class="hljs language-json"><span class="hljs-punctuation">{</span>
   <span class="hljs-attr">"data"</span><span class="hljs-punctuation">:</span> <span class="hljs-punctuation">{</span>
     <span class="hljs-attr">"batchPolicy"</span><span class="hljs-punctuation">:</span> <span class="hljs-punctuation">{</span>
-      <span class="hljs-attr">"errors"</span><span class="hljs-punctuation">:</span> <span class="hljs-punctuation">[</span><span class="hljs-string">"abc123"</span><span class="hljs-punctuation">]</span><span class="hljs-punctuation">,</span>
+      <span class="hljs-attr">"errors"</span><span class="hljs-punctuation">:</span> <span class="hljs-punctuation">[</span><span class="hljs-string">"xyz789"</span><span class="hljs-punctuation">]</span><span class="hljs-punctuation">,</span>
       <span class="hljs-attr">"policies"</span><span class="hljs-punctuation">:</span> <span class="hljs-punctuation">[</span><span class="hljs-string">PolicyResponse</span><span class="hljs-punctuation">]</span>
     <span class="hljs-punctuation">}</span>
   <span class="hljs-punctuation">}</span>
@@ -2879,6 +3243,7 @@ Authorization: Bearer &lt;YOUR_TOKEN_HERE&gt;</code></pre>
                 </html>
               </div>
             </div>
+            <a href="#top">back to top</a>
           </div>
         </section>
         <section id="mutation-batchUnits" class="operation operation-mutation" data-traverse-target="mutation-batchUnits">
@@ -2968,6 +3333,7 @@ Authorization: Bearer &lt;YOUR_TOKEN_HERE&gt;</code></pre>
                 </html>
               </div>
             </div>
+            <a href="#top">back to top</a>
           </div>
         </section>
         <section id="mutation-categoryRule" class="operation operation-mutation" data-traverse-target="mutation-categoryRule">
@@ -3052,6 +3418,7 @@ Authorization: Bearer &lt;YOUR_TOKEN_HERE&gt;</code></pre>
                 </html>
               </div>
             </div>
+            <a href="#top">back to top</a>
           </div>
         </section>
         <section id="mutation-createChannel" class="operation operation-mutation" data-traverse-target="mutation-createChannel">
@@ -3326,13 +3693,13 @@ Authorization: Bearer &lt;YOUR_TOKEN_HERE&gt;</code></pre>
                   <body><pre><code class="hljs language-json"><span class="hljs-punctuation">{</span>
   <span class="hljs-attr">"data"</span><span class="hljs-punctuation">:</span> <span class="hljs-punctuation">{</span>
     <span class="hljs-attr">"createChannel"</span><span class="hljs-punctuation">:</span> <span class="hljs-punctuation">{</span>
-      <span class="hljs-attr">"channelId"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"abc123"</span><span class="hljs-punctuation">,</span>
-      <span class="hljs-attr">"createdAt"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"xyz789"</span><span class="hljs-punctuation">,</span>
+      <span class="hljs-attr">"channelId"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"xyz789"</span><span class="hljs-punctuation">,</span>
+      <span class="hljs-attr">"createdAt"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"abc123"</span><span class="hljs-punctuation">,</span>
       <span class="hljs-attr">"name"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"abc123"</span><span class="hljs-punctuation">,</span>
       <span class="hljs-attr">"policies"</span><span class="hljs-punctuation">:</span> <span class="hljs-punctuation">[</span><span class="hljs-string">PolicyResponse</span><span class="hljs-punctuation">]</span><span class="hljs-punctuation">,</span>
       <span class="hljs-attr">"policyIds"</span><span class="hljs-punctuation">:</span> <span class="hljs-punctuation">[</span><span class="hljs-string">"xyz789"</span><span class="hljs-punctuation">]</span><span class="hljs-punctuation">,</span>
       <span class="hljs-attr">"scopes"</span><span class="hljs-punctuation">:</span> <span class="hljs-punctuation">[</span><span class="hljs-string">ChannelScopeResponse</span><span class="hljs-punctuation">]</span><span class="hljs-punctuation">,</span>
-      <span class="hljs-attr">"updatedAt"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"xyz789"</span>
+      <span class="hljs-attr">"updatedAt"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"abc123"</span>
     <span class="hljs-punctuation">}</span>
   <span class="hljs-punctuation">}</span>
 <span class="hljs-punctuation">}</span>
@@ -3341,6 +3708,7 @@ Authorization: Bearer &lt;YOUR_TOKEN_HERE&gt;</code></pre>
                 </html>
               </div>
             </div>
+            <a href="#top">back to top</a>
           </div>
         </section>
         <section id="mutation-createPolicy" class="operation operation-mutation" data-traverse-target="mutation-createPolicy">
@@ -3536,10 +3904,10 @@ Authorization: Bearer &lt;YOUR_TOKEN_HERE&gt;</code></pre>
   <span class="hljs-attr">"data"</span><span class="hljs-punctuation">:</span> <span class="hljs-punctuation">{</span>
     <span class="hljs-attr">"createPolicy"</span><span class="hljs-punctuation">:</span> <span class="hljs-punctuation">{</span>
       <span class="hljs-attr">"actions"</span><span class="hljs-punctuation">:</span> <span class="hljs-punctuation">[</span><span class="hljs-string">ActionResponse</span><span class="hljs-punctuation">]</span><span class="hljs-punctuation">,</span>
-      <span class="hljs-attr">"createdAt"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"xyz789"</span><span class="hljs-punctuation">,</span>
-      <span class="hljs-attr">"mandatory"</span><span class="hljs-punctuation">:</span> <span class="hljs-literal"><span class="hljs-keyword">false</span></span><span class="hljs-punctuation">,</span>
+      <span class="hljs-attr">"createdAt"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"abc123"</span><span class="hljs-punctuation">,</span>
+      <span class="hljs-attr">"mandatory"</span><span class="hljs-punctuation">:</span> <span class="hljs-literal"><span class="hljs-keyword">true</span></span><span class="hljs-punctuation">,</span>
       <span class="hljs-attr">"name"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"abc123"</span><span class="hljs-punctuation">,</span>
-      <span class="hljs-attr">"policyId"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"abc123"</span><span class="hljs-punctuation">,</span>
+      <span class="hljs-attr">"policyId"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"xyz789"</span><span class="hljs-punctuation">,</span>
       <span class="hljs-attr">"updatedAt"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"xyz789"</span>
     <span class="hljs-punctuation">}</span>
   <span class="hljs-punctuation">}</span>
@@ -3549,6 +3917,7 @@ Authorization: Bearer &lt;YOUR_TOKEN_HERE&gt;</code></pre>
                 </html>
               </div>
             </div>
+            <a href="#top">back to top</a>
           </div>
         </section>
         <section id="mutation-createUnit" class="operation operation-mutation" data-traverse-target="mutation-createUnit">
@@ -3642,15 +4011,15 @@ Authorization: Bearer &lt;YOUR_TOKEN_HERE&gt;</code></pre>
   <span class="hljs-attr">"data"</span><span class="hljs-punctuation">:</span> <span class="hljs-punctuation">{</span>
     <span class="hljs-attr">"createUnit"</span><span class="hljs-punctuation">:</span> <span class="hljs-punctuation">{</span>
       <span class="hljs-attr">"createdAt"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"xyz789"</span><span class="hljs-punctuation">,</span>
-      <span class="hljs-attr">"displayNumber"</span><span class="hljs-punctuation">:</span> <span class="hljs-number">123</span><span class="hljs-punctuation">,</span>
+      <span class="hljs-attr">"displayNumber"</span><span class="hljs-punctuation">:</span> <span class="hljs-number">987</span><span class="hljs-punctuation">,</span>
       <span class="hljs-attr">"displayOrder"</span><span class="hljs-punctuation">:</span> <span class="hljs-number">987</span><span class="hljs-punctuation">,</span>
       <span class="hljs-attr">"filterRules"</span><span class="hljs-punctuation">:</span> <span class="hljs-punctuation">[</span><span class="hljs-string">FilterRuleResponse</span><span class="hljs-punctuation">]</span><span class="hljs-punctuation">,</span>
-      <span class="hljs-attr">"id"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"abc123"</span><span class="hljs-punctuation">,</span>
+      <span class="hljs-attr">"id"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"xyz789"</span><span class="hljs-punctuation">,</span>
       <span class="hljs-attr">"metrics"</span><span class="hljs-punctuation">:</span> <span class="hljs-punctuation">[</span><span class="hljs-string">Metrics</span><span class="hljs-punctuation">]</span><span class="hljs-punctuation">,</span>
       <span class="hljs-attr">"pagePlacement"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"xyz789"</span><span class="hljs-punctuation">,</span>
       <span class="hljs-attr">"pageType"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"CART"</span><span class="hljs-punctuation">,</span>
-      <span class="hljs-attr">"storefrontLabel"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"xyz789"</span><span class="hljs-punctuation">,</span>
-      <span class="hljs-attr">"unitName"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"xyz789"</span><span class="hljs-punctuation">,</span>
+      <span class="hljs-attr">"storefrontLabel"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"abc123"</span><span class="hljs-punctuation">,</span>
+      <span class="hljs-attr">"unitName"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"abc123"</span><span class="hljs-punctuation">,</span>
       <span class="hljs-attr">"unitStatus"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"ACTIVE"</span><span class="hljs-punctuation">,</span>
       <span class="hljs-attr">"unitType"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"ADD_TO_CART_CONVERSION_RATE"</span><span class="hljs-punctuation">,</span>
       <span class="hljs-attr">"updatedAt"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"abc123"</span>
@@ -3662,6 +4031,7 @@ Authorization: Bearer &lt;YOUR_TOKEN_HERE&gt;</code></pre>
                 </html>
               </div>
             </div>
+            <a href="#top">back to top</a>
           </div>
         </section>
         <section id="mutation-deleteCategoryRule" class="operation operation-mutation" data-traverse-target="mutation-deleteCategoryRule">
@@ -3746,6 +4116,7 @@ Authorization: Bearer &lt;YOUR_TOKEN_HERE&gt;</code></pre>
                 </html>
               </div>
             </div>
+            <a href="#top">back to top</a>
           </div>
         </section>
         <section id="mutation-deleteChannel" class="operation operation-mutation" data-traverse-target="mutation-deleteChannel">
@@ -3874,6 +4245,7 @@ Authorization: Bearer &lt;YOUR_TOKEN_HERE&gt;</code></pre>
                 </html>
               </div>
             </div>
+            <a href="#top">back to top</a>
           </div>
         </section>
         <section id="mutation-deletePolicy" class="operation operation-mutation" data-traverse-target="mutation-deletePolicy">
@@ -3985,7 +4357,7 @@ Authorization: Bearer &lt;YOUR_TOKEN_HERE&gt;</code></pre>
                 <h5>Variables</h5>
                 <html>
                   <head></head>
-                  <body><pre><code class="hljs language-json"><span class="hljs-punctuation">{</span><span class="hljs-attr">"policyId"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"xyz789"</span><span class="hljs-punctuation">}</span>
+                  <body><pre><code class="hljs language-json"><span class="hljs-punctuation">{</span><span class="hljs-attr">"policyId"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"abc123"</span><span class="hljs-punctuation">}</span>
 </code></pre>
                   </body>
                 </html>
@@ -4000,6 +4372,7 @@ Authorization: Bearer &lt;YOUR_TOKEN_HERE&gt;</code></pre>
                 </html>
               </div>
             </div>
+            <a href="#top">back to top</a>
           </div>
         </section>
         <section id="mutation-deleteUnit" class="operation operation-mutation" data-traverse-target="mutation-deleteUnit">
@@ -4080,7 +4453,7 @@ Authorization: Bearer &lt;YOUR_TOKEN_HERE&gt;</code></pre>
                 <h5>Variables</h5>
                 <html>
                   <head></head>
-                  <body><pre><code class="hljs language-json"><span class="hljs-punctuation">{</span><span class="hljs-attr">"unitId"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"xyz789"</span><span class="hljs-punctuation">}</span>
+                  <body><pre><code class="hljs language-json"><span class="hljs-punctuation">{</span><span class="hljs-attr">"unitId"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"abc123"</span><span class="hljs-punctuation">}</span>
 </code></pre>
                   </body>
                 </html>
@@ -4096,11 +4469,11 @@ Authorization: Bearer &lt;YOUR_TOKEN_HERE&gt;</code></pre>
       <span class="hljs-attr">"displayNumber"</span><span class="hljs-punctuation">:</span> <span class="hljs-number">987</span><span class="hljs-punctuation">,</span>
       <span class="hljs-attr">"displayOrder"</span><span class="hljs-punctuation">:</span> <span class="hljs-number">123</span><span class="hljs-punctuation">,</span>
       <span class="hljs-attr">"filterRules"</span><span class="hljs-punctuation">:</span> <span class="hljs-punctuation">[</span><span class="hljs-string">FilterRuleResponse</span><span class="hljs-punctuation">]</span><span class="hljs-punctuation">,</span>
-      <span class="hljs-attr">"id"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"abc123"</span><span class="hljs-punctuation">,</span>
+      <span class="hljs-attr">"id"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"xyz789"</span><span class="hljs-punctuation">,</span>
       <span class="hljs-attr">"metrics"</span><span class="hljs-punctuation">:</span> <span class="hljs-punctuation">[</span><span class="hljs-string">Metrics</span><span class="hljs-punctuation">]</span><span class="hljs-punctuation">,</span>
-      <span class="hljs-attr">"pagePlacement"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"xyz789"</span><span class="hljs-punctuation">,</span>
+      <span class="hljs-attr">"pagePlacement"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"abc123"</span><span class="hljs-punctuation">,</span>
       <span class="hljs-attr">"pageType"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"CART"</span><span class="hljs-punctuation">,</span>
-      <span class="hljs-attr">"storefrontLabel"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"abc123"</span><span class="hljs-punctuation">,</span>
+      <span class="hljs-attr">"storefrontLabel"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"xyz789"</span><span class="hljs-punctuation">,</span>
       <span class="hljs-attr">"unitName"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"xyz789"</span><span class="hljs-punctuation">,</span>
       <span class="hljs-attr">"unitStatus"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"ACTIVE"</span><span class="hljs-punctuation">,</span>
       <span class="hljs-attr">"unitType"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"ADD_TO_CART_CONVERSION_RATE"</span><span class="hljs-punctuation">,</span>
@@ -4113,6 +4486,7 @@ Authorization: Bearer &lt;YOUR_TOKEN_HERE&gt;</code></pre>
                 </html>
               </div>
             </div>
+            <a href="#top">back to top</a>
           </div>
         </section>
         <section id="mutation-facetsConfiguration" class="operation operation-mutation" data-traverse-target="mutation-facetsConfiguration">
@@ -4190,7 +4564,7 @@ Authorization: Bearer &lt;YOUR_TOKEN_HERE&gt;</code></pre>
                   <body><pre><code class="hljs language-json"><span class="hljs-punctuation">{</span>
   <span class="hljs-attr">"data"</span><span class="hljs-punctuation">:</span> <span class="hljs-punctuation">{</span>
     <span class="hljs-attr">"facetsConfiguration"</span><span class="hljs-punctuation">:</span> <span class="hljs-punctuation">{</span>
-      <span class="hljs-attr">"message"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"xyz789"</span>
+      <span class="hljs-attr">"message"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"abc123"</span>
     <span class="hljs-punctuation">}</span>
   <span class="hljs-punctuation">}</span>
 <span class="hljs-punctuation">}</span>
@@ -4199,6 +4573,7 @@ Authorization: Bearer &lt;YOUR_TOKEN_HERE&gt;</code></pre>
                 </html>
               </div>
             </div>
+            <a href="#top">back to top</a>
           </div>
         </section>
         <section id="mutation-queryRules" class="operation operation-mutation" data-traverse-target="mutation-queryRules">
@@ -4284,6 +4659,7 @@ Authorization: Bearer &lt;YOUR_TOKEN_HERE&gt;</code></pre>
                 </html>
               </div>
             </div>
+            <a href="#top">back to top</a>
           </div>
         </section>
         <section id="mutation-storeConfiguration" class="operation operation-mutation" data-traverse-target="mutation-storeConfiguration">
@@ -4361,7 +4737,7 @@ Authorization: Bearer &lt;YOUR_TOKEN_HERE&gt;</code></pre>
                   <body><pre><code class="hljs language-json"><span class="hljs-punctuation">{</span>
   <span class="hljs-attr">"data"</span><span class="hljs-punctuation">:</span> <span class="hljs-punctuation">{</span>
     <span class="hljs-attr">"storeConfiguration"</span><span class="hljs-punctuation">:</span> <span class="hljs-punctuation">{</span>
-      <span class="hljs-attr">"message"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"xyz789"</span>
+      <span class="hljs-attr">"message"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"abc123"</span>
     <span class="hljs-punctuation">}</span>
   <span class="hljs-punctuation">}</span>
 <span class="hljs-punctuation">}</span>
@@ -4370,6 +4746,7 @@ Authorization: Bearer &lt;YOUR_TOKEN_HERE&gt;</code></pre>
                 </html>
               </div>
             </div>
+            <a href="#top">back to top</a>
           </div>
         </section>
         <section id="mutation-synonyms" class="operation operation-mutation" data-traverse-target="mutation-synonyms">
@@ -4447,7 +4824,7 @@ Authorization: Bearer &lt;YOUR_TOKEN_HERE&gt;</code></pre>
                   <head></head>
                   <body><pre><code class="hljs language-json"><span class="hljs-punctuation">{</span>
   <span class="hljs-attr">"data"</span><span class="hljs-punctuation">:</span> <span class="hljs-punctuation">{</span>
-    <span class="hljs-attr">"synonyms"</span><span class="hljs-punctuation">:</span> <span class="hljs-punctuation">{</span><span class="hljs-attr">"message"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"abc123"</span><span class="hljs-punctuation">}</span>
+    <span class="hljs-attr">"synonyms"</span><span class="hljs-punctuation">:</span> <span class="hljs-punctuation">{</span><span class="hljs-attr">"message"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"xyz789"</span><span class="hljs-punctuation">}</span>
   <span class="hljs-punctuation">}</span>
 <span class="hljs-punctuation">}</span>
 </code></pre>
@@ -4455,6 +4832,7 @@ Authorization: Bearer &lt;YOUR_TOKEN_HERE&gt;</code></pre>
                 </html>
               </div>
             </div>
+            <a href="#top">back to top</a>
           </div>
         </section>
         <section id="mutation-updateChannel" class="operation operation-mutation" data-traverse-target="mutation-updateChannel">
@@ -4590,11 +4968,11 @@ is <span class="hljs-keyword">an</span> all-<span class="hljs-keyword">or</span>
                   <body><pre><code class="hljs language-json"><span class="hljs-punctuation">{</span>
   <span class="hljs-attr">"data"</span><span class="hljs-punctuation">:</span> <span class="hljs-punctuation">{</span>
     <span class="hljs-attr">"updateChannel"</span><span class="hljs-punctuation">:</span> <span class="hljs-punctuation">{</span>
-      <span class="hljs-attr">"channelId"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"xyz789"</span><span class="hljs-punctuation">,</span>
+      <span class="hljs-attr">"channelId"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"abc123"</span><span class="hljs-punctuation">,</span>
       <span class="hljs-attr">"createdAt"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"xyz789"</span><span class="hljs-punctuation">,</span>
       <span class="hljs-attr">"name"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"xyz789"</span><span class="hljs-punctuation">,</span>
       <span class="hljs-attr">"policies"</span><span class="hljs-punctuation">:</span> <span class="hljs-punctuation">[</span><span class="hljs-string">PolicyResponse</span><span class="hljs-punctuation">]</span><span class="hljs-punctuation">,</span>
-      <span class="hljs-attr">"policyIds"</span><span class="hljs-punctuation">:</span> <span class="hljs-punctuation">[</span><span class="hljs-string">"xyz789"</span><span class="hljs-punctuation">]</span><span class="hljs-punctuation">,</span>
+      <span class="hljs-attr">"policyIds"</span><span class="hljs-punctuation">:</span> <span class="hljs-punctuation">[</span><span class="hljs-string">"abc123"</span><span class="hljs-punctuation">]</span><span class="hljs-punctuation">,</span>
       <span class="hljs-attr">"scopes"</span><span class="hljs-punctuation">:</span> <span class="hljs-punctuation">[</span><span class="hljs-string">ChannelScopeResponse</span><span class="hljs-punctuation">]</span><span class="hljs-punctuation">,</span>
       <span class="hljs-attr">"updatedAt"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"xyz789"</span>
     <span class="hljs-punctuation">}</span>
@@ -4605,6 +4983,7 @@ is <span class="hljs-keyword">an</span> all-<span class="hljs-keyword">or</span>
                 </html>
               </div>
             </div>
+            <a href="#top">back to top</a>
           </div>
         </section>
         <section id="mutation-updatePolicy" class="operation operation-mutation" data-traverse-target="mutation-updatePolicy">
@@ -4852,10 +5231,10 @@ is <span class="hljs-keyword">an</span> all-<span class="hljs-keyword">or</span>
     <span class="hljs-attr">"updatePolicy"</span><span class="hljs-punctuation">:</span> <span class="hljs-punctuation">{</span>
       <span class="hljs-attr">"actions"</span><span class="hljs-punctuation">:</span> <span class="hljs-punctuation">[</span><span class="hljs-string">ActionResponse</span><span class="hljs-punctuation">]</span><span class="hljs-punctuation">,</span>
       <span class="hljs-attr">"createdAt"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"xyz789"</span><span class="hljs-punctuation">,</span>
-      <span class="hljs-attr">"mandatory"</span><span class="hljs-punctuation">:</span> <span class="hljs-literal"><span class="hljs-keyword">false</span></span><span class="hljs-punctuation">,</span>
+      <span class="hljs-attr">"mandatory"</span><span class="hljs-punctuation">:</span> <span class="hljs-literal"><span class="hljs-keyword">true</span></span><span class="hljs-punctuation">,</span>
       <span class="hljs-attr">"name"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"xyz789"</span><span class="hljs-punctuation">,</span>
-      <span class="hljs-attr">"policyId"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"abc123"</span><span class="hljs-punctuation">,</span>
-      <span class="hljs-attr">"updatedAt"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"abc123"</span>
+      <span class="hljs-attr">"policyId"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"xyz789"</span><span class="hljs-punctuation">,</span>
+      <span class="hljs-attr">"updatedAt"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"xyz789"</span>
     <span class="hljs-punctuation">}</span>
   <span class="hljs-punctuation">}</span>
 <span class="hljs-punctuation">}</span>
@@ -4864,6 +5243,7 @@ is <span class="hljs-keyword">an</span> all-<span class="hljs-keyword">or</span>
                 </html>
               </div>
             </div>
+            <a href="#top">back to top</a>
           </div>
         </section>
         <section id="mutation-updateUnit" class="operation operation-mutation" data-traverse-target="mutation-updateUnit">
@@ -4958,14 +5338,14 @@ is <span class="hljs-keyword">an</span> all-<span class="hljs-keyword">or</span>
     <span class="hljs-attr">"updateUnit"</span><span class="hljs-punctuation">:</span> <span class="hljs-punctuation">{</span>
       <span class="hljs-attr">"createdAt"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"abc123"</span><span class="hljs-punctuation">,</span>
       <span class="hljs-attr">"displayNumber"</span><span class="hljs-punctuation">:</span> <span class="hljs-number">987</span><span class="hljs-punctuation">,</span>
-      <span class="hljs-attr">"displayOrder"</span><span class="hljs-punctuation">:</span> <span class="hljs-number">123</span><span class="hljs-punctuation">,</span>
+      <span class="hljs-attr">"displayOrder"</span><span class="hljs-punctuation">:</span> <span class="hljs-number">987</span><span class="hljs-punctuation">,</span>
       <span class="hljs-attr">"filterRules"</span><span class="hljs-punctuation">:</span> <span class="hljs-punctuation">[</span><span class="hljs-string">FilterRuleResponse</span><span class="hljs-punctuation">]</span><span class="hljs-punctuation">,</span>
       <span class="hljs-attr">"id"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"xyz789"</span><span class="hljs-punctuation">,</span>
       <span class="hljs-attr">"metrics"</span><span class="hljs-punctuation">:</span> <span class="hljs-punctuation">[</span><span class="hljs-string">Metrics</span><span class="hljs-punctuation">]</span><span class="hljs-punctuation">,</span>
-      <span class="hljs-attr">"pagePlacement"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"abc123"</span><span class="hljs-punctuation">,</span>
+      <span class="hljs-attr">"pagePlacement"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"xyz789"</span><span class="hljs-punctuation">,</span>
       <span class="hljs-attr">"pageType"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"CART"</span><span class="hljs-punctuation">,</span>
-      <span class="hljs-attr">"storefrontLabel"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"xyz789"</span><span class="hljs-punctuation">,</span>
-      <span class="hljs-attr">"unitName"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"xyz789"</span><span class="hljs-punctuation">,</span>
+      <span class="hljs-attr">"storefrontLabel"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"abc123"</span><span class="hljs-punctuation">,</span>
+      <span class="hljs-attr">"unitName"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"abc123"</span><span class="hljs-punctuation">,</span>
       <span class="hljs-attr">"unitStatus"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"ACTIVE"</span><span class="hljs-punctuation">,</span>
       <span class="hljs-attr">"unitType"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"ADD_TO_CART_CONVERSION_RATE"</span><span class="hljs-punctuation">,</span>
       <span class="hljs-attr">"updatedAt"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"xyz789"</span>
@@ -4977,6 +5357,7 @@ is <span class="hljs-keyword">an</span> all-<span class="hljs-keyword">or</span>
                 </html>
               </div>
             </div>
+            <a href="#top">back to top</a>
           </div>
         </section>
         <h1 id="group-Types" class="group-heading" data-traverse-target="group-Types">Types</h1>
@@ -5034,6 +5415,7 @@ is <span class="hljs-keyword">an</span> all-<span class="hljs-keyword">or</span>
                 </html>
               </div>
             </div>
+            <a href="#top">back to top</a>
           </div>
         </section>
         <section id="definition-ActionFilterRequest" class="definition definition-input-object" data-traverse-target="definition-ActionFilterRequest">
@@ -5104,7 +5486,7 @@ is <span class="hljs-keyword">an</span> all-<span class="hljs-keyword">or</span>
                   <head></head>
                   <body><pre><code class="hljs language-json"><span class="hljs-punctuation">{</span>
   <span class="hljs-attr">"actionFilterOperator"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"EQUALS"</span><span class="hljs-punctuation">,</span>
-  <span class="hljs-attr">"attribute"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"xyz789"</span><span class="hljs-punctuation">,</span>
+  <span class="hljs-attr">"attribute"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"abc123"</span><span class="hljs-punctuation">,</span>
   <span class="hljs-attr">"enabled"</span><span class="hljs-punctuation">:</span> <span class="hljs-literal"><span class="hljs-keyword">false</span></span><span class="hljs-punctuation">,</span>
   <span class="hljs-attr">"value"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"abc123"</span><span class="hljs-punctuation">,</span>
   <span class="hljs-attr">"valueSource"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"STATIC"</span>
@@ -5114,6 +5496,7 @@ is <span class="hljs-keyword">an</span> all-<span class="hljs-keyword">or</span>
                 </html>
               </div>
             </div>
+            <a href="#top">back to top</a>
           </div>
         </section>
         <section id="definition-ActionFilterResponse" class="definition definition-object" data-traverse-target="definition-ActionFilterResponse">
@@ -5174,7 +5557,7 @@ is <span class="hljs-keyword">an</span> all-<span class="hljs-keyword">or</span>
                   <body><pre><code class="hljs language-json"><span class="hljs-punctuation">{</span>
   <span class="hljs-attr">"actionFilterOperator"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"EQUALS"</span><span class="hljs-punctuation">,</span>
   <span class="hljs-attr">"attribute"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"xyz789"</span><span class="hljs-punctuation">,</span>
-  <span class="hljs-attr">"enabled"</span><span class="hljs-punctuation">:</span> <span class="hljs-literal"><span class="hljs-keyword">true</span></span><span class="hljs-punctuation">,</span>
+  <span class="hljs-attr">"enabled"</span><span class="hljs-punctuation">:</span> <span class="hljs-literal"><span class="hljs-keyword">false</span></span><span class="hljs-punctuation">,</span>
   <span class="hljs-attr">"value"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"abc123"</span><span class="hljs-punctuation">,</span>
   <span class="hljs-attr">"valueSource"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"STATIC"</span>
 <span class="hljs-punctuation">}</span>
@@ -5183,6 +5566,7 @@ is <span class="hljs-keyword">an</span> all-<span class="hljs-keyword">or</span>
                 </html>
               </div>
             </div>
+            <a href="#top">back to top</a>
           </div>
         </section>
         <section id="definition-ActionFilterValueSource" class="definition definition-enum" data-traverse-target="definition-ActionFilterValueSource">
@@ -5235,6 +5619,7 @@ is <span class="hljs-keyword">an</span> all-<span class="hljs-keyword">or</span>
                 </html>
               </div>
             </div>
+            <a href="#top">back to top</a>
           </div>
         </section>
         <section id="definition-ActionRequest" class="definition definition-input-object" data-traverse-target="definition-ActionRequest">
@@ -5288,6 +5673,7 @@ is <span class="hljs-keyword">an</span> all-<span class="hljs-keyword">or</span>
                 </html>
               </div>
             </div>
+            <a href="#top">back to top</a>
           </div>
         </section>
         <section id="definition-ActionResponse" class="definition definition-object" data-traverse-target="definition-ActionResponse">
@@ -5339,6 +5725,7 @@ is <span class="hljs-keyword">an</span> all-<span class="hljs-keyword">or</span>
                 </html>
               </div>
             </div>
+            <a href="#top">back to top</a>
           </div>
         </section>
         <section id="definition-ActionType" class="definition definition-enum" data-traverse-target="definition-ActionType">
@@ -5405,6 +5792,7 @@ is <span class="hljs-keyword">an</span> all-<span class="hljs-keyword">or</span>
                 </html>
               </div>
             </div>
+            <a href="#top">back to top</a>
           </div>
         </section>
         <section id="definition-AnalyticsInput" class="definition definition-input-object" data-traverse-target="definition-AnalyticsInput">
@@ -5458,6 +5846,7 @@ is <span class="hljs-keyword">an</span> all-<span class="hljs-keyword">or</span>
                 </html>
               </div>
             </div>
+            <a href="#top">back to top</a>
           </div>
         </section>
         <section id="definition-AnalyticsTypes" class="definition definition-enum" data-traverse-target="definition-AnalyticsTypes">
@@ -5524,6 +5913,7 @@ is <span class="hljs-keyword">an</span> all-<span class="hljs-keyword">or</span>
                 </html>
               </div>
             </div>
+            <a href="#top">back to top</a>
           </div>
         </section>
         <section id="definition-BatchChannelResponse" class="definition definition-object" data-traverse-target="definition-BatchChannelResponse">
@@ -5575,6 +5965,7 @@ is <span class="hljs-keyword">an</span> all-<span class="hljs-keyword">or</span>
                 </html>
               </div>
             </div>
+            <a href="#top">back to top</a>
           </div>
         </section>
         <section id="definition-BatchPolicyResponse" class="definition definition-object" data-traverse-target="definition-BatchPolicyResponse">
@@ -5626,6 +6017,7 @@ is <span class="hljs-keyword">an</span> all-<span class="hljs-keyword">or</span>
                 </html>
               </div>
             </div>
+            <a href="#top">back to top</a>
           </div>
         </section>
         <section id="definition-BatchUnitResponse" class="definition definition-object" data-traverse-target="definition-BatchUnitResponse">
@@ -5669,7 +6061,7 @@ is <span class="hljs-keyword">an</span> all-<span class="hljs-keyword">or</span>
                 <html>
                   <head></head>
                   <body><pre><code class="hljs language-json"><span class="hljs-punctuation">{</span>
-  <span class="hljs-attr">"errors"</span><span class="hljs-punctuation">:</span> <span class="hljs-punctuation">[</span><span class="hljs-string">"xyz789"</span><span class="hljs-punctuation">]</span><span class="hljs-punctuation">,</span>
+  <span class="hljs-attr">"errors"</span><span class="hljs-punctuation">:</span> <span class="hljs-punctuation">[</span><span class="hljs-string">"abc123"</span><span class="hljs-punctuation">]</span><span class="hljs-punctuation">,</span>
   <span class="hljs-attr">"units"</span><span class="hljs-punctuation">:</span> <span class="hljs-punctuation">[</span><span class="hljs-string">UnitResponse</span><span class="hljs-punctuation">]</span>
 <span class="hljs-punctuation">}</span>
 </code></pre>
@@ -5677,6 +6069,33 @@ is <span class="hljs-keyword">an</span> all-<span class="hljs-keyword">or</span>
                 </html>
               </div>
             </div>
+            <a href="#top">back to top</a>
+          </div>
+        </section>
+        <section id="definition-BigDecimal" class="definition definition-scalar" data-traverse-target="definition-BigDecimal">
+          <div class="definition-group-name">
+            <a href="#group-Types">Types</a>
+          </div>
+          <h2 class="definition-heading">BigDecimal</h2>
+          <div class="doc-row">
+            <div class="doc-copy">
+              <div class="definition-description doc-copy-section">
+                <h5>Description</h5>
+                <p>An arbitrary precision signed decimal</p>
+              </div>
+            </div>
+            <div class="doc-examples">
+              <div class="example-section example-section-is-code">
+                <h5>Example</h5>
+                <html>
+                  <head></head>
+                  <body><pre><code class="hljs language-gql"><span class="hljs-symbol">BigDecimal</span>
+</code></pre>
+                  </body>
+                </html>
+              </div>
+            </div>
+            <a href="#top">back to top</a>
           </div>
         </section>
         <section id="definition-Boolean" class="definition definition-scalar" data-traverse-target="definition-Boolean">
@@ -5692,7 +6111,144 @@ is <span class="hljs-keyword">an</span> all-<span class="hljs-keyword">or</span>
               </div>
             </div>
             <div class="doc-examples">
+              <div class="example-section example-section-is-code">
+                <h5>Example</h5>
+                <html>
+                  <head></head>
+                  <body><pre><code class="hljs language-json"><span class="hljs-literal"><span class="hljs-keyword">true</span></span>
+</code></pre>
+                  </body>
+                </html>
+              </div>
             </div>
+            <a href="#top">back to top</a>
+          </div>
+        </section>
+        <section id="definition-CatalogStorefront" class="definition definition-object" data-traverse-target="definition-CatalogStorefront">
+          <div class="definition-group-name">
+            <a href="#group-Types">Types</a>
+          </div>
+          <h2 class="definition-heading">CatalogStorefront</h2>
+          <div class="doc-row">
+            <div class="doc-copy">
+              <div class="definition-properties doc-copy-section">
+                <h5>Fields</h5>
+                <table>
+                  <thead>
+                    <tr>
+                      <th>Field Name</th>
+                      <th>Description</th>
+                    </tr>
+                  </thead>
+                  <tbody>
+                    <tr>
+                      <td data-property-name=""><span class="property-name"><code>count</code></span> - <span class="property-type"><a href="#definition-Int"><code>Int!</code></a></span>
+                      </td>
+                      <td> Queries the Catalog Storefront Service for the count of products. This represents the number of products that are indexed and available for catalog storefront functionality. </td>
+                    </tr>
+                    <tr class="row-has-field-arguments">
+                      <td data-property-name=""><span class="property-name"><code>countFromTo</code></span> - <span class="property-type"><a href="#definition-CountFromTo"><code>CountFromTo!</code></a></span>
+                      </td>
+                      <td>
+                        <p>Queries the Catalog Storefront Service for the number of products indexed between two given timestamps.</p>
+                        <p>Parameters:</p>
+                        <ul>
+                          <li>from: The start timestamp to query from (optional, if not provided will count all products up to the &#39;to&#39; timestamp)</li>
+                          <li>to: The end timestamp to query to (optional, if not provided will count all products from the &#39;from&#39; timestamp)</li>
+                        </ul>
+                      </td>
+                    </tr>
+                    <tr class="row-field-arguments">
+                      <td colspan="2">
+                        <div class="field-arguments">
+                          <h5 class="field-arguments-heading"> Arguments </h5>
+                          <div class="field-argument-list">
+                            <div class="field-argument">
+                              <h6 class="field-argument-name"><span class="property-name"><code>from</code></span> - <span class="property-type"><a href="#definition-String"><code>String</code></a></span>
+                              </h6>
+                            </div>
+                            <div class="field-argument">
+                              <h6 class="field-argument-name"><span class="property-name"><code>to</code></span> - <span class="property-type"><a href="#definition-String"><code>String</code></a></span>
+                              </h6>
+                            </div>
+                          </div>
+                        </div>
+                      </td>
+                    </tr>
+                    <tr class="row-has-field-arguments">
+                      <td data-property-name=""><span class="property-name"><code>productDetail</code></span> - <span class="property-type"><a href="#definition-ProductDetail"><code>ProductDetail!</code></a></span>
+                      </td>
+                      <td>
+                        <p>Queries the Catalog Storefront Service for detailed product information for a given SKU</p>
+                        <p>Parameters:</p>
+                        <ul>
+                          <li>sku: The SKU of the product to retrieve (required)</li>
+                        </ul>
+                      </td>
+                    </tr>
+                    <tr class="row-field-arguments">
+                      <td colspan="2">
+                        <div class="field-arguments">
+                          <h5 class="field-arguments-heading"> Arguments </h5>
+                          <div class="field-argument-list">
+                            <div class="field-argument">
+                              <h6 class="field-argument-name"><span class="property-name"><code>sku</code></span> - <span class="property-type"><a href="#definition-String"><code>String!</code></a></span>
+                              </h6>
+                            </div>
+                          </div>
+                        </div>
+                      </td>
+                    </tr>
+                    <tr class="row-has-field-arguments">
+                      <td data-property-name=""><span class="property-name"><code>productList</code></span> - <span class="property-type"><a href="#definition-ProductList"><code>ProductList!</code></a></span>
+                      </td>
+                      <td>
+                        <p>Queries the Catalog Storefront Service for a list of products indexed. This represents the list of products that are indexed and available for catalog storefront functionality. The product list is sorted by last indexed timestamp in descending order.</p>
+                        <p>Parameters:</p>
+                        <ul>
+                          <li>cursor: The cursor to continue a previous search (optional)</li>
+                          <li>size: The number of products to return (optional, default: 50)</li>
+                        </ul>
+                      </td>
+                    </tr>
+                    <tr class="row-field-arguments">
+                      <td colspan="2">
+                        <div class="field-arguments">
+                          <h5 class="field-arguments-heading"> Arguments </h5>
+                          <div class="field-argument-list">
+                            <div class="field-argument">
+                              <h6 class="field-argument-name"><span class="property-name"><code>cursor</code></span> - <span class="property-type"><a href="#definition-String"><code>String</code></a></span>
+                              </h6>
+                            </div>
+                            <div class="field-argument">
+                              <h6 class="field-argument-name"><span class="property-name"><code>size</code></span> - <span class="property-type"><a href="#definition-Int"><code>Int</code></a></span>
+                              </h6>
+                            </div>
+                          </div>
+                        </div>
+                      </td>
+                    </tr>
+                  </tbody>
+                </table>
+              </div>
+            </div>
+            <div class="doc-examples">
+              <div class="example-section example-section-is-code">
+                <h5>Example</h5>
+                <html>
+                  <head></head>
+                  <body><pre><code class="hljs language-json"><span class="hljs-punctuation">{</span>
+  <span class="hljs-attr">"count"</span><span class="hljs-punctuation">:</span> <span class="hljs-number">123</span><span class="hljs-punctuation">,</span>
+  <span class="hljs-attr">"countFromTo"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">CountFromTo</span><span class="hljs-punctuation">,</span>
+  <span class="hljs-attr">"productDetail"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">ProductDetail</span><span class="hljs-punctuation">,</span>
+  <span class="hljs-attr">"productList"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">ProductList</span>
+<span class="hljs-punctuation">}</span>
+</code></pre>
+                  </body>
+                </html>
+              </div>
+            </div>
+            <a href="#top">back to top</a>
           </div>
         </section>
         <section id="definition-CategoriesResponse" class="definition definition-object" data-traverse-target="definition-CategoriesResponse">
@@ -5737,6 +6293,7 @@ is <span class="hljs-keyword">an</span> all-<span class="hljs-keyword">or</span>
                 </html>
               </div>
             </div>
+            <a href="#top">back to top</a>
           </div>
         </section>
         <section id="definition-Category" class="definition definition-object" data-traverse-target="definition-Category">
@@ -5805,10 +6362,10 @@ is <span class="hljs-keyword">an</span> all-<span class="hljs-keyword">or</span>
                 <html>
                   <head></head>
                   <body><pre><code class="hljs language-json"><span class="hljs-punctuation">{</span>
-  <span class="hljs-attr">"children"</span><span class="hljs-punctuation">:</span> <span class="hljs-punctuation">[</span><span class="hljs-string">"xyz789"</span><span class="hljs-punctuation">]</span><span class="hljs-punctuation">,</span>
-  <span class="hljs-attr">"id"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"abc123"</span><span class="hljs-punctuation">,</span>
-  <span class="hljs-attr">"level"</span><span class="hljs-punctuation">:</span> <span class="hljs-number">987</span><span class="hljs-punctuation">,</span>
-  <span class="hljs-attr">"name"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"xyz789"</span><span class="hljs-punctuation">,</span>
+  <span class="hljs-attr">"children"</span><span class="hljs-punctuation">:</span> <span class="hljs-punctuation">[</span><span class="hljs-string">"abc123"</span><span class="hljs-punctuation">]</span><span class="hljs-punctuation">,</span>
+  <span class="hljs-attr">"id"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"xyz789"</span><span class="hljs-punctuation">,</span>
+  <span class="hljs-attr">"level"</span><span class="hljs-punctuation">:</span> <span class="hljs-number">123</span><span class="hljs-punctuation">,</span>
+  <span class="hljs-attr">"name"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"abc123"</span><span class="hljs-punctuation">,</span>
   <span class="hljs-attr">"parentId"</span><span class="hljs-punctuation">:</span> <span class="hljs-number">123</span><span class="hljs-punctuation">,</span>
   <span class="hljs-attr">"path"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"xyz789"</span><span class="hljs-punctuation">,</span>
   <span class="hljs-attr">"urlPath"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"xyz789"</span>
@@ -5818,6 +6375,7 @@ is <span class="hljs-keyword">an</span> all-<span class="hljs-keyword">or</span>
                 </html>
               </div>
             </div>
+            <a href="#top">back to top</a>
           </div>
         </section>
         <section id="definition-CategoryRule" class="definition definition-object" data-traverse-target="definition-CategoryRule">
@@ -5916,14 +6474,14 @@ is <span class="hljs-keyword">an</span> all-<span class="hljs-keyword">or</span>
                 <html>
                   <head></head>
                   <body><pre><code class="hljs language-json"><span class="hljs-punctuation">{</span>
-  <span class="hljs-attr">"applyToSubcategories"</span><span class="hljs-punctuation">:</span> <span class="hljs-literal"><span class="hljs-keyword">true</span></span><span class="hljs-punctuation">,</span>
-  <span class="hljs-attr">"categoryId"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"xyz789"</span><span class="hljs-punctuation">,</span>
-  <span class="hljs-attr">"categoryName"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"abc123"</span><span class="hljs-punctuation">,</span>
-  <span class="hljs-attr">"children"</span><span class="hljs-punctuation">:</span> <span class="hljs-punctuation">[</span><span class="hljs-string">"abc123"</span><span class="hljs-punctuation">]</span><span class="hljs-punctuation">,</span>
+  <span class="hljs-attr">"applyToSubcategories"</span><span class="hljs-punctuation">:</span> <span class="hljs-literal"><span class="hljs-keyword">false</span></span><span class="hljs-punctuation">,</span>
+  <span class="hljs-attr">"categoryId"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"abc123"</span><span class="hljs-punctuation">,</span>
+  <span class="hljs-attr">"categoryName"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"xyz789"</span><span class="hljs-punctuation">,</span>
+  <span class="hljs-attr">"children"</span><span class="hljs-punctuation">:</span> <span class="hljs-punctuation">[</span><span class="hljs-string">"xyz789"</span><span class="hljs-punctuation">]</span><span class="hljs-punctuation">,</span>
   <span class="hljs-attr">"level"</span><span class="hljs-punctuation">:</span> <span class="hljs-number">987</span><span class="hljs-punctuation">,</span>
-  <span class="hljs-attr">"parentId"</span><span class="hljs-punctuation">:</span> <span class="hljs-number">123</span><span class="hljs-punctuation">,</span>
-  <span class="hljs-attr">"parentRuleId"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"xyz789"</span><span class="hljs-punctuation">,</span>
-  <span class="hljs-attr">"path"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"abc123"</span><span class="hljs-punctuation">,</span>
+  <span class="hljs-attr">"parentId"</span><span class="hljs-punctuation">:</span> <span class="hljs-number">987</span><span class="hljs-punctuation">,</span>
+  <span class="hljs-attr">"parentRuleId"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"abc123"</span><span class="hljs-punctuation">,</span>
+  <span class="hljs-attr">"path"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"xyz789"</span><span class="hljs-punctuation">,</span>
   <span class="hljs-attr">"rankingType"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"MOST_ADDED_TO_CART"</span><span class="hljs-punctuation">,</span>
   <span class="hljs-attr">"ruleId"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"abc123"</span><span class="hljs-punctuation">,</span>
   <span class="hljs-attr">"ruleUpdated"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"xyz789"</span><span class="hljs-punctuation">,</span>
@@ -5935,6 +6493,7 @@ is <span class="hljs-keyword">an</span> all-<span class="hljs-keyword">or</span>
                 </html>
               </div>
             </div>
+            <a href="#top">back to top</a>
           </div>
         </section>
         <section id="definition-CategoryRuleDetail" class="definition definition-object" data-traverse-target="definition-CategoryRuleDetail">
@@ -6041,14 +6600,14 @@ is <span class="hljs-keyword">an</span> all-<span class="hljs-keyword">or</span>
   <span class="hljs-attr">"applyToSubcategories"</span><span class="hljs-punctuation">:</span> <span class="hljs-literal"><span class="hljs-keyword">true</span></span><span class="hljs-punctuation">,</span>
   <span class="hljs-attr">"categoryId"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"abc123"</span><span class="hljs-punctuation">,</span>
   <span class="hljs-attr">"categoryName"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"abc123"</span><span class="hljs-punctuation">,</span>
-  <span class="hljs-attr">"children"</span><span class="hljs-punctuation">:</span> <span class="hljs-punctuation">[</span><span class="hljs-string">"xyz789"</span><span class="hljs-punctuation">]</span><span class="hljs-punctuation">,</span>
+  <span class="hljs-attr">"children"</span><span class="hljs-punctuation">:</span> <span class="hljs-punctuation">[</span><span class="hljs-string">"abc123"</span><span class="hljs-punctuation">]</span><span class="hljs-punctuation">,</span>
   <span class="hljs-attr">"events"</span><span class="hljs-punctuation">:</span> <span class="hljs-punctuation">[</span><span class="hljs-string">Event</span><span class="hljs-punctuation">]</span><span class="hljs-punctuation">,</span>
   <span class="hljs-attr">"level"</span><span class="hljs-punctuation">:</span> <span class="hljs-number">123</span><span class="hljs-punctuation">,</span>
-  <span class="hljs-attr">"parentId"</span><span class="hljs-punctuation">:</span> <span class="hljs-number">123</span><span class="hljs-punctuation">,</span>
-  <span class="hljs-attr">"parentRuleId"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"abc123"</span><span class="hljs-punctuation">,</span>
+  <span class="hljs-attr">"parentId"</span><span class="hljs-punctuation">:</span> <span class="hljs-number">987</span><span class="hljs-punctuation">,</span>
+  <span class="hljs-attr">"parentRuleId"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"xyz789"</span><span class="hljs-punctuation">,</span>
   <span class="hljs-attr">"path"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"xyz789"</span><span class="hljs-punctuation">,</span>
   <span class="hljs-attr">"rankingType"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"MOST_ADDED_TO_CART"</span><span class="hljs-punctuation">,</span>
-  <span class="hljs-attr">"ruleId"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"abc123"</span><span class="hljs-punctuation">,</span>
+  <span class="hljs-attr">"ruleId"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"xyz789"</span><span class="hljs-punctuation">,</span>
   <span class="hljs-attr">"ruleUpdated"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"xyz789"</span><span class="hljs-punctuation">,</span>
   <span class="hljs-attr">"trendingWindow"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"FOURTEEN"</span><span class="hljs-punctuation">,</span>
   <span class="hljs-attr">"urlPath"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"abc123"</span>
@@ -6058,6 +6617,7 @@ is <span class="hljs-keyword">an</span> all-<span class="hljs-keyword">or</span>
                 </html>
               </div>
             </div>
+            <a href="#top">back to top</a>
           </div>
         </section>
         <section id="definition-CategoryRuleInput" class="definition definition-input-object" data-traverse-target="definition-CategoryRuleInput">
@@ -6133,12 +6693,12 @@ is <span class="hljs-keyword">an</span> all-<span class="hljs-keyword">or</span>
                 <html>
                   <head></head>
                   <body><pre><code class="hljs language-json"><span class="hljs-punctuation">{</span>
-  <span class="hljs-attr">"applyToSubcategories"</span><span class="hljs-punctuation">:</span> <span class="hljs-literal"><span class="hljs-keyword">false</span></span><span class="hljs-punctuation">,</span>
+  <span class="hljs-attr">"applyToSubcategories"</span><span class="hljs-punctuation">:</span> <span class="hljs-literal"><span class="hljs-keyword">true</span></span><span class="hljs-punctuation">,</span>
   <span class="hljs-attr">"categoryId"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"xyz789"</span><span class="hljs-punctuation">,</span>
   <span class="hljs-attr">"events"</span><span class="hljs-punctuation">:</span> <span class="hljs-punctuation">[</span><span class="hljs-string">EventInput</span><span class="hljs-punctuation">]</span><span class="hljs-punctuation">,</span>
   <span class="hljs-attr">"preview"</span><span class="hljs-punctuation">:</span> <span class="hljs-literal"><span class="hljs-keyword">true</span></span><span class="hljs-punctuation">,</span>
   <span class="hljs-attr">"rankingType"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"MOST_ADDED_TO_CART"</span><span class="hljs-punctuation">,</span>
-  <span class="hljs-attr">"ruleId"</span><span class="hljs-punctuation">:</span> <span class="hljs-number">4</span><span class="hljs-punctuation">,</span>
+  <span class="hljs-attr">"ruleId"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"4"</span><span class="hljs-punctuation">,</span>
   <span class="hljs-attr">"trendingWindow"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"FOURTEEN"</span>
 <span class="hljs-punctuation">}</span>
 </code></pre>
@@ -6146,6 +6706,7 @@ is <span class="hljs-keyword">an</span> all-<span class="hljs-keyword">or</span>
                 </html>
               </div>
             </div>
+            <a href="#top">back to top</a>
           </div>
         </section>
         <section id="definition-CategoryRulesDeleteCount" class="definition definition-object" data-traverse-target="definition-CategoryRulesDeleteCount">
@@ -6189,6 +6750,7 @@ is <span class="hljs-keyword">an</span> all-<span class="hljs-keyword">or</span>
                 </html>
               </div>
             </div>
+            <a href="#top">back to top</a>
           </div>
         </section>
         <section id="definition-CategoryRulesMutationResponse" class="definition definition-object" data-traverse-target="definition-CategoryRulesMutationResponse">
@@ -6226,12 +6788,13 @@ is <span class="hljs-keyword">an</span> all-<span class="hljs-keyword">or</span>
                 <h5>Example</h5>
                 <html>
                   <head></head>
-                  <body><pre><code class="hljs language-json"><span class="hljs-punctuation">{</span><span class="hljs-attr">"message"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"abc123"</span><span class="hljs-punctuation">}</span>
+                  <body><pre><code class="hljs language-json"><span class="hljs-punctuation">{</span><span class="hljs-attr">"message"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"xyz789"</span><span class="hljs-punctuation">}</span>
 </code></pre>
                   </body>
                 </html>
               </div>
             </div>
+            <a href="#top">back to top</a>
           </div>
         </section>
         <section id="definition-CategoryRulesQueryResponse" class="definition definition-object" data-traverse-target="definition-CategoryRulesQueryResponse">
@@ -6275,6 +6838,7 @@ is <span class="hljs-keyword">an</span> all-<span class="hljs-keyword">or</span>
                 </html>
               </div>
             </div>
+            <a href="#top">back to top</a>
           </div>
         </section>
         <section id="definition-ChannelResponse" class="definition definition-object" data-traverse-target="definition-ChannelResponse">
@@ -6343,19 +6907,20 @@ is <span class="hljs-keyword">an</span> all-<span class="hljs-keyword">or</span>
                 <html>
                   <head></head>
                   <body><pre><code class="hljs language-json"><span class="hljs-punctuation">{</span>
-  <span class="hljs-attr">"channelId"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"abc123"</span><span class="hljs-punctuation">,</span>
+  <span class="hljs-attr">"channelId"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"xyz789"</span><span class="hljs-punctuation">,</span>
   <span class="hljs-attr">"createdAt"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"abc123"</span><span class="hljs-punctuation">,</span>
-  <span class="hljs-attr">"name"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"xyz789"</span><span class="hljs-punctuation">,</span>
+  <span class="hljs-attr">"name"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"abc123"</span><span class="hljs-punctuation">,</span>
   <span class="hljs-attr">"policies"</span><span class="hljs-punctuation">:</span> <span class="hljs-punctuation">[</span><span class="hljs-string">PolicyResponse</span><span class="hljs-punctuation">]</span><span class="hljs-punctuation">,</span>
   <span class="hljs-attr">"policyIds"</span><span class="hljs-punctuation">:</span> <span class="hljs-punctuation">[</span><span class="hljs-string">"xyz789"</span><span class="hljs-punctuation">]</span><span class="hljs-punctuation">,</span>
   <span class="hljs-attr">"scopes"</span><span class="hljs-punctuation">:</span> <span class="hljs-punctuation">[</span><span class="hljs-string">ChannelScopeResponse</span><span class="hljs-punctuation">]</span><span class="hljs-punctuation">,</span>
-  <span class="hljs-attr">"updatedAt"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"abc123"</span>
+  <span class="hljs-attr">"updatedAt"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"xyz789"</span>
 <span class="hljs-punctuation">}</span>
 </code></pre>
                   </body>
                 </html>
               </div>
             </div>
+            <a href="#top">back to top</a>
           </div>
         </section>
         <section id="definition-ChannelScopeRequest" class="definition definition-input-object" data-traverse-target="definition-ChannelScopeRequest">
@@ -6391,12 +6956,13 @@ is <span class="hljs-keyword">an</span> all-<span class="hljs-keyword">or</span>
                 <h5>Example</h5>
                 <html>
                   <head></head>
-                  <body><pre><code class="hljs language-json"><span class="hljs-punctuation">{</span><span class="hljs-attr">"locale"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"abc123"</span><span class="hljs-punctuation">}</span>
+                  <body><pre><code class="hljs language-json"><span class="hljs-punctuation">{</span><span class="hljs-attr">"locale"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"xyz789"</span><span class="hljs-punctuation">}</span>
 </code></pre>
                   </body>
                 </html>
               </div>
             </div>
+            <a href="#top">back to top</a>
           </div>
         </section>
         <section id="definition-ChannelScopeResponse" class="definition definition-object" data-traverse-target="definition-ChannelScopeResponse">
@@ -6431,12 +6997,13 @@ is <span class="hljs-keyword">an</span> all-<span class="hljs-keyword">or</span>
                 <h5>Example</h5>
                 <html>
                   <head></head>
-                  <body><pre><code class="hljs language-json"><span class="hljs-punctuation">{</span><span class="hljs-attr">"locale"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"xyz789"</span><span class="hljs-punctuation">}</span>
+                  <body><pre><code class="hljs language-json"><span class="hljs-punctuation">{</span><span class="hljs-attr">"locale"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"abc123"</span><span class="hljs-punctuation">}</span>
 </code></pre>
                   </body>
                 </html>
               </div>
             </div>
+            <a href="#top">back to top</a>
           </div>
         </section>
         <section id="definition-ConditionRequest" class="definition definition-input-object" data-traverse-target="definition-ConditionRequest">
@@ -6489,7 +7056,7 @@ is <span class="hljs-keyword">an</span> all-<span class="hljs-keyword">or</span>
                   <head></head>
                   <body><pre><code class="hljs language-json"><span class="hljs-punctuation">{</span>
   <span class="hljs-attr">"enabled"</span><span class="hljs-punctuation">:</span> <span class="hljs-literal"><span class="hljs-keyword">true</span></span><span class="hljs-punctuation">,</span>
-  <span class="hljs-attr">"field"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"xyz789"</span><span class="hljs-punctuation">,</span>
+  <span class="hljs-attr">"field"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"abc123"</span><span class="hljs-punctuation">,</span>
   <span class="hljs-attr">"operator"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">OperatorRequest</span>
 <span class="hljs-punctuation">}</span>
 </code></pre>
@@ -6497,6 +7064,7 @@ is <span class="hljs-keyword">an</span> all-<span class="hljs-keyword">or</span>
                 </html>
               </div>
             </div>
+            <a href="#top">back to top</a>
           </div>
         </section>
         <section id="definition-ConditionResponse" class="definition definition-object" data-traverse-target="definition-ConditionResponse">
@@ -6554,6 +7122,64 @@ is <span class="hljs-keyword">an</span> all-<span class="hljs-keyword">or</span>
                 </html>
               </div>
             </div>
+            <a href="#top">back to top</a>
+          </div>
+        </section>
+        <section id="definition-CountFromTo" class="definition definition-object" data-traverse-target="definition-CountFromTo">
+          <div class="definition-group-name">
+            <a href="#group-Types">Types</a>
+          </div>
+          <h2 class="definition-heading">CountFromTo</h2>
+          <div class="doc-row">
+            <div class="doc-copy">
+              <div class="definition-properties doc-copy-section">
+                <h5>Fields</h5>
+                <table>
+                  <thead>
+                    <tr>
+                      <th>Field Name</th>
+                      <th>Description</th>
+                    </tr>
+                  </thead>
+                  <tbody>
+                    <tr>
+                      <td data-property-name=""><span class="property-name"><code>count</code></span> - <span class="property-type"><a href="#definition-Int"><code>Int!</code></a></span>
+                      </td>
+                      <td>
+                      </td>
+                    </tr>
+                    <tr>
+                      <td data-property-name=""><span class="property-name"><code>from</code></span> - <span class="property-type"><a href="#definition-String"><code>String!</code></a></span>
+                      </td>
+                      <td>
+                      </td>
+                    </tr>
+                    <tr>
+                      <td data-property-name=""><span class="property-name"><code>to</code></span> - <span class="property-type"><a href="#definition-String"><code>String!</code></a></span>
+                      </td>
+                      <td>
+                      </td>
+                    </tr>
+                  </tbody>
+                </table>
+              </div>
+            </div>
+            <div class="doc-examples">
+              <div class="example-section example-section-is-code">
+                <h5>Example</h5>
+                <html>
+                  <head></head>
+                  <body><pre><code class="hljs language-json"><span class="hljs-punctuation">{</span>
+  <span class="hljs-attr">"count"</span><span class="hljs-punctuation">:</span> <span class="hljs-number">123</span><span class="hljs-punctuation">,</span>
+  <span class="hljs-attr">"from"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"abc123"</span><span class="hljs-punctuation">,</span>
+  <span class="hljs-attr">"to"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"abc123"</span>
+<span class="hljs-punctuation">}</span>
+</code></pre>
+                  </body>
+                </html>
+              </div>
+            </div>
+            <a href="#top">back to top</a>
           </div>
         </section>
         <section id="definition-CreateChannelRequest" class="definition definition-input-object" data-traverse-target="definition-CreateChannelRequest">
@@ -6587,13 +7213,13 @@ is <span class="hljs-keyword">an</span> all-<span class="hljs-keyword">or</span>
                       <td>
                         <span class="property-name"><code>policyIds</code></span> - <span class="property-type"><a href="#definition-String"><code>[String!]</code></a></span>
                       </td>
-                      <td> List of policy identifiers. If included, it cannot be empty. </td>
+                      <td> List of policy identifiers. </td>
                     </tr>
                     <tr>
                       <td>
                         <span class="property-name"><code>scopes</code></span> - <span class="property-type"><a href="#definition-ChannelScopeRequest"><code>[ChannelScopeRequest!]</code></a></span>
                       </td>
-                      <td> List of locale identifiers. If included, it cannot be empty. </td>
+                      <td> List of locale identifiers. </td>
                     </tr>
                   </tbody>
                 </table>
@@ -6614,6 +7240,7 @@ is <span class="hljs-keyword">an</span> all-<span class="hljs-keyword">or</span>
                 </html>
               </div>
             </div>
+            <a href="#top">back to top</a>
           </div>
         </section>
         <section id="definition-CreatePolicyRequest" class="definition definition-input-object" data-traverse-target="definition-CreatePolicyRequest">
@@ -6674,6 +7301,7 @@ is <span class="hljs-keyword">an</span> all-<span class="hljs-keyword">or</span>
                 </html>
               </div>
             </div>
+            <a href="#top">back to top</a>
           </div>
         </section>
         <section id="definition-CreateUnitRequest" class="definition definition-input-object" data-traverse-target="definition-CreateUnitRequest">
@@ -6769,12 +7397,12 @@ is <span class="hljs-keyword">an</span> all-<span class="hljs-keyword">or</span>
                   <head></head>
                   <body><pre><code class="hljs language-json"><span class="hljs-punctuation">{</span>
   <span class="hljs-attr">"displayNumber"</span><span class="hljs-punctuation">:</span> <span class="hljs-number">987</span><span class="hljs-punctuation">,</span>
-  <span class="hljs-attr">"displayOrder"</span><span class="hljs-punctuation">:</span> <span class="hljs-number">987</span><span class="hljs-punctuation">,</span>
+  <span class="hljs-attr">"displayOrder"</span><span class="hljs-punctuation">:</span> <span class="hljs-number">123</span><span class="hljs-punctuation">,</span>
   <span class="hljs-attr">"filterRules"</span><span class="hljs-punctuation">:</span> <span class="hljs-punctuation">[</span><span class="hljs-string">FilterRuleRequest</span><span class="hljs-punctuation">]</span><span class="hljs-punctuation">,</span>
-  <span class="hljs-attr">"pagePlacement"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"xyz789"</span><span class="hljs-punctuation">,</span>
+  <span class="hljs-attr">"pagePlacement"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"abc123"</span><span class="hljs-punctuation">,</span>
   <span class="hljs-attr">"pageType"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"CART"</span><span class="hljs-punctuation">,</span>
-  <span class="hljs-attr">"storefrontLabel"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"abc123"</span><span class="hljs-punctuation">,</span>
-  <span class="hljs-attr">"unitName"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"xyz789"</span><span class="hljs-punctuation">,</span>
+  <span class="hljs-attr">"storefrontLabel"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"xyz789"</span><span class="hljs-punctuation">,</span>
+  <span class="hljs-attr">"unitName"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"abc123"</span><span class="hljs-punctuation">,</span>
   <span class="hljs-attr">"unitStatus"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"ACTIVE"</span><span class="hljs-punctuation">,</span>
   <span class="hljs-attr">"unitType"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"ADD_TO_CART_CONVERSION_RATE"</span>
 <span class="hljs-punctuation">}</span>
@@ -6783,6 +7411,7 @@ is <span class="hljs-keyword">an</span> all-<span class="hljs-keyword">or</span>
                 </html>
               </div>
             </div>
+            <a href="#top">back to top</a>
           </div>
         </section>
         <section id="definition-CustomOperatorRequest" class="definition definition-input-object" data-traverse-target="definition-CustomOperatorRequest">
@@ -6827,12 +7456,13 @@ is <span class="hljs-keyword">an</span> all-<span class="hljs-keyword">or</span>
                 <h5>Example</h5>
                 <html>
                   <head></head>
-                  <body><pre><code class="hljs language-json"><span class="hljs-punctuation">{</span><span class="hljs-attr">"type"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"CUSTOM"</span><span class="hljs-punctuation">,</span> <span class="hljs-attr">"value"</span><span class="hljs-punctuation">:</span> <span class="hljs-punctuation">[</span><span class="hljs-string">"abc123"</span><span class="hljs-punctuation">]</span><span class="hljs-punctuation">}</span>
+                  <body><pre><code class="hljs language-json"><span class="hljs-punctuation">{</span><span class="hljs-attr">"type"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"CUSTOM"</span><span class="hljs-punctuation">,</span> <span class="hljs-attr">"value"</span><span class="hljs-punctuation">:</span> <span class="hljs-punctuation">[</span><span class="hljs-string">"xyz789"</span><span class="hljs-punctuation">]</span><span class="hljs-punctuation">}</span>
 </code></pre>
                   </body>
                 </html>
               </div>
             </div>
+            <a href="#top">back to top</a>
           </div>
         </section>
         <section id="definition-CustomOperatorResponse" class="definition definition-object" data-traverse-target="definition-CustomOperatorResponse">
@@ -6881,6 +7511,7 @@ is <span class="hljs-keyword">an</span> all-<span class="hljs-keyword">or</span>
                 </html>
               </div>
             </div>
+            <a href="#top">back to top</a>
           </div>
         </section>
         <section id="definition-CustomOperatorType" class="definition definition-enum" data-traverse-target="definition-CustomOperatorType">
@@ -6926,6 +7557,7 @@ is <span class="hljs-keyword">an</span> all-<span class="hljs-keyword">or</span>
                 </html>
               </div>
             </div>
+            <a href="#top">back to top</a>
           </div>
         </section>
         <section id="definition-DefaultQueryRule" class="definition definition-object" data-traverse-target="definition-DefaultQueryRule">
@@ -7031,6 +7663,7 @@ is <span class="hljs-keyword">an</span> all-<span class="hljs-keyword">or</span>
                 </html>
               </div>
             </div>
+            <a href="#top">back to top</a>
           </div>
         </section>
         <section id="definition-DefaultQueryRuleQueryResponse" class="definition definition-object" data-traverse-target="definition-DefaultQueryRuleQueryResponse">
@@ -7075,6 +7708,7 @@ is <span class="hljs-keyword">an</span> all-<span class="hljs-keyword">or</span>
                 </html>
               </div>
             </div>
+            <a href="#top">back to top</a>
           </div>
         </section>
         <section id="definition-Event" class="definition definition-object" data-traverse-target="definition-Event">
@@ -7138,6 +7772,7 @@ is <span class="hljs-keyword">an</span> all-<span class="hljs-keyword">or</span>
                 </html>
               </div>
             </div>
+            <a href="#top">back to top</a>
           </div>
         </section>
         <section id="definition-EventAction" class="definition definition-object" data-traverse-target="definition-EventAction">
@@ -7188,6 +7823,7 @@ is <span class="hljs-keyword">an</span> all-<span class="hljs-keyword">or</span>
                 </html>
               </div>
             </div>
+            <a href="#top">back to top</a>
           </div>
         </section>
         <section id="definition-EventActionInput" class="definition definition-input-object" data-traverse-target="definition-EventActionInput">
@@ -7238,6 +7874,85 @@ is <span class="hljs-keyword">an</span> all-<span class="hljs-keyword">or</span>
                 </html>
               </div>
             </div>
+            <a href="#top">back to top</a>
+          </div>
+        </section>
+        <section id="definition-EventCounts" class="definition definition-object" data-traverse-target="definition-EventCounts">
+          <div class="definition-group-name">
+            <a href="#group-Types">Types</a>
+          </div>
+          <h2 class="definition-heading">EventCounts</h2>
+          <div class="doc-row">
+            <div class="doc-copy">
+              <div class="definition-properties doc-copy-section">
+                <h5>Fields</h5>
+                <table>
+                  <thead>
+                    <tr>
+                      <th>Field Name</th>
+                      <th>Description</th>
+                    </tr>
+                  </thead>
+                  <tbody>
+                    <tr>
+                      <td data-property-name=""><span class="property-name"><code>action</code></span> - <span class="property-type"><a href="#definition-String"><code>String</code></a></span>
+                      </td>
+                      <td>
+                      </td>
+                    </tr>
+                    <tr>
+                      <td data-property-name=""><span class="property-name"><code>category</code></span> - <span class="property-type"><a href="#definition-String"><code>String</code></a></span>
+                      </td>
+                      <td>
+                      </td>
+                    </tr>
+                    <tr>
+                      <td data-property-name=""><span class="property-name"><code>count</code></span> - <span class="property-type"><a href="#definition-Int"><code>Int!</code></a></span>
+                      </td>
+                      <td>
+                      </td>
+                    </tr>
+                    <tr>
+                      <td data-property-name=""><span class="property-name"><code>day</code></span> - <span class="property-type"><a href="#definition-String"><code>String!</code></a></span>
+                      </td>
+                      <td>
+                      </td>
+                    </tr>
+                    <tr>
+                      <td data-property-name=""><span class="property-name"><code>hour</code></span> - <span class="property-type"><a href="#definition-String"><code>String</code></a></span>
+                      </td>
+                      <td>
+                      </td>
+                    </tr>
+                    <tr>
+                      <td data-property-name=""><span class="property-name"><code>type</code></span> - <span class="property-type"><a href="#definition-String"><code>String</code></a></span>
+                      </td>
+                      <td>
+                      </td>
+                    </tr>
+                  </tbody>
+                </table>
+              </div>
+            </div>
+            <div class="doc-examples">
+              <div class="example-section example-section-is-code">
+                <h5>Example</h5>
+                <html>
+                  <head></head>
+                  <body><pre><code class="hljs language-json"><span class="hljs-punctuation">{</span>
+  <span class="hljs-attr">"action"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"abc123"</span><span class="hljs-punctuation">,</span>
+  <span class="hljs-attr">"category"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"xyz789"</span><span class="hljs-punctuation">,</span>
+  <span class="hljs-attr">"count"</span><span class="hljs-punctuation">:</span> <span class="hljs-number">123</span><span class="hljs-punctuation">,</span>
+  <span class="hljs-attr">"day"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"abc123"</span><span class="hljs-punctuation">,</span>
+  <span class="hljs-attr">"hour"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"abc123"</span><span class="hljs-punctuation">,</span>
+  <span class="hljs-attr">"type"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"abc123"</span>
+<span class="hljs-punctuation">}</span>
+</code></pre>
+                  </body>
+                </html>
+              </div>
+            </div>
+            <a href="#top">back to top</a>
           </div>
         </section>
         <section id="definition-EventInput" class="definition definition-input-object" data-traverse-target="definition-EventInput">
@@ -7296,7 +8011,7 @@ is <span class="hljs-keyword">an</span> all-<span class="hljs-keyword">or</span>
                   <head></head>
                   <body><pre><code class="hljs language-json"><span class="hljs-punctuation">{</span>
   <span class="hljs-attr">"action"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">EventActionInput</span><span class="hljs-punctuation">,</span>
-  <span class="hljs-attr">"notes"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"abc123"</span><span class="hljs-punctuation">,</span>
+  <span class="hljs-attr">"notes"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"xyz789"</span><span class="hljs-punctuation">,</span>
   <span class="hljs-attr">"targetType"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"SKU"</span><span class="hljs-punctuation">,</span>
   <span class="hljs-attr">"targetValue"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"xyz789"</span>
 <span class="hljs-punctuation">}</span>
@@ -7305,6 +8020,7 @@ is <span class="hljs-keyword">an</span> all-<span class="hljs-keyword">or</span>
                 </html>
               </div>
             </div>
+            <a href="#top">back to top</a>
           </div>
         </section>
         <section id="definition-EventTargetType" class="definition definition-enum" data-traverse-target="definition-EventTargetType">
@@ -7350,6 +8066,103 @@ is <span class="hljs-keyword">an</span> all-<span class="hljs-keyword">or</span>
                 </html>
               </div>
             </div>
+            <a href="#top">back to top</a>
+          </div>
+        </section>
+        <section id="definition-Eventing" class="definition definition-object" data-traverse-target="definition-Eventing">
+          <div class="definition-group-name">
+            <a href="#group-Types">Types</a>
+          </div>
+          <h2 class="definition-heading">Eventing</h2>
+          <div class="doc-row">
+            <div class="doc-copy">
+              <div class="definition-properties doc-copy-section">
+                <h5>Fields</h5>
+                <table>
+                  <thead>
+                    <tr>
+                      <th>Field Name</th>
+                      <th>Description</th>
+                    </tr>
+                  </thead>
+                  <tbody>
+                    <tr class="row-has-field-arguments">
+                      <td data-property-name=""><span class="property-name"><code>countsByDay</code></span> - <span class="property-type"><a href="#definition-EventCounts"><code>[EventCounts]</code></a></span>
+                      </td>
+                      <td>
+                        <p>Get all event counts aggregated by day for the given date range</p>
+                        <p>Parameters:</p>
+                        <ul>
+                          <li>from: The start timestamp to query from (required)</li>
+                          <li>to: The end timestamp to query to (optional, defaults to current timestamp)</li>
+                        </ul>
+                      </td>
+                    </tr>
+                    <tr class="row-field-arguments">
+                      <td colspan="2">
+                        <div class="field-arguments">
+                          <h5 class="field-arguments-heading"> Arguments </h5>
+                          <div class="field-argument-list">
+                            <div class="field-argument">
+                              <h6 class="field-argument-name"><span class="property-name"><code>from</code></span> - <span class="property-type"><a href="#definition-String"><code>String</code></a></span>
+                              </h6>
+                            </div>
+                            <div class="field-argument">
+                              <h6 class="field-argument-name"><span class="property-name"><code>to</code></span> - <span class="property-type"><a href="#definition-String"><code>String</code></a></span>
+                              </h6>
+                            </div>
+                          </div>
+                        </div>
+                      </td>
+                    </tr>
+                    <tr class="row-has-field-arguments">
+                      <td data-property-name=""><span class="property-name"><code>countsByHour</code></span> - <span class="property-type"><a href="#definition-EventCounts"><code>[EventCounts]</code></a></span>
+                      </td>
+                      <td>
+                        <p>Get event counts aggregated by hour for the given date range</p>
+                        <p>Parameters:</p>
+                        <ul>
+                          <li>from: The start timestamp to query from (required)</li>
+                          <li>to: The end timestamp to query to (optional, defaults to current timestamp)</li>
+                        </ul>
+                      </td>
+                    </tr>
+                    <tr class="row-field-arguments">
+                      <td colspan="2">
+                        <div class="field-arguments">
+                          <h5 class="field-arguments-heading"> Arguments </h5>
+                          <div class="field-argument-list">
+                            <div class="field-argument">
+                              <h6 class="field-argument-name"><span class="property-name"><code>from</code></span> - <span class="property-type"><a href="#definition-String"><code>String</code></a></span>
+                              </h6>
+                            </div>
+                            <div class="field-argument">
+                              <h6 class="field-argument-name"><span class="property-name"><code>to</code></span> - <span class="property-type"><a href="#definition-String"><code>String</code></a></span>
+                              </h6>
+                            </div>
+                          </div>
+                        </div>
+                      </td>
+                    </tr>
+                  </tbody>
+                </table>
+              </div>
+            </div>
+            <div class="doc-examples">
+              <div class="example-section example-section-is-code">
+                <h5>Example</h5>
+                <html>
+                  <head></head>
+                  <body><pre><code class="hljs language-json"><span class="hljs-punctuation">{</span>
+  <span class="hljs-attr">"countsByDay"</span><span class="hljs-punctuation">:</span> <span class="hljs-punctuation">[</span><span class="hljs-string">EventCounts</span><span class="hljs-punctuation">]</span><span class="hljs-punctuation">,</span>
+  <span class="hljs-attr">"countsByHour"</span><span class="hljs-punctuation">:</span> <span class="hljs-punctuation">[</span><span class="hljs-string">EventCounts</span><span class="hljs-punctuation">]</span>
+<span class="hljs-punctuation">}</span>
+</code></pre>
+                  </body>
+                </html>
+              </div>
+            </div>
+            <a href="#top">back to top</a>
           </div>
         </section>
         <section id="definition-FacetAggregationRange" class="definition definition-object" data-traverse-target="definition-FacetAggregationRange">
@@ -7394,12 +8207,13 @@ is <span class="hljs-keyword">an</span> all-<span class="hljs-keyword">or</span>
                 <h5>Example</h5>
                 <html>
                   <head></head>
-                  <body><pre><code class="hljs language-json"><span class="hljs-punctuation">{</span><span class="hljs-attr">"from"</span><span class="hljs-punctuation">:</span> <span class="hljs-number">123.45</span><span class="hljs-punctuation">,</span> <span class="hljs-attr">"to"</span><span class="hljs-punctuation">:</span> <span class="hljs-number">987.65</span><span class="hljs-punctuation">}</span>
+                  <body><pre><code class="hljs language-json"><span class="hljs-punctuation">{</span><span class="hljs-attr">"from"</span><span class="hljs-punctuation">:</span> <span class="hljs-number">987.65</span><span class="hljs-punctuation">,</span> <span class="hljs-attr">"to"</span><span class="hljs-punctuation">:</span> <span class="hljs-number">123.45</span><span class="hljs-punctuation">}</span>
 </code></pre>
                   </body>
                 </html>
               </div>
             </div>
+            <a href="#top">back to top</a>
           </div>
         </section>
         <section id="definition-FacetAggregationRangeInput" class="definition definition-input-object" data-traverse-target="definition-FacetAggregationRangeInput">
@@ -7446,12 +8260,13 @@ is <span class="hljs-keyword">an</span> all-<span class="hljs-keyword">or</span>
                 <h5>Example</h5>
                 <html>
                   <head></head>
-                  <body><pre><code class="hljs language-json"><span class="hljs-punctuation">{</span><span class="hljs-attr">"from"</span><span class="hljs-punctuation">:</span> <span class="hljs-number">987.65</span><span class="hljs-punctuation">,</span> <span class="hljs-attr">"to"</span><span class="hljs-punctuation">:</span> <span class="hljs-number">987.65</span><span class="hljs-punctuation">}</span>
+                  <body><pre><code class="hljs language-json"><span class="hljs-punctuation">{</span><span class="hljs-attr">"from"</span><span class="hljs-punctuation">:</span> <span class="hljs-number">123.45</span><span class="hljs-punctuation">,</span> <span class="hljs-attr">"to"</span><span class="hljs-punctuation">:</span> <span class="hljs-number">123.45</span><span class="hljs-punctuation">}</span>
 </code></pre>
                   </body>
                 </html>
               </div>
             </div>
+            <a href="#top">back to top</a>
           </div>
         </section>
         <section id="definition-FacetConfigAggregationType" class="definition definition-enum" data-traverse-target="definition-FacetConfigAggregationType">
@@ -7504,6 +8319,7 @@ is <span class="hljs-keyword">an</span> all-<span class="hljs-keyword">or</span>
                 </html>
               </div>
             </div>
+            <a href="#top">back to top</a>
           </div>
         </section>
         <section id="definition-FacetConfigDisplayType" class="definition definition-enum" data-traverse-target="definition-FacetConfigDisplayType">
@@ -7556,6 +8372,7 @@ is <span class="hljs-keyword">an</span> all-<span class="hljs-keyword">or</span>
                 </html>
               </div>
             </div>
+            <a href="#top">back to top</a>
           </div>
         </section>
         <section id="definition-FacetConfigurationInput" class="definition definition-input-object" data-traverse-target="definition-FacetConfigurationInput">
@@ -7663,22 +8480,23 @@ is <span class="hljs-keyword">an</span> all-<span class="hljs-keyword">or</span>
                   <body><pre><code class="hljs language-json"><span class="hljs-punctuation">{</span>
   <span class="hljs-attr">"aggregationRanges"</span><span class="hljs-punctuation">:</span> <span class="hljs-punctuation">[</span><span class="hljs-string">FacetAggregationRangeInput</span><span class="hljs-punctuation">]</span><span class="hljs-punctuation">,</span>
   <span class="hljs-attr">"aggregationType"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"RANGE_AGGREGATION"</span><span class="hljs-punctuation">,</span>
-  <span class="hljs-attr">"attributeCode"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"abc123"</span><span class="hljs-punctuation">,</span>
+  <span class="hljs-attr">"attributeCode"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"xyz789"</span><span class="hljs-punctuation">,</span>
   <span class="hljs-attr">"dataType"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"abc123"</span><span class="hljs-punctuation">,</span>
   <span class="hljs-attr">"facetType"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"ALWAYS_DISPLAYED"</span><span class="hljs-punctuation">,</span>
   <span class="hljs-attr">"frontendInput"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"xyz789"</span><span class="hljs-punctuation">,</span>
   <span class="hljs-attr">"maxValue"</span><span class="hljs-punctuation">:</span> <span class="hljs-number">987</span><span class="hljs-punctuation">,</span>
-  <span class="hljs-attr">"multiSelect"</span><span class="hljs-punctuation">:</span> <span class="hljs-literal"><span class="hljs-keyword">true</span></span><span class="hljs-punctuation">,</span>
+  <span class="hljs-attr">"multiSelect"</span><span class="hljs-punctuation">:</span> <span class="hljs-literal"><span class="hljs-keyword">false</span></span><span class="hljs-punctuation">,</span>
   <span class="hljs-attr">"multiSelectOperator"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"AND"</span><span class="hljs-punctuation">,</span>
-  <span class="hljs-attr">"numeric"</span><span class="hljs-punctuation">:</span> <span class="hljs-literal"><span class="hljs-keyword">false</span></span><span class="hljs-punctuation">,</span>
+  <span class="hljs-attr">"numeric"</span><span class="hljs-punctuation">:</span> <span class="hljs-literal"><span class="hljs-keyword">true</span></span><span class="hljs-punctuation">,</span>
   <span class="hljs-attr">"sortType"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"ALPHABETICAL"</span><span class="hljs-punctuation">,</span>
-  <span class="hljs-attr">"title"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"xyz789"</span>
+  <span class="hljs-attr">"title"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"abc123"</span>
 <span class="hljs-punctuation">}</span>
 </code></pre>
                   </body>
                 </html>
               </div>
             </div>
+            <a href="#top">back to top</a>
           </div>
         </section>
         <section id="definition-FacetConfigurationResponse" class="definition definition-object" data-traverse-target="definition-FacetConfigurationResponse">
@@ -7774,14 +8592,14 @@ is <span class="hljs-keyword">an</span> all-<span class="hljs-keyword">or</span>
                   <body><pre><code class="hljs language-json"><span class="hljs-punctuation">{</span>
   <span class="hljs-attr">"aggregationRanges"</span><span class="hljs-punctuation">:</span> <span class="hljs-punctuation">[</span><span class="hljs-string">FacetAggregationRange</span><span class="hljs-punctuation">]</span><span class="hljs-punctuation">,</span>
   <span class="hljs-attr">"aggregationType"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"RANGE_AGGREGATION"</span><span class="hljs-punctuation">,</span>
-  <span class="hljs-attr">"attributeCode"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"xyz789"</span><span class="hljs-punctuation">,</span>
-  <span class="hljs-attr">"dataType"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"xyz789"</span><span class="hljs-punctuation">,</span>
+  <span class="hljs-attr">"attributeCode"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"abc123"</span><span class="hljs-punctuation">,</span>
+  <span class="hljs-attr">"dataType"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"abc123"</span><span class="hljs-punctuation">,</span>
   <span class="hljs-attr">"facetType"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"ALWAYS_DISPLAYED"</span><span class="hljs-punctuation">,</span>
-  <span class="hljs-attr">"frontendInput"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"xyz789"</span><span class="hljs-punctuation">,</span>
+  <span class="hljs-attr">"frontendInput"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"abc123"</span><span class="hljs-punctuation">,</span>
   <span class="hljs-attr">"maxValue"</span><span class="hljs-punctuation">:</span> <span class="hljs-number">987</span><span class="hljs-punctuation">,</span>
-  <span class="hljs-attr">"multiSelect"</span><span class="hljs-punctuation">:</span> <span class="hljs-literal"><span class="hljs-keyword">true</span></span><span class="hljs-punctuation">,</span>
+  <span class="hljs-attr">"multiSelect"</span><span class="hljs-punctuation">:</span> <span class="hljs-literal"><span class="hljs-keyword">false</span></span><span class="hljs-punctuation">,</span>
   <span class="hljs-attr">"multiSelectOperator"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"AND"</span><span class="hljs-punctuation">,</span>
-  <span class="hljs-attr">"numeric"</span><span class="hljs-punctuation">:</span> <span class="hljs-literal"><span class="hljs-keyword">true</span></span><span class="hljs-punctuation">,</span>
+  <span class="hljs-attr">"numeric"</span><span class="hljs-punctuation">:</span> <span class="hljs-literal"><span class="hljs-keyword">false</span></span><span class="hljs-punctuation">,</span>
   <span class="hljs-attr">"sortType"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"ALPHABETICAL"</span><span class="hljs-punctuation">,</span>
   <span class="hljs-attr">"title"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"abc123"</span>
 <span class="hljs-punctuation">}</span>
@@ -7790,6 +8608,7 @@ is <span class="hljs-keyword">an</span> all-<span class="hljs-keyword">or</span>
                 </html>
               </div>
             </div>
+            <a href="#top">back to top</a>
           </div>
         </section>
         <section id="definition-FacetValuesSortType" class="definition definition-enum" data-traverse-target="definition-FacetValuesSortType">
@@ -7846,6 +8665,7 @@ is <span class="hljs-keyword">an</span> all-<span class="hljs-keyword">or</span>
                 </html>
               </div>
             </div>
+            <a href="#top">back to top</a>
           </div>
         </section>
         <section id="definition-FacetsConfigurationMutationResponse" class="definition definition-object" data-traverse-target="definition-FacetsConfigurationMutationResponse">
@@ -7883,12 +8703,13 @@ is <span class="hljs-keyword">an</span> all-<span class="hljs-keyword">or</span>
                 <h5>Example</h5>
                 <html>
                   <head></head>
-                  <body><pre><code class="hljs language-json"><span class="hljs-punctuation">{</span><span class="hljs-attr">"message"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"abc123"</span><span class="hljs-punctuation">}</span>
+                  <body><pre><code class="hljs language-json"><span class="hljs-punctuation">{</span><span class="hljs-attr">"message"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"xyz789"</span><span class="hljs-punctuation">}</span>
 </code></pre>
                   </body>
                 </html>
               </div>
             </div>
+            <a href="#top">back to top</a>
           </div>
         </section>
         <section id="definition-FacetsConfigurationQueryResponse" class="definition definition-object" data-traverse-target="definition-FacetsConfigurationQueryResponse">
@@ -7933,6 +8754,7 @@ is <span class="hljs-keyword">an</span> all-<span class="hljs-keyword">or</span>
                 </html>
               </div>
             </div>
+            <a href="#top">back to top</a>
           </div>
         </section>
         <section id="definition-FilterRuleRequest" class="definition definition-input-object" data-traverse-target="definition-FilterRuleRequest">
@@ -7986,7 +8808,7 @@ is <span class="hljs-keyword">an</span> all-<span class="hljs-keyword">or</span>
                   <head></head>
                   <body><pre><code class="hljs language-json"><span class="hljs-punctuation">{</span>
   <span class="hljs-attr">"conditions"</span><span class="hljs-punctuation">:</span> <span class="hljs-punctuation">[</span><span class="hljs-string">ConditionRequest</span><span class="hljs-punctuation">]</span><span class="hljs-punctuation">,</span>
-  <span class="hljs-attr">"name"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"xyz789"</span><span class="hljs-punctuation">,</span>
+  <span class="hljs-attr">"name"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"abc123"</span><span class="hljs-punctuation">,</span>
   <span class="hljs-attr">"type"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"EXCLUSION"</span>
 <span class="hljs-punctuation">}</span>
 </code></pre>
@@ -7994,6 +8816,7 @@ is <span class="hljs-keyword">an</span> all-<span class="hljs-keyword">or</span>
                 </html>
               </div>
             </div>
+            <a href="#top">back to top</a>
           </div>
         </section>
         <section id="definition-FilterRuleResponse" class="definition definition-object" data-traverse-target="definition-FilterRuleResponse">
@@ -8043,7 +8866,7 @@ is <span class="hljs-keyword">an</span> all-<span class="hljs-keyword">or</span>
                   <head></head>
                   <body><pre><code class="hljs language-json"><span class="hljs-punctuation">{</span>
   <span class="hljs-attr">"conditions"</span><span class="hljs-punctuation">:</span> <span class="hljs-punctuation">[</span><span class="hljs-string">ConditionResponse</span><span class="hljs-punctuation">]</span><span class="hljs-punctuation">,</span>
-  <span class="hljs-attr">"name"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"abc123"</span><span class="hljs-punctuation">,</span>
+  <span class="hljs-attr">"name"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"xyz789"</span><span class="hljs-punctuation">,</span>
   <span class="hljs-attr">"type"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"EXCLUSION"</span>
 <span class="hljs-punctuation">}</span>
 </code></pre>
@@ -8051,6 +8874,7 @@ is <span class="hljs-keyword">an</span> all-<span class="hljs-keyword">or</span>
                 </html>
               </div>
             </div>
+            <a href="#top">back to top</a>
           </div>
         </section>
         <section id="definition-FilterRuleType" class="definition definition-enum" data-traverse-target="definition-FilterRuleType">
@@ -8103,6 +8927,7 @@ is <span class="hljs-keyword">an</span> all-<span class="hljs-keyword">or</span>
                 </html>
               </div>
             </div>
+            <a href="#top">back to top</a>
           </div>
         </section>
         <section id="definition-Float" class="definition definition-scalar" data-traverse-target="definition-Float">
@@ -8122,12 +8947,13 @@ is <span class="hljs-keyword">an</span> all-<span class="hljs-keyword">or</span>
                 <h5>Example</h5>
                 <html>
                   <head></head>
-                  <body><pre><code class="hljs language-json"><span class="hljs-number">987.65</span>
+                  <body><pre><code class="hljs language-json"><span class="hljs-number">123.45</span>
 </code></pre>
                   </body>
                 </html>
               </div>
             </div>
+            <a href="#top">back to top</a>
           </div>
         </section>
         <section id="definition-ID" class="definition definition-scalar" data-traverse-target="definition-ID">
@@ -8153,6 +8979,57 @@ is <span class="hljs-keyword">an</span> all-<span class="hljs-keyword">or</span>
                 </html>
               </div>
             </div>
+            <a href="#top">back to top</a>
+          </div>
+        </section>
+        <section id="definition-Image" class="definition definition-object" data-traverse-target="definition-Image">
+          <div class="definition-group-name">
+            <a href="#group-Types">Types</a>
+          </div>
+          <h2 class="definition-heading">Image</h2>
+          <div class="doc-row">
+            <div class="doc-copy">
+              <div class="definition-properties doc-copy-section">
+                <h5>Fields</h5>
+                <table>
+                  <thead>
+                    <tr>
+                      <th>Field Name</th>
+                      <th>Description</th>
+                    </tr>
+                  </thead>
+                  <tbody>
+                    <tr>
+                      <td data-property-name=""><span class="property-name"><code>label</code></span> - <span class="property-type"><a href="#definition-String"><code>String</code></a></span>
+                      </td>
+                      <td>
+                      </td>
+                    </tr>
+                    <tr>
+                      <td data-property-name=""><span class="property-name"><code>url</code></span> - <span class="property-type"><a href="#definition-String"><code>String</code></a></span>
+                      </td>
+                      <td>
+                      </td>
+                    </tr>
+                  </tbody>
+                </table>
+              </div>
+            </div>
+            <div class="doc-examples">
+              <div class="example-section example-section-is-code">
+                <h5>Example</h5>
+                <html>
+                  <head></head>
+                  <body><pre><code class="hljs language-json"><span class="hljs-punctuation">{</span>
+  <span class="hljs-attr">"label"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"abc123"</span><span class="hljs-punctuation">,</span>
+  <span class="hljs-attr">"url"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"abc123"</span>
+<span class="hljs-punctuation">}</span>
+</code></pre>
+                  </body>
+                </html>
+              </div>
+            </div>
+            <a href="#top">back to top</a>
           </div>
         </section>
         <section id="definition-IndexLanguageConfiguration" class="definition definition-object" data-traverse-target="definition-IndexLanguageConfiguration">
@@ -8196,6 +9073,7 @@ is <span class="hljs-keyword">an</span> all-<span class="hljs-keyword">or</span>
                 </html>
               </div>
             </div>
+            <a href="#top">back to top</a>
           </div>
         </section>
         <section id="definition-IndexLanguageConfigurationInput" class="definition definition-input-object" data-traverse-target="definition-IndexLanguageConfigurationInput">
@@ -8240,6 +9118,7 @@ is <span class="hljs-keyword">an</span> all-<span class="hljs-keyword">or</span>
                 </html>
               </div>
             </div>
+            <a href="#top">back to top</a>
           </div>
         </section>
         <section id="definition-Int" class="definition definition-scalar" data-traverse-target="definition-Int">
@@ -8265,6 +9144,7 @@ is <span class="hljs-keyword">an</span> all-<span class="hljs-keyword">or</span>
                 </html>
               </div>
             </div>
+            <a href="#top">back to top</a>
           </div>
         </section>
         <section id="definition-IsOperatorRequest" class="definition definition-input-object" data-traverse-target="definition-IsOperatorRequest">
@@ -8309,12 +9189,13 @@ is <span class="hljs-keyword">an</span> all-<span class="hljs-keyword">or</span>
                 <h5>Example</h5>
                 <html>
                   <head></head>
-                  <body><pre><code class="hljs language-json"><span class="hljs-punctuation">{</span><span class="hljs-attr">"type"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"IS"</span><span class="hljs-punctuation">,</span> <span class="hljs-attr">"value"</span><span class="hljs-punctuation">:</span> <span class="hljs-literal"><span class="hljs-keyword">true</span></span><span class="hljs-punctuation">}</span>
+                  <body><pre><code class="hljs language-json"><span class="hljs-punctuation">{</span><span class="hljs-attr">"type"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"IS"</span><span class="hljs-punctuation">,</span> <span class="hljs-attr">"value"</span><span class="hljs-punctuation">:</span> <span class="hljs-literal"><span class="hljs-keyword">false</span></span><span class="hljs-punctuation">}</span>
 </code></pre>
                   </body>
                 </html>
               </div>
             </div>
+            <a href="#top">back to top</a>
           </div>
         </section>
         <section id="definition-IsOperatorResponse" class="definition definition-object" data-traverse-target="definition-IsOperatorResponse">
@@ -8365,6 +9246,7 @@ is <span class="hljs-keyword">an</span> all-<span class="hljs-keyword">or</span>
                 </html>
               </div>
             </div>
+            <a href="#top">back to top</a>
           </div>
         </section>
         <section id="definition-IsOperatorType" class="definition definition-enum" data-traverse-target="definition-IsOperatorType">
@@ -8417,6 +9299,7 @@ is <span class="hljs-keyword">an</span> all-<span class="hljs-keyword">or</span>
                 </html>
               </div>
             </div>
+            <a href="#top">back to top</a>
           </div>
         </section>
         <section id="definition-JoinOperatorType" class="definition definition-enum" data-traverse-target="definition-JoinOperatorType">
@@ -8469,6 +9352,7 @@ is <span class="hljs-keyword">an</span> all-<span class="hljs-keyword">or</span>
                 </html>
               </div>
             </div>
+            <a href="#top">back to top</a>
           </div>
         </section>
         <section id="definition-Language" class="definition definition-enum" data-traverse-target="definition-Language">
@@ -8741,6 +9625,7 @@ is <span class="hljs-keyword">an</span> all-<span class="hljs-keyword">or</span>
                 </html>
               </div>
             </div>
+            <a href="#top">back to top</a>
           </div>
         </section>
         <section id="definition-LanguageAnalyzer" class="definition definition-object" data-traverse-target="definition-LanguageAnalyzer">
@@ -8784,6 +9669,7 @@ is <span class="hljs-keyword">an</span> all-<span class="hljs-keyword">or</span>
                 </html>
               </div>
             </div>
+            <a href="#top">back to top</a>
           </div>
         </section>
         <section id="definition-LanguageAnalyzerInput" class="definition definition-input-object" data-traverse-target="definition-LanguageAnalyzerInput">
@@ -8831,6 +9717,134 @@ is <span class="hljs-keyword">an</span> all-<span class="hljs-keyword">or</span>
                 </html>
               </div>
             </div>
+            <a href="#top">back to top</a>
+          </div>
+        </section>
+        <section id="definition-LiveSearch" class="definition definition-object" data-traverse-target="definition-LiveSearch">
+          <div class="definition-group-name">
+            <a href="#group-Types">Types</a>
+          </div>
+          <h2 class="definition-heading">LiveSearch</h2>
+          <div class="doc-row">
+            <div class="doc-copy">
+              <div class="definition-properties doc-copy-section">
+                <h5>Fields</h5>
+                <table>
+                  <thead>
+                    <tr>
+                      <th>Field Name</th>
+                      <th>Description</th>
+                    </tr>
+                  </thead>
+                  <tbody>
+                    <tr>
+                      <td data-property-name=""><span class="property-name"><code>count</code></span> - <span class="property-type"><a href="#definition-Int"><code>Int!</code></a></span>
+                      </td>
+                      <td> Queries the Live Search data store for the count of products. This represents the number of products that are indexed and available for Live Search. </td>
+                    </tr>
+                    <tr class="row-has-field-arguments">
+                      <td data-property-name=""><span class="property-name"><code>productDetail</code></span> - <span class="property-type"><a href="#definition-ProductDetail"><code>ProductDetail</code></a></span>
+                      </td>
+                      <td>
+                        <p>Queries the Live Search data store for detailed product information for a given SKU.</p>
+                        <p>Parameters:</p>
+                        <ul>
+                          <li>sku: The SKU of the product to retrieve (required)</li>
+                        </ul>
+                      </td>
+                    </tr>
+                    <tr class="row-field-arguments">
+                      <td colspan="2">
+                        <div class="field-arguments">
+                          <h5 class="field-arguments-heading"> Arguments </h5>
+                          <div class="field-argument-list">
+                            <div class="field-argument">
+                              <h6 class="field-argument-name"><span class="property-name"><code>sku</code></span> - <span class="property-type"><a href="#definition-String"><code>String!</code></a></span>
+                              </h6>
+                            </div>
+                          </div>
+                        </div>
+                      </td>
+                    </tr>
+                    <tr class="row-has-field-arguments">
+                      <td data-property-name=""><span class="property-name"><code>productList</code></span> - <span class="property-type"><a href="#definition-ProductList"><code>ProductList!</code></a></span>
+                      </td>
+                      <td>
+                        <p>Queries the Live Search data store for a list of products indexed. This represents the list of products that are indexed and available for Live Search. The product list is sorted by last indexed timestamp in descending order.</p>
+                        <p>Parameters:</p>
+                        <ul>
+                          <li>searchTerm: The search term to filter the product list by (optional)</li>
+                          <li>scrollId: The scroll ID to continue a previous search (optional)</li>
+                          <li>size: The number of products to return (optional, default: 50)</li>
+                        </ul>
+                      </td>
+                    </tr>
+                    <tr class="row-field-arguments">
+                      <td colspan="2">
+                        <div class="field-arguments">
+                          <h5 class="field-arguments-heading"> Arguments </h5>
+                          <div class="field-argument-list">
+                            <div class="field-argument">
+                              <h6 class="field-argument-name"><span class="property-name"><code>scrollId</code></span> - <span class="property-type"><a href="#definition-String"><code>String</code></a></span>
+                              </h6>
+                            </div>
+                            <div class="field-argument">
+                              <h6 class="field-argument-name"><span class="property-name"><code>searchTerm</code></span> - <span class="property-type"><a href="#definition-String"><code>String</code></a></span>
+                              </h6>
+                            </div>
+                            <div class="field-argument">
+                              <h6 class="field-argument-name"><span class="property-name"><code>size</code></span> - <span class="property-type"><a href="#definition-Int"><code>Int</code></a></span>
+                              </h6>
+                            </div>
+                          </div>
+                        </div>
+                      </td>
+                    </tr>
+                    <tr class="row-has-field-arguments">
+                      <td data-property-name=""><span class="property-name"><code>since</code></span> - <span class="property-type"><a href="#definition-Since"><code>Since!</code></a></span>
+                      </td>
+                      <td>
+                        <p>Queries the Live Search data store for the number of products indexed since a given datetime.</p>
+                        <p>Parameters:</p>
+                        <ul>
+                          <li>datetime: The start datetime to query from (required)</li>
+                        </ul>
+                      </td>
+                    </tr>
+                    <tr class="row-field-arguments">
+                      <td colspan="2">
+                        <div class="field-arguments">
+                          <h5 class="field-arguments-heading"> Arguments </h5>
+                          <div class="field-argument-list">
+                            <div class="field-argument">
+                              <h6 class="field-argument-name"><span class="property-name"><code>datetime</code></span> - <span class="property-type"><a href="#definition-String"><code>String!</code></a></span>
+                              </h6>
+                            </div>
+                          </div>
+                        </div>
+                      </td>
+                    </tr>
+                  </tbody>
+                </table>
+              </div>
+            </div>
+            <div class="doc-examples">
+              <div class="example-section example-section-is-code">
+                <h5>Example</h5>
+                <html>
+                  <head></head>
+                  <body><pre><code class="hljs language-json"><span class="hljs-punctuation">{</span>
+  <span class="hljs-attr">"count"</span><span class="hljs-punctuation">:</span> <span class="hljs-number">987</span><span class="hljs-punctuation">,</span>
+  <span class="hljs-attr">"productDetail"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">ProductDetail</span><span class="hljs-punctuation">,</span>
+  <span class="hljs-attr">"productList"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">ProductList</span><span class="hljs-punctuation">,</span>
+  <span class="hljs-attr">"since"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">Since</span>
+<span class="hljs-punctuation">}</span>
+</code></pre>
+                  </body>
+                </html>
+              </div>
+            </div>
+            <a href="#top">back to top</a>
           </div>
         </section>
         <section id="definition-ManualPriceBucketConfiguration" class="definition definition-object" data-traverse-target="definition-ManualPriceBucketConfiguration">
@@ -8873,12 +9887,13 @@ is <span class="hljs-keyword">an</span> all-<span class="hljs-keyword">or</span>
                 <h5>Example</h5>
                 <html>
                   <head></head>
-                  <body><pre><code class="hljs language-json"><span class="hljs-punctuation">{</span><span class="hljs-attr">"interval"</span><span class="hljs-punctuation">:</span> <span class="hljs-number">123</span><span class="hljs-punctuation">,</span> <span class="hljs-attr">"numSelections"</span><span class="hljs-punctuation">:</span> <span class="hljs-number">123</span><span class="hljs-punctuation">}</span>
+                  <body><pre><code class="hljs language-json"><span class="hljs-punctuation">{</span><span class="hljs-attr">"interval"</span><span class="hljs-punctuation">:</span> <span class="hljs-number">123</span><span class="hljs-punctuation">,</span> <span class="hljs-attr">"numSelections"</span><span class="hljs-punctuation">:</span> <span class="hljs-number">987</span><span class="hljs-punctuation">}</span>
 </code></pre>
                   </body>
                 </html>
               </div>
             </div>
+            <a href="#top">back to top</a>
           </div>
         </section>
         <section id="definition-ManualPriceBucketConfigurationInput" class="definition definition-input-object" data-traverse-target="definition-ManualPriceBucketConfigurationInput">
@@ -8929,6 +9944,7 @@ is <span class="hljs-keyword">an</span> all-<span class="hljs-keyword">or</span>
                 </html>
               </div>
             </div>
+            <a href="#top">back to top</a>
           </div>
         </section>
         <section id="definition-MetadataBooleanCondition" class="definition definition-input-object" data-traverse-target="definition-MetadataBooleanCondition">
@@ -8973,12 +9989,13 @@ is <span class="hljs-keyword">an</span> all-<span class="hljs-keyword">or</span>
                 <h5>Example</h5>
                 <html>
                   <head></head>
-                  <body><pre><code class="hljs language-json"><span class="hljs-punctuation">{</span><span class="hljs-attr">"filterField"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"FILTERABLE"</span><span class="hljs-punctuation">,</span> <span class="hljs-attr">"value"</span><span class="hljs-punctuation">:</span> <span class="hljs-literal"><span class="hljs-keyword">true</span></span><span class="hljs-punctuation">}</span>
+                  <body><pre><code class="hljs language-json"><span class="hljs-punctuation">{</span><span class="hljs-attr">"filterField"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"FILTERABLE"</span><span class="hljs-punctuation">,</span> <span class="hljs-attr">"value"</span><span class="hljs-punctuation">:</span> <span class="hljs-literal"><span class="hljs-keyword">false</span></span><span class="hljs-punctuation">}</span>
 </code></pre>
                   </body>
                 </html>
               </div>
             </div>
+            <a href="#top">back to top</a>
           </div>
         </section>
         <section id="definition-MetadataBooleanFieldFilterEnum" class="definition definition-enum" data-traverse-target="definition-MetadataBooleanFieldFilterEnum">
@@ -9031,6 +10048,7 @@ is <span class="hljs-keyword">an</span> all-<span class="hljs-keyword">or</span>
                 </html>
               </div>
             </div>
+            <a href="#top">back to top</a>
           </div>
         </section>
         <section id="definition-MetadataBooleanFilter" class="definition definition-input-object" data-traverse-target="definition-MetadataBooleanFilter">
@@ -9084,6 +10102,7 @@ is <span class="hljs-keyword">an</span> all-<span class="hljs-keyword">or</span>
                 </html>
               </div>
             </div>
+            <a href="#top">back to top</a>
           </div>
         </section>
         <section id="definition-MetadataFilterOperatorEnum" class="definition definition-enum" data-traverse-target="definition-MetadataFilterOperatorEnum">
@@ -9136,6 +10155,7 @@ is <span class="hljs-keyword">an</span> all-<span class="hljs-keyword">or</span>
                 </html>
               </div>
             </div>
+            <a href="#top">back to top</a>
           </div>
         </section>
         <section id="definition-Metrics" class="definition definition-object" data-traverse-target="definition-Metrics">
@@ -9226,14 +10246,14 @@ is <span class="hljs-keyword">an</span> all-<span class="hljs-keyword">or</span>
                   <head></head>
                   <body><pre><code class="hljs language-json"><span class="hljs-punctuation">{</span>
   <span class="hljs-attr">"clickThroughRate"</span><span class="hljs-punctuation">:</span> <span class="hljs-number">987.65</span><span class="hljs-punctuation">,</span>
-  <span class="hljs-attr">"clicks"</span><span class="hljs-punctuation">:</span> <span class="hljs-number">987</span><span class="hljs-punctuation">,</span>
+  <span class="hljs-attr">"clicks"</span><span class="hljs-punctuation">:</span> <span class="hljs-number">123</span><span class="hljs-punctuation">,</span>
   <span class="hljs-attr">"impressions"</span><span class="hljs-punctuation">:</span> <span class="hljs-number">987</span><span class="hljs-punctuation">,</span>
   <span class="hljs-attr">"lifetimeRevenue"</span><span class="hljs-punctuation">:</span> <span class="hljs-number">123.45</span><span class="hljs-punctuation">,</span>
-  <span class="hljs-attr">"period"</span><span class="hljs-punctuation">:</span> <span class="hljs-number">123</span><span class="hljs-punctuation">,</span>
-  <span class="hljs-attr">"revenue"</span><span class="hljs-punctuation">:</span> <span class="hljs-number">987.65</span><span class="hljs-punctuation">,</span>
-  <span class="hljs-attr">"unitId"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"abc123"</span><span class="hljs-punctuation">,</span>
-  <span class="hljs-attr">"viewability"</span><span class="hljs-punctuation">:</span> <span class="hljs-number">123.45</span><span class="hljs-punctuation">,</span>
-  <span class="hljs-attr">"viewableClickThroughRate"</span><span class="hljs-punctuation">:</span> <span class="hljs-number">123.45</span><span class="hljs-punctuation">,</span>
+  <span class="hljs-attr">"period"</span><span class="hljs-punctuation">:</span> <span class="hljs-number">987</span><span class="hljs-punctuation">,</span>
+  <span class="hljs-attr">"revenue"</span><span class="hljs-punctuation">:</span> <span class="hljs-number">123.45</span><span class="hljs-punctuation">,</span>
+  <span class="hljs-attr">"unitId"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"xyz789"</span><span class="hljs-punctuation">,</span>
+  <span class="hljs-attr">"viewability"</span><span class="hljs-punctuation">:</span> <span class="hljs-number">987.65</span><span class="hljs-punctuation">,</span>
+  <span class="hljs-attr">"viewableClickThroughRate"</span><span class="hljs-punctuation">:</span> <span class="hljs-number">987.65</span><span class="hljs-punctuation">,</span>
   <span class="hljs-attr">"viewableImpressions"</span><span class="hljs-punctuation">:</span> <span class="hljs-number">987</span><span class="hljs-punctuation">,</span>
   <span class="hljs-attr">"views"</span><span class="hljs-punctuation">:</span> <span class="hljs-number">987</span>
 <span class="hljs-punctuation">}</span>
@@ -9242,6 +10262,7 @@ is <span class="hljs-keyword">an</span> all-<span class="hljs-keyword">or</span>
                 </html>
               </div>
             </div>
+            <a href="#top">back to top</a>
           </div>
         </section>
         <section id="definition-MultiSelectOperator" class="definition definition-enum" data-traverse-target="definition-MultiSelectOperator">
@@ -9294,6 +10315,7 @@ is <span class="hljs-keyword">an</span> all-<span class="hljs-keyword">or</span>
                 </html>
               </div>
             </div>
+            <a href="#top">back to top</a>
           </div>
         </section>
         <section id="definition-NumericOperatorRequest" class="definition definition-input-object" data-traverse-target="definition-NumericOperatorRequest">
@@ -9338,6 +10360,7 @@ is <span class="hljs-keyword">an</span> all-<span class="hljs-keyword">or</span>
                 </html>
               </div>
             </div>
+            <a href="#top">back to top</a>
           </div>
         </section>
         <section id="definition-NumericOperatorResponse" class="definition definition-object" data-traverse-target="definition-NumericOperatorResponse">
@@ -9382,6 +10405,7 @@ is <span class="hljs-keyword">an</span> all-<span class="hljs-keyword">or</span>
                 </html>
               </div>
             </div>
+            <a href="#top">back to top</a>
           </div>
         </section>
         <section id="definition-NumericOperatorType" class="definition definition-enum" data-traverse-target="definition-NumericOperatorType">
@@ -9434,6 +10458,7 @@ is <span class="hljs-keyword">an</span> all-<span class="hljs-keyword">or</span>
                 </html>
               </div>
             </div>
+            <a href="#top">back to top</a>
           </div>
         </section>
         <section id="definition-OperatorRequest" class="definition definition-input-object" data-traverse-target="definition-OperatorRequest">
@@ -9508,6 +10533,7 @@ is <span class="hljs-keyword">an</span> all-<span class="hljs-keyword">or</span>
                 </html>
               </div>
             </div>
+            <a href="#top">back to top</a>
           </div>
         </section>
         <section id="definition-OperatorResponse" class="definition definition-object" data-traverse-target="definition-OperatorResponse">
@@ -9577,6 +10603,7 @@ is <span class="hljs-keyword">an</span> all-<span class="hljs-keyword">or</span>
                 </html>
               </div>
             </div>
+            <a href="#top">back to top</a>
           </div>
         </section>
         <section id="definition-PolicyResponse" class="definition definition-object" data-traverse-target="definition-PolicyResponse">
@@ -9642,16 +10669,17 @@ is <span class="hljs-keyword">an</span> all-<span class="hljs-keyword">or</span>
                   <body><pre><code class="hljs language-json"><span class="hljs-punctuation">{</span>
   <span class="hljs-attr">"actions"</span><span class="hljs-punctuation">:</span> <span class="hljs-punctuation">[</span><span class="hljs-string">ActionResponse</span><span class="hljs-punctuation">]</span><span class="hljs-punctuation">,</span>
   <span class="hljs-attr">"createdAt"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"abc123"</span><span class="hljs-punctuation">,</span>
-  <span class="hljs-attr">"mandatory"</span><span class="hljs-punctuation">:</span> <span class="hljs-literal"><span class="hljs-keyword">false</span></span><span class="hljs-punctuation">,</span>
+  <span class="hljs-attr">"mandatory"</span><span class="hljs-punctuation">:</span> <span class="hljs-literal"><span class="hljs-keyword">true</span></span><span class="hljs-punctuation">,</span>
   <span class="hljs-attr">"name"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"abc123"</span><span class="hljs-punctuation">,</span>
-  <span class="hljs-attr">"policyId"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"abc123"</span><span class="hljs-punctuation">,</span>
-  <span class="hljs-attr">"updatedAt"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"xyz789"</span>
+  <span class="hljs-attr">"policyId"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"xyz789"</span><span class="hljs-punctuation">,</span>
+  <span class="hljs-attr">"updatedAt"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"abc123"</span>
 <span class="hljs-punctuation">}</span>
 </code></pre>
                   </body>
                 </html>
               </div>
             </div>
+            <a href="#top">back to top</a>
           </div>
         </section>
         <section id="definition-PopularSkuResponse" class="definition definition-object" data-traverse-target="definition-PopularSkuResponse">
@@ -9714,13 +10742,64 @@ is <span class="hljs-keyword">an</span> all-<span class="hljs-keyword">or</span>
   <span class="hljs-attr">"impressions"</span><span class="hljs-punctuation">:</span> <span class="hljs-number">123</span><span class="hljs-punctuation">,</span>
   <span class="hljs-attr">"productName"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"abc123"</span><span class="hljs-punctuation">,</span>
   <span class="hljs-attr">"revenue"</span><span class="hljs-punctuation">:</span> <span class="hljs-number">987.65</span><span class="hljs-punctuation">,</span>
-  <span class="hljs-attr">"topSku"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"abc123"</span>
+  <span class="hljs-attr">"topSku"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"xyz789"</span>
 <span class="hljs-punctuation">}</span>
 </code></pre>
                   </body>
                 </html>
               </div>
             </div>
+            <a href="#top">back to top</a>
+          </div>
+        </section>
+        <section id="definition-Price" class="definition definition-object" data-traverse-target="definition-Price">
+          <div class="definition-group-name">
+            <a href="#group-Types">Types</a>
+          </div>
+          <h2 class="definition-heading">Price</h2>
+          <div class="doc-row">
+            <div class="doc-copy">
+              <div class="definition-properties doc-copy-section">
+                <h5>Fields</h5>
+                <table>
+                  <thead>
+                    <tr>
+                      <th>Field Name</th>
+                      <th>Description</th>
+                    </tr>
+                  </thead>
+                  <tbody>
+                    <tr>
+                      <td data-property-name=""><span class="property-name"><code>finalPrice</code></span> - <span class="property-type"><a href="#definition-BigDecimal"><code>BigDecimal</code></a></span>
+                      </td>
+                      <td>
+                      </td>
+                    </tr>
+                    <tr>
+                      <td data-property-name=""><span class="property-name"><code>regularPrice</code></span> - <span class="property-type"><a href="#definition-BigDecimal"><code>BigDecimal</code></a></span>
+                      </td>
+                      <td>
+                      </td>
+                    </tr>
+                  </tbody>
+                </table>
+              </div>
+            </div>
+            <div class="doc-examples">
+              <div class="example-section example-section-is-code">
+                <h5>Example</h5>
+                <html>
+                  <head></head>
+                  <body><pre><code class="hljs language-json"><span class="hljs-punctuation">{</span>
+  <span class="hljs-attr">"finalPrice"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">BigDecimal</span><span class="hljs-punctuation">,</span>
+  <span class="hljs-attr">"regularPrice"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">BigDecimal</span>
+<span class="hljs-punctuation">}</span>
+</code></pre>
+                  </body>
+                </html>
+              </div>
+            </div>
+            <a href="#top">back to top</a>
           </div>
         </section>
         <section id="definition-PriceBucketConfiguration" class="definition definition-interface" data-traverse-target="definition-PriceBucketConfiguration">
@@ -9782,6 +10861,7 @@ is <span class="hljs-keyword">an</span> all-<span class="hljs-keyword">or</span>
                 </html>
               </div>
             </div>
+            <a href="#top">back to top</a>
           </div>
         </section>
         <section id="definition-PriceBucketConfigurationInput" class="definition definition-input-object" data-traverse-target="definition-PriceBucketConfigurationInput">
@@ -9835,6 +10915,7 @@ is <span class="hljs-keyword">an</span> all-<span class="hljs-keyword">or</span>
                 </html>
               </div>
             </div>
+            <a href="#top">back to top</a>
           </div>
         </section>
         <section id="definition-PriceBucketType" class="definition definition-enum" data-traverse-target="definition-PriceBucketType">
@@ -9887,6 +10968,54 @@ is <span class="hljs-keyword">an</span> all-<span class="hljs-keyword">or</span>
                 </html>
               </div>
             </div>
+            <a href="#top">back to top</a>
+          </div>
+        </section>
+        <section id="definition-PriceWrapper" class="definition definition-object" data-traverse-target="definition-PriceWrapper">
+          <div class="definition-group-name">
+            <a href="#group-Types">Types</a>
+          </div>
+          <h2 class="definition-heading">PriceWrapper</h2>
+          <div class="doc-row">
+            <div class="doc-copy">
+              <div class="definition-properties doc-copy-section">
+                <h5>Fields</h5>
+                <table>
+                  <thead>
+                    <tr>
+                      <th>Field Name</th>
+                      <th>Description</th>
+                    </tr>
+                  </thead>
+                  <tbody>
+                    <tr>
+                      <td data-property-name=""><span class="property-name"><code>maximum</code></span> - <span class="property-type"><a href="#definition-Price"><code>Price</code></a></span>
+                      </td>
+                      <td>
+                      </td>
+                    </tr>
+                    <tr>
+                      <td data-property-name=""><span class="property-name"><code>minimum</code></span> - <span class="property-type"><a href="#definition-Price"><code>Price</code></a></span>
+                      </td>
+                      <td>
+                      </td>
+                    </tr>
+                  </tbody>
+                </table>
+              </div>
+            </div>
+            <div class="doc-examples">
+              <div class="example-section example-section-is-code">
+                <h5>Example</h5>
+                <html>
+                  <head></head>
+                  <body><pre><code class="hljs language-json"><span class="hljs-punctuation">{</span><span class="hljs-attr">"maximum"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">Price</span><span class="hljs-punctuation">,</span> <span class="hljs-attr">"minimum"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">Price</span><span class="hljs-punctuation">}</span>
+</code></pre>
+                  </body>
+                </html>
+              </div>
+            </div>
+            <a href="#top">back to top</a>
           </div>
         </section>
         <section id="definition-ProductAttributeMetadataQueryResponse" class="definition definition-object" data-traverse-target="definition-ProductAttributeMetadataQueryResponse">
@@ -9930,6 +11059,7 @@ is <span class="hljs-keyword">an</span> all-<span class="hljs-keyword">or</span>
                 </html>
               </div>
             </div>
+            <a href="#top">back to top</a>
           </div>
         </section>
         <section id="definition-ProductAttributeMetadataResponse" class="definition definition-object" data-traverse-target="definition-ProductAttributeMetadataResponse">
@@ -10064,31 +11194,457 @@ is <span class="hljs-keyword">an</span> all-<span class="hljs-keyword">or</span>
                   <head></head>
                   <body><pre><code class="hljs language-json"><span class="hljs-punctuation">{</span>
   <span class="hljs-attr">"attributeCode"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"xyz789"</span><span class="hljs-punctuation">,</span>
-  <span class="hljs-attr">"dataType"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"xyz789"</span><span class="hljs-punctuation">,</span>
+  <span class="hljs-attr">"dataType"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"abc123"</span><span class="hljs-punctuation">,</span>
   <span class="hljs-attr">"deleted"</span><span class="hljs-punctuation">:</span> <span class="hljs-literal"><span class="hljs-keyword">false</span></span><span class="hljs-punctuation">,</span>
-  <span class="hljs-attr">"filterable"</span><span class="hljs-punctuation">:</span> <span class="hljs-literal"><span class="hljs-keyword">false</span></span><span class="hljs-punctuation">,</span>
-  <span class="hljs-attr">"filterableInSearch"</span><span class="hljs-punctuation">:</span> <span class="hljs-literal"><span class="hljs-keyword">true</span></span><span class="hljs-punctuation">,</span>
+  <span class="hljs-attr">"filterable"</span><span class="hljs-punctuation">:</span> <span class="hljs-literal"><span class="hljs-keyword">true</span></span><span class="hljs-punctuation">,</span>
+  <span class="hljs-attr">"filterableInSearch"</span><span class="hljs-punctuation">:</span> <span class="hljs-literal"><span class="hljs-keyword">false</span></span><span class="hljs-punctuation">,</span>
   <span class="hljs-attr">"frontendInput"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"xyz789"</span><span class="hljs-punctuation">,</span>
-  <span class="hljs-attr">"global"</span><span class="hljs-punctuation">:</span> <span class="hljs-literal"><span class="hljs-keyword">true</span></span><span class="hljs-punctuation">,</span>
+  <span class="hljs-attr">"global"</span><span class="hljs-punctuation">:</span> <span class="hljs-literal"><span class="hljs-keyword">false</span></span><span class="hljs-punctuation">,</span>
   <span class="hljs-attr">"label"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"xyz789"</span><span class="hljs-punctuation">,</span>
   <span class="hljs-attr">"multiSelect"</span><span class="hljs-punctuation">:</span> <span class="hljs-literal"><span class="hljs-keyword">true</span></span><span class="hljs-punctuation">,</span>
-  <span class="hljs-attr">"numeric"</span><span class="hljs-punctuation">:</span> <span class="hljs-literal"><span class="hljs-keyword">true</span></span><span class="hljs-punctuation">,</span>
+  <span class="hljs-attr">"numeric"</span><span class="hljs-punctuation">:</span> <span class="hljs-literal"><span class="hljs-keyword">false</span></span><span class="hljs-punctuation">,</span>
   <span class="hljs-attr">"required"</span><span class="hljs-punctuation">:</span> <span class="hljs-literal"><span class="hljs-keyword">true</span></span><span class="hljs-punctuation">,</span>
-  <span class="hljs-attr">"searchWeight"</span><span class="hljs-punctuation">:</span> <span class="hljs-number">987.65</span><span class="hljs-punctuation">,</span>
-  <span class="hljs-attr">"searchable"</span><span class="hljs-punctuation">:</span> <span class="hljs-literal"><span class="hljs-keyword">true</span></span><span class="hljs-punctuation">,</span>
-  <span class="hljs-attr">"sortable"</span><span class="hljs-punctuation">:</span> <span class="hljs-literal"><span class="hljs-keyword">false</span></span><span class="hljs-punctuation">,</span>
+  <span class="hljs-attr">"searchWeight"</span><span class="hljs-punctuation">:</span> <span class="hljs-number">123.45</span><span class="hljs-punctuation">,</span>
+  <span class="hljs-attr">"searchable"</span><span class="hljs-punctuation">:</span> <span class="hljs-literal"><span class="hljs-keyword">false</span></span><span class="hljs-punctuation">,</span>
+  <span class="hljs-attr">"sortable"</span><span class="hljs-punctuation">:</span> <span class="hljs-literal"><span class="hljs-keyword">true</span></span><span class="hljs-punctuation">,</span>
   <span class="hljs-attr">"unique"</span><span class="hljs-punctuation">:</span> <span class="hljs-literal"><span class="hljs-keyword">false</span></span><span class="hljs-punctuation">,</span>
-  <span class="hljs-attr">"usedForRules"</span><span class="hljs-punctuation">:</span> <span class="hljs-literal"><span class="hljs-keyword">false</span></span><span class="hljs-punctuation">,</span>
-  <span class="hljs-attr">"visible"</span><span class="hljs-punctuation">:</span> <span class="hljs-literal"><span class="hljs-keyword">false</span></span><span class="hljs-punctuation">,</span>
-  <span class="hljs-attr">"visibleInCompareList"</span><span class="hljs-punctuation">:</span> <span class="hljs-literal"><span class="hljs-keyword">false</span></span><span class="hljs-punctuation">,</span>
+  <span class="hljs-attr">"usedForRules"</span><span class="hljs-punctuation">:</span> <span class="hljs-literal"><span class="hljs-keyword">true</span></span><span class="hljs-punctuation">,</span>
+  <span class="hljs-attr">"visible"</span><span class="hljs-punctuation">:</span> <span class="hljs-literal"><span class="hljs-keyword">true</span></span><span class="hljs-punctuation">,</span>
+  <span class="hljs-attr">"visibleInCompareList"</span><span class="hljs-punctuation">:</span> <span class="hljs-literal"><span class="hljs-keyword">true</span></span><span class="hljs-punctuation">,</span>
   <span class="hljs-attr">"visibleInListing"</span><span class="hljs-punctuation">:</span> <span class="hljs-literal"><span class="hljs-keyword">false</span></span><span class="hljs-punctuation">,</span>
-  <span class="hljs-attr">"visibleInSearch"</span><span class="hljs-punctuation">:</span> <span class="hljs-literal"><span class="hljs-keyword">true</span></span>
+  <span class="hljs-attr">"visibleInSearch"</span><span class="hljs-punctuation">:</span> <span class="hljs-literal"><span class="hljs-keyword">false</span></span>
 <span class="hljs-punctuation">}</span>
 </code></pre>
                   </body>
                 </html>
               </div>
             </div>
+            <a href="#top">back to top</a>
+          </div>
+        </section>
+        <section id="definition-ProductDetail" class="definition definition-object" data-traverse-target="definition-ProductDetail">
+          <div class="definition-group-name">
+            <a href="#group-Types">Types</a>
+          </div>
+          <h2 class="definition-heading">ProductDetail</h2>
+          <div class="doc-row">
+            <div class="doc-copy">
+              <div class="definition-description doc-copy-section">
+                <h5>Description</h5>
+                <p>Represents product detail information for a given SKU from the destination system.</p>
+              </div>
+              <div class="definition-properties doc-copy-section">
+                <h5>Fields</h5>
+                <table>
+                  <thead>
+                    <tr>
+                      <th>Field Name</th>
+                      <th>Description</th>
+                    </tr>
+                  </thead>
+                  <tbody>
+                    <tr>
+                      <td data-property-name=""><span class="property-name"><code>attributes</code></span> - <span class="property-type"><a href="#definition-String"><code>[String]</code></a></span>
+                      </td>
+                      <td>
+                      </td>
+                    </tr>
+                    <tr>
+                      <td data-property-name=""><span class="property-name"><code>currency</code></span> - <span class="property-type"><a href="#definition-String"><code>String</code></a></span>
+                      </td>
+                      <td>
+                      </td>
+                    </tr>
+                    <tr>
+                      <td data-property-name=""><span class="property-name"><code>description</code></span> - <span class="property-type"><a href="#definition-String"><code>String</code></a></span>
+                      </td>
+                      <td>
+                      </td>
+                    </tr>
+                    <tr>
+                      <td data-property-name=""><span class="property-name"><code>image</code></span> - <span class="property-type"><a href="#definition-Image"><code>Image</code></a></span>
+                      </td>
+                      <td>
+                      </td>
+                    </tr>
+                    <tr>
+                      <td data-property-name=""><span class="property-name"><code>inStock</code></span> - <span class="property-type"><a href="#definition-Boolean"><code>Boolean</code></a></span>
+                      </td>
+                      <td>
+                      </td>
+                    </tr>
+                    <tr>
+                      <td data-property-name=""><span class="property-name"><code>lastIndexedTs</code></span> - <span class="property-type"><a href="#definition-String"><code>String</code></a></span>
+                      </td>
+                      <td>
+                      </td>
+                    </tr>
+                    <tr>
+                      <td data-property-name=""><span class="property-name"><code>lowStock</code></span> - <span class="property-type"><a href="#definition-Boolean"><code>Boolean</code></a></span>
+                      </td>
+                      <td>
+                      </td>
+                    </tr>
+                    <tr>
+                      <td data-property-name=""><span class="property-name"><code>metaDescription</code></span> - <span class="property-type"><a href="#definition-String"><code>String</code></a></span>
+                      </td>
+                      <td>
+                      </td>
+                    </tr>
+                    <tr>
+                      <td data-property-name=""><span class="property-name"><code>metaKeyword</code></span> - <span class="property-type"><a href="#definition-String"><code>String</code></a></span>
+                      </td>
+                      <td>
+                      </td>
+                    </tr>
+                    <tr>
+                      <td data-property-name=""><span class="property-name"><code>metaTitle</code></span> - <span class="property-type"><a href="#definition-String"><code>String</code></a></span>
+                      </td>
+                      <td>
+                      </td>
+                    </tr>
+                    <tr>
+                      <td data-property-name=""><span class="property-name"><code>name</code></span> - <span class="property-type"><a href="#definition-String"><code>String!</code></a></span>
+                      </td>
+                      <td>
+                      </td>
+                    </tr>
+                    <tr>
+                      <td data-property-name=""><span class="property-name"><code>productId</code></span> - <span class="property-type"><a href="#definition-Int"><code>Int</code></a></span>
+                      </td>
+                      <td>
+                      </td>
+                    </tr>
+                    <tr>
+                      <td data-property-name=""><span class="property-name"><code>productOverrides</code></span> - <span class="property-type"><a href="#definition-ProductOverride"><code>[ProductOverride]</code></a></span>
+                      </td>
+                      <td>
+                      </td>
+                    </tr>
+                    <tr>
+                      <td data-property-name=""><span class="property-name"><code>shortDescription</code></span> - <span class="property-type"><a href="#definition-String"><code>String</code></a></span>
+                      </td>
+                      <td>
+                      </td>
+                    </tr>
+                    <tr>
+                      <td data-property-name=""><span class="property-name"><code>sku</code></span> - <span class="property-type"><a href="#definition-String"><code>String!</code></a></span>
+                      </td>
+                      <td>
+                      </td>
+                    </tr>
+                    <tr>
+                      <td data-property-name=""><span class="property-name"><code>smallImage</code></span> - <span class="property-type"><a href="#definition-Image"><code>Image</code></a></span>
+                      </td>
+                      <td>
+                      </td>
+                    </tr>
+                    <tr>
+                      <td data-property-name=""><span class="property-name"><code>storeViewCode</code></span> - <span class="property-type"><a href="#definition-String"><code>String!</code></a></span>
+                      </td>
+                      <td>
+                      </td>
+                    </tr>
+                    <tr>
+                      <td data-property-name=""><span class="property-name"><code>thumbnailImage</code></span> - <span class="property-type"><a href="#definition-Image"><code>Image</code></a></span>
+                      </td>
+                      <td>
+                      </td>
+                    </tr>
+                    <tr>
+                      <td data-property-name=""><span class="property-name"><code>type</code></span> - <span class="property-type"><a href="#definition-String"><code>String!</code></a></span>
+                      </td>
+                      <td>
+                      </td>
+                    </tr>
+                    <tr>
+                      <td data-property-name=""><span class="property-name"><code>url</code></span> - <span class="property-type"><a href="#definition-String"><code>String</code></a></span>
+                      </td>
+                      <td>
+                      </td>
+                    </tr>
+                    <tr>
+                      <td data-property-name=""><span class="property-name"><code>websiteCode</code></span> - <span class="property-type"><a href="#definition-String"><code>String!</code></a></span>
+                      </td>
+                      <td>
+                      </td>
+                    </tr>
+                  </tbody>
+                </table>
+              </div>
+            </div>
+            <div class="doc-examples">
+              <div class="example-section example-section-is-code">
+                <h5>Example</h5>
+                <html>
+                  <head></head>
+                  <body><pre><code class="hljs language-json"><span class="hljs-punctuation">{</span>
+  <span class="hljs-attr">"attributes"</span><span class="hljs-punctuation">:</span> <span class="hljs-punctuation">[</span><span class="hljs-string">"xyz789"</span><span class="hljs-punctuation">]</span><span class="hljs-punctuation">,</span>
+  <span class="hljs-attr">"currency"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"abc123"</span><span class="hljs-punctuation">,</span>
+  <span class="hljs-attr">"description"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"xyz789"</span><span class="hljs-punctuation">,</span>
+  <span class="hljs-attr">"image"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">Image</span><span class="hljs-punctuation">,</span>
+  <span class="hljs-attr">"inStock"</span><span class="hljs-punctuation">:</span> <span class="hljs-literal"><span class="hljs-keyword">false</span></span><span class="hljs-punctuation">,</span>
+  <span class="hljs-attr">"lastIndexedTs"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"xyz789"</span><span class="hljs-punctuation">,</span>
+  <span class="hljs-attr">"lowStock"</span><span class="hljs-punctuation">:</span> <span class="hljs-literal"><span class="hljs-keyword">false</span></span><span class="hljs-punctuation">,</span>
+  <span class="hljs-attr">"metaDescription"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"abc123"</span><span class="hljs-punctuation">,</span>
+  <span class="hljs-attr">"metaKeyword"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"abc123"</span><span class="hljs-punctuation">,</span>
+  <span class="hljs-attr">"metaTitle"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"abc123"</span><span class="hljs-punctuation">,</span>
+  <span class="hljs-attr">"name"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"xyz789"</span><span class="hljs-punctuation">,</span>
+  <span class="hljs-attr">"productId"</span><span class="hljs-punctuation">:</span> <span class="hljs-number">987</span><span class="hljs-punctuation">,</span>
+  <span class="hljs-attr">"productOverrides"</span><span class="hljs-punctuation">:</span> <span class="hljs-punctuation">[</span><span class="hljs-string">ProductOverride</span><span class="hljs-punctuation">]</span><span class="hljs-punctuation">,</span>
+  <span class="hljs-attr">"shortDescription"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"xyz789"</span><span class="hljs-punctuation">,</span>
+  <span class="hljs-attr">"sku"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"abc123"</span><span class="hljs-punctuation">,</span>
+  <span class="hljs-attr">"smallImage"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">Image</span><span class="hljs-punctuation">,</span>
+  <span class="hljs-attr">"storeViewCode"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"xyz789"</span><span class="hljs-punctuation">,</span>
+  <span class="hljs-attr">"thumbnailImage"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">Image</span><span class="hljs-punctuation">,</span>
+  <span class="hljs-attr">"type"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"abc123"</span><span class="hljs-punctuation">,</span>
+  <span class="hljs-attr">"url"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"xyz789"</span><span class="hljs-punctuation">,</span>
+  <span class="hljs-attr">"websiteCode"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"xyz789"</span>
+<span class="hljs-punctuation">}</span>
+</code></pre>
+                  </body>
+                </html>
+              </div>
+            </div>
+            <a href="#top">back to top</a>
+          </div>
+        </section>
+        <section id="definition-ProductList" class="definition definition-object" data-traverse-target="definition-ProductList">
+          <div class="definition-group-name">
+            <a href="#group-Types">Types</a>
+          </div>
+          <h2 class="definition-heading">ProductList</h2>
+          <div class="doc-row">
+            <div class="doc-copy">
+              <div class="definition-description doc-copy-section">
+                <h5>Description</h5>
+                <p>Represents the list of products indexed for a given data space and scope.</p>
+              </div>
+              <div class="definition-properties doc-copy-section">
+                <h5>Fields</h5>
+                <table>
+                  <thead>
+                    <tr>
+                      <th>Field Name</th>
+                      <th>Description</th>
+                    </tr>
+                  </thead>
+                  <tbody>
+                    <tr>
+                      <td data-property-name=""><span class="property-name"><code>lastPage</code></span> - <span class="property-type"><a href="#definition-Boolean"><code>Boolean!</code></a></span>
+                      </td>
+                      <td> The last page number in the product list. </td>
+                    </tr>
+                    <tr>
+                      <td data-property-name=""><span class="property-name"><code>pageSize</code></span> - <span class="property-type"><a href="#definition-Int"><code>Int!</code></a></span>
+                      </td>
+                      <td> The total number of pages in the product list. </td>
+                    </tr>
+                    <tr>
+                      <td data-property-name=""><span class="property-name"><code>products</code></span> - <span class="property-type"><a href="#definition-ProductRow"><code>[ProductRow]</code></a></span>
+                      </td>
+                      <td> The list of product data used to populate the product list table. </td>
+                    </tr>
+                    <tr>
+                      <td data-property-name=""><span class="property-name"><code>scrollId</code></span> - <span class="property-type"><a href="#definition-String"><code>String</code></a></span>
+                      </td>
+                      <td> The scroll ID to use for the next page of results. If the last page is reached, this will be null. </td>
+                    </tr>
+                  </tbody>
+                </table>
+              </div>
+            </div>
+            <div class="doc-examples">
+              <div class="example-section example-section-is-code">
+                <h5>Example</h5>
+                <html>
+                  <head></head>
+                  <body><pre><code class="hljs language-json"><span class="hljs-punctuation">{</span>
+  <span class="hljs-attr">"lastPage"</span><span class="hljs-punctuation">:</span> <span class="hljs-literal"><span class="hljs-keyword">true</span></span><span class="hljs-punctuation">,</span>
+  <span class="hljs-attr">"pageSize"</span><span class="hljs-punctuation">:</span> <span class="hljs-number">987</span><span class="hljs-punctuation">,</span>
+  <span class="hljs-attr">"products"</span><span class="hljs-punctuation">:</span> <span class="hljs-punctuation">[</span><span class="hljs-string">ProductRow</span><span class="hljs-punctuation">]</span><span class="hljs-punctuation">,</span>
+  <span class="hljs-attr">"scrollId"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"xyz789"</span>
+<span class="hljs-punctuation">}</span>
+</code></pre>
+                  </body>
+                </html>
+              </div>
+            </div>
+            <a href="#top">back to top</a>
+          </div>
+        </section>
+        <section id="definition-ProductOverride" class="definition definition-object" data-traverse-target="definition-ProductOverride">
+          <div class="definition-group-name">
+            <a href="#group-Types">Types</a>
+          </div>
+          <h2 class="definition-heading">ProductOverride</h2>
+          <div class="doc-row">
+            <div class="doc-copy">
+              <div class="definition-properties doc-copy-section">
+                <h5>Fields</h5>
+                <table>
+                  <thead>
+                    <tr>
+                      <th>Field Name</th>
+                      <th>Description</th>
+                    </tr>
+                  </thead>
+                  <tbody>
+                    <tr>
+                      <td data-property-name=""><span class="property-name"><code>addToCartAllowed</code></span> - <span class="property-type"><a href="#definition-Boolean"><code>Boolean</code></a></span>
+                      </td>
+                      <td>
+                      </td>
+                    </tr>
+                    <tr>
+                      <td data-property-name=""><span class="property-name"><code>customerGroupHash</code></span> - <span class="property-type"><a href="#definition-String"><code>String</code></a></span>
+                      </td>
+                      <td>
+                      </td>
+                    </tr>
+                    <tr>
+                      <td data-property-name=""><span class="property-name"><code>prices</code></span> - <span class="property-type"><a href="#definition-PriceWrapper"><code>PriceWrapper</code></a></span>
+                      </td>
+                      <td>
+                      </td>
+                    </tr>
+                  </tbody>
+                </table>
+              </div>
+            </div>
+            <div class="doc-examples">
+              <div class="example-section example-section-is-code">
+                <h5>Example</h5>
+                <html>
+                  <head></head>
+                  <body><pre><code class="hljs language-json"><span class="hljs-punctuation">{</span>
+  <span class="hljs-attr">"addToCartAllowed"</span><span class="hljs-punctuation">:</span> <span class="hljs-literal"><span class="hljs-keyword">true</span></span><span class="hljs-punctuation">,</span>
+  <span class="hljs-attr">"customerGroupHash"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"abc123"</span><span class="hljs-punctuation">,</span>
+  <span class="hljs-attr">"prices"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">PriceWrapper</span>
+<span class="hljs-punctuation">}</span>
+</code></pre>
+                  </body>
+                </html>
+              </div>
+            </div>
+            <a href="#top">back to top</a>
+          </div>
+        </section>
+        <section id="definition-ProductRow" class="definition definition-object" data-traverse-target="definition-ProductRow">
+          <div class="definition-group-name">
+            <a href="#group-Types">Types</a>
+          </div>
+          <h2 class="definition-heading">ProductRow</h2>
+          <div class="doc-row">
+            <div class="doc-copy">
+              <div class="definition-description doc-copy-section">
+                <h5>Description</h5>
+                <p>Represents a view of a product to populate the product list table.</p>
+              </div>
+              <div class="definition-properties doc-copy-section">
+                <h5>Fields</h5>
+                <table>
+                  <thead>
+                    <tr>
+                      <th>Field Name</th>
+                      <th>Description</th>
+                    </tr>
+                  </thead>
+                  <tbody>
+                    <tr>
+                      <td data-property-name=""><span class="property-name"><code>currency</code></span> - <span class="property-type"><a href="#definition-String"><code>String</code></a></span>
+                      </td>
+                      <td>
+                      </td>
+                    </tr>
+                    <tr>
+                      <td data-property-name=""><span class="property-name"><code>inStock</code></span> - <span class="property-type"><a href="#definition-Boolean"><code>Boolean</code></a></span>
+                      </td>
+                      <td>
+                      </td>
+                    </tr>
+                    <tr>
+                      <td data-property-name=""><span class="property-name"><code>lastIndexedTs</code></span> - <span class="property-type"><a href="#definition-String"><code>String</code></a></span>
+                      </td>
+                      <td>
+                      </td>
+                    </tr>
+                    <tr>
+                      <td data-property-name=""><span class="property-name"><code>lowStock</code></span> - <span class="property-type"><a href="#definition-Boolean"><code>Boolean</code></a></span>
+                      </td>
+                      <td>
+                      </td>
+                    </tr>
+                    <tr>
+                      <td data-property-name=""><span class="property-name"><code>name</code></span> - <span class="property-type"><a href="#definition-String"><code>String!</code></a></span>
+                      </td>
+                      <td>
+                      </td>
+                    </tr>
+                    <tr>
+                      <td data-property-name=""><span class="property-name"><code>price</code></span> - <span class="property-type"><a href="#definition-BigDecimal"><code>BigDecimal</code></a></span>
+                      </td>
+                      <td>
+                      </td>
+                    </tr>
+                    <tr>
+                      <td data-property-name=""><span class="property-name"><code>productId</code></span> - <span class="property-type"><a href="#definition-Int"><code>Int!</code></a></span>
+                      </td>
+                      <td>
+                      </td>
+                    </tr>
+                    <tr>
+                      <td data-property-name=""><span class="property-name"><code>sku</code></span> - <span class="property-type"><a href="#definition-String"><code>String!</code></a></span>
+                      </td>
+                      <td>
+                      </td>
+                    </tr>
+                    <tr>
+                      <td data-property-name=""><span class="property-name"><code>type</code></span> - <span class="property-type"><a href="#definition-String"><code>String!</code></a></span>
+                      </td>
+                      <td>
+                      </td>
+                    </tr>
+                    <tr>
+                      <td data-property-name=""><span class="property-name"><code>url</code></span> - <span class="property-type"><a href="#definition-String"><code>String</code></a></span>
+                      </td>
+                      <td>
+                      </td>
+                    </tr>
+                    <tr>
+                      <td data-property-name=""><span class="property-name"><code>visibility</code></span> - <span class="property-type"><a href="#definition-String"><code>String</code></a></span>
+                      </td>
+                      <td>
+                      </td>
+                    </tr>
+                  </tbody>
+                </table>
+              </div>
+            </div>
+            <div class="doc-examples">
+              <div class="example-section example-section-is-code">
+                <h5>Example</h5>
+                <html>
+                  <head></head>
+                  <body><pre><code class="hljs language-json"><span class="hljs-punctuation">{</span>
+  <span class="hljs-attr">"currency"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"xyz789"</span><span class="hljs-punctuation">,</span>
+  <span class="hljs-attr">"inStock"</span><span class="hljs-punctuation">:</span> <span class="hljs-literal"><span class="hljs-keyword">true</span></span><span class="hljs-punctuation">,</span>
+  <span class="hljs-attr">"lastIndexedTs"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"xyz789"</span><span class="hljs-punctuation">,</span>
+  <span class="hljs-attr">"lowStock"</span><span class="hljs-punctuation">:</span> <span class="hljs-literal"><span class="hljs-keyword">false</span></span><span class="hljs-punctuation">,</span>
+  <span class="hljs-attr">"name"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"xyz789"</span><span class="hljs-punctuation">,</span>
+  <span class="hljs-attr">"price"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">BigDecimal</span><span class="hljs-punctuation">,</span>
+  <span class="hljs-attr">"productId"</span><span class="hljs-punctuation">:</span> <span class="hljs-number">123</span><span class="hljs-punctuation">,</span>
+  <span class="hljs-attr">"sku"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"xyz789"</span><span class="hljs-punctuation">,</span>
+  <span class="hljs-attr">"type"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"abc123"</span><span class="hljs-punctuation">,</span>
+  <span class="hljs-attr">"url"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"abc123"</span><span class="hljs-punctuation">,</span>
+  <span class="hljs-attr">"visibility"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"abc123"</span>
+<span class="hljs-punctuation">}</span>
+</code></pre>
+                  </body>
+                </html>
+              </div>
+            </div>
+            <a href="#top">back to top</a>
           </div>
         </section>
         <section id="definition-QueryCondition" class="definition definition-object" data-traverse-target="definition-QueryCondition">
@@ -10137,6 +11693,7 @@ is <span class="hljs-keyword">an</span> all-<span class="hljs-keyword">or</span>
                 </html>
               </div>
             </div>
+            <a href="#top">back to top</a>
           </div>
         </section>
         <section id="definition-QueryConditionGroup" class="definition definition-object" data-traverse-target="definition-QueryConditionGroup">
@@ -10188,6 +11745,7 @@ is <span class="hljs-keyword">an</span> all-<span class="hljs-keyword">or</span>
                 </html>
               </div>
             </div>
+            <a href="#top">back to top</a>
           </div>
         </section>
         <section id="definition-QueryConditionGroupInput" class="definition definition-input-object" data-traverse-target="definition-QueryConditionGroupInput">
@@ -10241,6 +11799,7 @@ is <span class="hljs-keyword">an</span> all-<span class="hljs-keyword">or</span>
                 </html>
               </div>
             </div>
+            <a href="#top">back to top</a>
           </div>
         </section>
         <section id="definition-QueryConditionInput" class="definition definition-input-object" data-traverse-target="definition-QueryConditionInput">
@@ -10291,6 +11850,7 @@ is <span class="hljs-keyword">an</span> all-<span class="hljs-keyword">or</span>
                 </html>
               </div>
             </div>
+            <a href="#top">back to top</a>
           </div>
         </section>
         <section id="definition-QueryConditionType" class="definition definition-enum" data-traverse-target="definition-QueryConditionType">
@@ -10357,6 +11917,7 @@ is <span class="hljs-keyword">an</span> all-<span class="hljs-keyword">or</span>
                 </html>
               </div>
             </div>
+            <a href="#top">back to top</a>
           </div>
         </section>
         <section id="definition-QueryRule" class="definition definition-object" data-traverse-target="definition-QueryRule">
@@ -10452,10 +12013,10 @@ is <span class="hljs-keyword">an</span> all-<span class="hljs-keyword">or</span>
                   <body><pre><code class="hljs language-json"><span class="hljs-punctuation">{</span>
   <span class="hljs-attr">"description"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"abc123"</span><span class="hljs-punctuation">,</span>
   <span class="hljs-attr">"events"</span><span class="hljs-punctuation">:</span> <span class="hljs-punctuation">[</span><span class="hljs-string">Event</span><span class="hljs-punctuation">]</span><span class="hljs-punctuation">,</span>
-  <span class="hljs-attr">"id"</span><span class="hljs-punctuation">:</span> <span class="hljs-number">4</span><span class="hljs-punctuation">,</span>
-  <span class="hljs-attr">"lastUpdatedAt"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"abc123"</span><span class="hljs-punctuation">,</span>
-  <span class="hljs-attr">"name"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"abc123"</span><span class="hljs-punctuation">,</span>
-  <span class="hljs-attr">"preview"</span><span class="hljs-punctuation">:</span> <span class="hljs-literal"><span class="hljs-keyword">true</span></span><span class="hljs-punctuation">,</span>
+  <span class="hljs-attr">"id"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"4"</span><span class="hljs-punctuation">,</span>
+  <span class="hljs-attr">"lastUpdatedAt"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"xyz789"</span><span class="hljs-punctuation">,</span>
+  <span class="hljs-attr">"name"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"xyz789"</span><span class="hljs-punctuation">,</span>
+  <span class="hljs-attr">"preview"</span><span class="hljs-punctuation">:</span> <span class="hljs-literal"><span class="hljs-keyword">false</span></span><span class="hljs-punctuation">,</span>
   <span class="hljs-attr">"queryConditionGroup"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">QueryConditionGroup</span><span class="hljs-punctuation">,</span>
   <span class="hljs-attr">"rankingType"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"MOST_ADDED_TO_CART"</span><span class="hljs-punctuation">,</span>
   <span class="hljs-attr">"ruleType"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"DEFAULT_RULE"</span><span class="hljs-punctuation">,</span>
@@ -10468,6 +12029,7 @@ is <span class="hljs-keyword">an</span> all-<span class="hljs-keyword">or</span>
                 </html>
               </div>
             </div>
+            <a href="#top">back to top</a>
           </div>
         </section>
         <section id="definition-QueryRuleInput" class="definition definition-input-object" data-traverse-target="definition-QueryRuleInput">
@@ -10567,9 +12129,9 @@ is <span class="hljs-keyword">an</span> all-<span class="hljs-keyword">or</span>
                 <html>
                   <head></head>
                   <body><pre><code class="hljs language-json"><span class="hljs-punctuation">{</span>
-  <span class="hljs-attr">"description"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"abc123"</span><span class="hljs-punctuation">,</span>
+  <span class="hljs-attr">"description"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"xyz789"</span><span class="hljs-punctuation">,</span>
   <span class="hljs-attr">"events"</span><span class="hljs-punctuation">:</span> <span class="hljs-punctuation">[</span><span class="hljs-string">EventInput</span><span class="hljs-punctuation">]</span><span class="hljs-punctuation">,</span>
-  <span class="hljs-attr">"id"</span><span class="hljs-punctuation">:</span> <span class="hljs-number">4</span><span class="hljs-punctuation">,</span>
+  <span class="hljs-attr">"id"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"4"</span><span class="hljs-punctuation">,</span>
   <span class="hljs-attr">"name"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"abc123"</span><span class="hljs-punctuation">,</span>
   <span class="hljs-attr">"preview"</span><span class="hljs-punctuation">:</span> <span class="hljs-literal"><span class="hljs-keyword">false</span></span><span class="hljs-punctuation">,</span>
   <span class="hljs-attr">"queryConditionGroup"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">QueryConditionGroupInput</span><span class="hljs-punctuation">,</span>
@@ -10584,6 +12146,7 @@ is <span class="hljs-keyword">an</span> all-<span class="hljs-keyword">or</span>
                 </html>
               </div>
             </div>
+            <a href="#top">back to top</a>
           </div>
         </section>
         <section id="definition-QueryRulesMutationResponse" class="definition definition-object" data-traverse-target="definition-QueryRulesMutationResponse">
@@ -10627,6 +12190,7 @@ is <span class="hljs-keyword">an</span> all-<span class="hljs-keyword">or</span>
                 </html>
               </div>
             </div>
+            <a href="#top">back to top</a>
           </div>
         </section>
         <section id="definition-QueryRulesQueryResponse" class="definition definition-object" data-traverse-target="definition-QueryRulesQueryResponse">
@@ -10671,6 +12235,7 @@ is <span class="hljs-keyword">an</span> all-<span class="hljs-keyword">or</span>
                 </html>
               </div>
             </div>
+            <a href="#top">back to top</a>
           </div>
         </section>
         <section id="definition-RangeInput" class="definition definition-input-object" data-traverse-target="definition-RangeInput">
@@ -10717,12 +12282,13 @@ is <span class="hljs-keyword">an</span> all-<span class="hljs-keyword">or</span>
                 <h5>Example</h5>
                 <html>
                   <head></head>
-                  <body><pre><code class="hljs language-json"><span class="hljs-punctuation">{</span><span class="hljs-attr">"from"</span><span class="hljs-punctuation">:</span> <span class="hljs-number">123</span><span class="hljs-punctuation">,</span> <span class="hljs-attr">"to"</span><span class="hljs-punctuation">:</span> <span class="hljs-number">987</span><span class="hljs-punctuation">}</span>
+                  <body><pre><code class="hljs language-json"><span class="hljs-punctuation">{</span><span class="hljs-attr">"from"</span><span class="hljs-punctuation">:</span> <span class="hljs-number">987</span><span class="hljs-punctuation">,</span> <span class="hljs-attr">"to"</span><span class="hljs-punctuation">:</span> <span class="hljs-number">987</span><span class="hljs-punctuation">}</span>
 </code></pre>
                   </body>
                 </html>
               </div>
             </div>
+            <a href="#top">back to top</a>
           </div>
         </section>
         <section id="definition-RangeOperatorRequest" class="definition definition-input-object" data-traverse-target="definition-RangeOperatorRequest">
@@ -10773,6 +12339,7 @@ is <span class="hljs-keyword">an</span> all-<span class="hljs-keyword">or</span>
                 </html>
               </div>
             </div>
+            <a href="#top">back to top</a>
           </div>
         </section>
         <section id="definition-RangeOperatorResponse" class="definition definition-object" data-traverse-target="definition-RangeOperatorResponse">
@@ -10821,6 +12388,7 @@ is <span class="hljs-keyword">an</span> all-<span class="hljs-keyword">or</span>
                 </html>
               </div>
             </div>
+            <a href="#top">back to top</a>
           </div>
         </section>
         <section id="definition-RangeType" class="definition definition-enum" data-traverse-target="definition-RangeType">
@@ -10880,6 +12448,7 @@ is <span class="hljs-keyword">an</span> all-<span class="hljs-keyword">or</span>
                 </html>
               </div>
             </div>
+            <a href="#top">back to top</a>
           </div>
         </section>
         <section id="definition-RangeValue" class="definition definition-object" data-traverse-target="definition-RangeValue">
@@ -10922,12 +12491,13 @@ is <span class="hljs-keyword">an</span> all-<span class="hljs-keyword">or</span>
                 <h5>Example</h5>
                 <html>
                   <head></head>
-                  <body><pre><code class="hljs language-json"><span class="hljs-punctuation">{</span><span class="hljs-attr">"from"</span><span class="hljs-punctuation">:</span> <span class="hljs-number">123.45</span><span class="hljs-punctuation">,</span> <span class="hljs-attr">"to"</span><span class="hljs-punctuation">:</span> <span class="hljs-number">987.65</span><span class="hljs-punctuation">}</span>
+                  <body><pre><code class="hljs language-json"><span class="hljs-punctuation">{</span><span class="hljs-attr">"from"</span><span class="hljs-punctuation">:</span> <span class="hljs-number">123.45</span><span class="hljs-punctuation">,</span> <span class="hljs-attr">"to"</span><span class="hljs-punctuation">:</span> <span class="hljs-number">123.45</span><span class="hljs-punctuation">}</span>
 </code></pre>
                   </body>
                 </html>
               </div>
             </div>
+            <a href="#top">back to top</a>
           </div>
         </section>
         <section id="definition-RangeValueRequest" class="definition definition-input-object" data-traverse-target="definition-RangeValueRequest">
@@ -10972,12 +12542,13 @@ is <span class="hljs-keyword">an</span> all-<span class="hljs-keyword">or</span>
                 <h5>Example</h5>
                 <html>
                   <head></head>
-                  <body><pre><code class="hljs language-json"><span class="hljs-punctuation">{</span><span class="hljs-attr">"from"</span><span class="hljs-punctuation">:</span> <span class="hljs-number">987.65</span><span class="hljs-punctuation">,</span> <span class="hljs-attr">"to"</span><span class="hljs-punctuation">:</span> <span class="hljs-number">123.45</span><span class="hljs-punctuation">}</span>
+                  <body><pre><code class="hljs language-json"><span class="hljs-punctuation">{</span><span class="hljs-attr">"from"</span><span class="hljs-punctuation">:</span> <span class="hljs-number">123.45</span><span class="hljs-punctuation">,</span> <span class="hljs-attr">"to"</span><span class="hljs-punctuation">:</span> <span class="hljs-number">987.65</span><span class="hljs-punctuation">}</span>
 </code></pre>
                   </body>
                 </html>
               </div>
             </div>
+            <a href="#top">back to top</a>
           </div>
         </section>
         <section id="definition-RankingType" class="definition definition-enum" data-traverse-target="definition-RankingType">
@@ -11058,6 +12629,134 @@ is <span class="hljs-keyword">an</span> all-<span class="hljs-keyword">or</span>
                 </html>
               </div>
             </div>
+            <a href="#top">back to top</a>
+          </div>
+        </section>
+        <section id="definition-Recommendations" class="definition definition-object" data-traverse-target="definition-Recommendations">
+          <div class="definition-group-name">
+            <a href="#group-Types">Types</a>
+          </div>
+          <h2 class="definition-heading">Recommendations</h2>
+          <div class="doc-row">
+            <div class="doc-copy">
+              <div class="definition-properties doc-copy-section">
+                <h5>Fields</h5>
+                <table>
+                  <thead>
+                    <tr>
+                      <th>Field Name</th>
+                      <th>Description</th>
+                    </tr>
+                  </thead>
+                  <tbody>
+                    <tr>
+                      <td data-property-name=""><span class="property-name"><code>count</code></span> - <span class="property-type"><a href="#definition-Int"><code>Int!</code></a></span>
+                      </td>
+                      <td> Queries the Product Recommendations data store for the count of products. This represents the number of products that are indexed and available for Product Recommendations . </td>
+                    </tr>
+                    <tr class="row-has-field-arguments">
+                      <td data-property-name=""><span class="property-name"><code>productDetail</code></span> - <span class="property-type"><a href="#definition-ProductDetail"><code>ProductDetail</code></a></span>
+                      </td>
+                      <td>
+                        <p>Queries the Product Recommendations data store for detailed product information for a given SKU.</p>
+                        <p>Parameters:</p>
+                        <ul>
+                          <li>sku: The SKU of the product to retrieve (required)</li>
+                        </ul>
+                      </td>
+                    </tr>
+                    <tr class="row-field-arguments">
+                      <td colspan="2">
+                        <div class="field-arguments">
+                          <h5 class="field-arguments-heading"> Arguments </h5>
+                          <div class="field-argument-list">
+                            <div class="field-argument">
+                              <h6 class="field-argument-name"><span class="property-name"><code>sku</code></span> - <span class="property-type"><a href="#definition-String"><code>String!</code></a></span>
+                              </h6>
+                            </div>
+                          </div>
+                        </div>
+                      </td>
+                    </tr>
+                    <tr class="row-has-field-arguments">
+                      <td data-property-name=""><span class="property-name"><code>productList</code></span> - <span class="property-type"><a href="#definition-ProductList"><code>ProductList!</code></a></span>
+                      </td>
+                      <td>
+                        <p>Queries the Product Recommendations data store for a list of products indexed. This represents the list of products that are indexed and available for Product Recommendations . The product list is sorted by last indexed timestamp in descending order.</p>
+                        <p>Parameters:</p>
+                        <ul>
+                          <li>searchTerm: The search term to filter the product list by (optional)</li>
+                          <li>scrollId: The scroll ID to continue a previous search (optional)</li>
+                          <li>size: The number of products to return (optional, default: 50)</li>
+                        </ul>
+                      </td>
+                    </tr>
+                    <tr class="row-field-arguments">
+                      <td colspan="2">
+                        <div class="field-arguments">
+                          <h5 class="field-arguments-heading"> Arguments </h5>
+                          <div class="field-argument-list">
+                            <div class="field-argument">
+                              <h6 class="field-argument-name"><span class="property-name"><code>scrollId</code></span> - <span class="property-type"><a href="#definition-String"><code>String</code></a></span>
+                              </h6>
+                            </div>
+                            <div class="field-argument">
+                              <h6 class="field-argument-name"><span class="property-name"><code>searchTerm</code></span> - <span class="property-type"><a href="#definition-String"><code>String</code></a></span>
+                              </h6>
+                            </div>
+                            <div class="field-argument">
+                              <h6 class="field-argument-name"><span class="property-name"><code>size</code></span> - <span class="property-type"><a href="#definition-Int"><code>Int</code></a></span>
+                              </h6>
+                            </div>
+                          </div>
+                        </div>
+                      </td>
+                    </tr>
+                    <tr class="row-has-field-arguments">
+                      <td data-property-name=""><span class="property-name"><code>since</code></span> - <span class="property-type"><a href="#definition-Since"><code>Since!</code></a></span>
+                      </td>
+                      <td>
+                        <p>Queries the Product Recommendations data store for the number of products indexed since a given datetime.</p>
+                        <p>Parameters:</p>
+                        <ul>
+                          <li>datetime: The start datetime to query from (required)</li>
+                        </ul>
+                      </td>
+                    </tr>
+                    <tr class="row-field-arguments">
+                      <td colspan="2">
+                        <div class="field-arguments">
+                          <h5 class="field-arguments-heading"> Arguments </h5>
+                          <div class="field-argument-list">
+                            <div class="field-argument">
+                              <h6 class="field-argument-name"><span class="property-name"><code>datetime</code></span> - <span class="property-type"><a href="#definition-String"><code>String!</code></a></span>
+                              </h6>
+                            </div>
+                          </div>
+                        </div>
+                      </td>
+                    </tr>
+                  </tbody>
+                </table>
+              </div>
+            </div>
+            <div class="doc-examples">
+              <div class="example-section example-section-is-code">
+                <h5>Example</h5>
+                <html>
+                  <head></head>
+                  <body><pre><code class="hljs language-json"><span class="hljs-punctuation">{</span>
+  <span class="hljs-attr">"count"</span><span class="hljs-punctuation">:</span> <span class="hljs-number">123</span><span class="hljs-punctuation">,</span>
+  <span class="hljs-attr">"productDetail"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">ProductDetail</span><span class="hljs-punctuation">,</span>
+  <span class="hljs-attr">"productList"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">ProductList</span><span class="hljs-punctuation">,</span>
+  <span class="hljs-attr">"since"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">Since</span>
+<span class="hljs-punctuation">}</span>
+</code></pre>
+                  </body>
+                </html>
+              </div>
+            </div>
+            <a href="#top">back to top</a>
           </div>
         </section>
         <section id="definition-RuleStatusType" class="definition definition-enum" data-traverse-target="definition-RuleStatusType">
@@ -11110,6 +12809,7 @@ is <span class="hljs-keyword">an</span> all-<span class="hljs-keyword">or</span>
                 </html>
               </div>
             </div>
+            <a href="#top">back to top</a>
           </div>
         </section>
         <section id="definition-RuleType" class="definition definition-enum" data-traverse-target="definition-RuleType">
@@ -11162,6 +12862,48 @@ is <span class="hljs-keyword">an</span> all-<span class="hljs-keyword">or</span>
                 </html>
               </div>
             </div>
+            <a href="#top">back to top</a>
+          </div>
+        </section>
+        <section id="definition-Scope" class="definition definition-object" data-traverse-target="definition-Scope">
+          <div class="definition-group-name">
+            <a href="#group-Types">Types</a>
+          </div>
+          <h2 class="definition-heading">Scope</h2>
+          <div class="doc-row">
+            <div class="doc-copy">
+              <div class="definition-properties doc-copy-section">
+                <h5>Fields</h5>
+                <table>
+                  <thead>
+                    <tr>
+                      <th>Field Name</th>
+                      <th>Description</th>
+                    </tr>
+                  </thead>
+                  <tbody>
+                    <tr>
+                      <td data-property-name=""><span class="property-name"><code>locale</code></span> - <span class="property-type"><a href="#definition-String"><code>String</code></a></span>
+                      </td>
+                      <td>
+                      </td>
+                    </tr>
+                  </tbody>
+                </table>
+              </div>
+            </div>
+            <div class="doc-examples">
+              <div class="example-section example-section-is-code">
+                <h5>Example</h5>
+                <html>
+                  <head></head>
+                  <body><pre><code class="hljs language-json"><span class="hljs-punctuation">{</span><span class="hljs-attr">"locale"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"xyz789"</span><span class="hljs-punctuation">}</span>
+</code></pre>
+                  </body>
+                </html>
+              </div>
+            </div>
+            <a href="#top">back to top</a>
           </div>
         </section>
         <section id="definition-SearchAnalyticsQueryResponse" class="definition definition-object" data-traverse-target="definition-SearchAnalyticsQueryResponse">
@@ -11225,6 +12967,7 @@ is <span class="hljs-keyword">an</span> all-<span class="hljs-keyword">or</span>
                 </html>
               </div>
             </div>
+            <a href="#top">back to top</a>
           </div>
         </section>
         <section id="definition-SearchMerchandisingRule" class="definition definition-interface" data-traverse-target="definition-SearchMerchandisingRule">
@@ -11335,12 +13078,12 @@ is <span class="hljs-keyword">an</span> all-<span class="hljs-keyword">or</span>
                 <html>
                   <head></head>
                   <body><pre><code class="hljs language-json"><span class="hljs-punctuation">{</span>
-  <span class="hljs-attr">"description"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"xyz789"</span><span class="hljs-punctuation">,</span>
+  <span class="hljs-attr">"description"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"abc123"</span><span class="hljs-punctuation">,</span>
   <span class="hljs-attr">"events"</span><span class="hljs-punctuation">:</span> <span class="hljs-punctuation">[</span><span class="hljs-string">Event</span><span class="hljs-punctuation">]</span><span class="hljs-punctuation">,</span>
-  <span class="hljs-attr">"id"</span><span class="hljs-punctuation">:</span> <span class="hljs-number">4</span><span class="hljs-punctuation">,</span>
-  <span class="hljs-attr">"lastUpdatedAt"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"xyz789"</span><span class="hljs-punctuation">,</span>
-  <span class="hljs-attr">"name"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"abc123"</span><span class="hljs-punctuation">,</span>
-  <span class="hljs-attr">"preview"</span><span class="hljs-punctuation">:</span> <span class="hljs-literal"><span class="hljs-keyword">true</span></span><span class="hljs-punctuation">,</span>
+  <span class="hljs-attr">"id"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"4"</span><span class="hljs-punctuation">,</span>
+  <span class="hljs-attr">"lastUpdatedAt"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"abc123"</span><span class="hljs-punctuation">,</span>
+  <span class="hljs-attr">"name"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"xyz789"</span><span class="hljs-punctuation">,</span>
+  <span class="hljs-attr">"preview"</span><span class="hljs-punctuation">:</span> <span class="hljs-literal"><span class="hljs-keyword">false</span></span><span class="hljs-punctuation">,</span>
   <span class="hljs-attr">"rankingType"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"MOST_ADDED_TO_CART"</span><span class="hljs-punctuation">,</span>
   <span class="hljs-attr">"ruleType"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"DEFAULT_RULE"</span><span class="hljs-punctuation">,</span>
   <span class="hljs-attr">"status"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"ACTIVE"</span><span class="hljs-punctuation">,</span>
@@ -11352,6 +13095,54 @@ is <span class="hljs-keyword">an</span> all-<span class="hljs-keyword">or</span>
                 </html>
               </div>
             </div>
+            <a href="#top">back to top</a>
+          </div>
+        </section>
+        <section id="definition-Since" class="definition definition-object" data-traverse-target="definition-Since">
+          <div class="definition-group-name">
+            <a href="#group-Types">Types</a>
+          </div>
+          <h2 class="definition-heading">Since</h2>
+          <div class="doc-row">
+            <div class="doc-copy">
+              <div class="definition-properties doc-copy-section">
+                <h5>Fields</h5>
+                <table>
+                  <thead>
+                    <tr>
+                      <th>Field Name</th>
+                      <th>Description</th>
+                    </tr>
+                  </thead>
+                  <tbody>
+                    <tr>
+                      <td data-property-name=""><span class="property-name"><code>count</code></span> - <span class="property-type"><a href="#definition-Int"><code>Int!</code></a></span>
+                      </td>
+                      <td>
+                      </td>
+                    </tr>
+                    <tr>
+                      <td data-property-name=""><span class="property-name"><code>datetime</code></span> - <span class="property-type"><a href="#definition-String"><code>String!</code></a></span>
+                      </td>
+                      <td>
+                      </td>
+                    </tr>
+                  </tbody>
+                </table>
+              </div>
+            </div>
+            <div class="doc-examples">
+              <div class="example-section example-section-is-code">
+                <h5>Example</h5>
+                <html>
+                  <head></head>
+                  <body><pre><code class="hljs language-json"><span class="hljs-punctuation">{</span><span class="hljs-attr">"count"</span><span class="hljs-punctuation">:</span> <span class="hljs-number">123</span><span class="hljs-punctuation">,</span> <span class="hljs-attr">"datetime"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"xyz789"</span><span class="hljs-punctuation">}</span>
+</code></pre>
+                  </body>
+                </html>
+              </div>
+            </div>
+            <a href="#top">back to top</a>
           </div>
         </section>
         <section id="definition-StoreConfiguration" class="definition definition-object" data-traverse-target="definition-StoreConfiguration">
@@ -11408,6 +13199,7 @@ is <span class="hljs-keyword">an</span> all-<span class="hljs-keyword">or</span>
                 </html>
               </div>
             </div>
+            <a href="#top">back to top</a>
           </div>
         </section>
         <section id="definition-StoreConfigurationInput" class="definition definition-input-object" data-traverse-target="definition-StoreConfigurationInput">
@@ -11461,6 +13253,7 @@ is <span class="hljs-keyword">an</span> all-<span class="hljs-keyword">or</span>
                 </html>
               </div>
             </div>
+            <a href="#top">back to top</a>
           </div>
         </section>
         <section id="definition-StoreConfigurationMutationResponse" class="definition definition-object" data-traverse-target="definition-StoreConfigurationMutationResponse">
@@ -11504,6 +13297,7 @@ is <span class="hljs-keyword">an</span> all-<span class="hljs-keyword">or</span>
                 </html>
               </div>
             </div>
+            <a href="#top">back to top</a>
           </div>
         </section>
         <section id="definition-StoreConfigurationQueryResponse" class="definition definition-object" data-traverse-target="definition-StoreConfigurationQueryResponse">
@@ -11547,6 +13341,7 @@ is <span class="hljs-keyword">an</span> all-<span class="hljs-keyword">or</span>
                 </html>
               </div>
             </div>
+            <a href="#top">back to top</a>
           </div>
         </section>
         <section id="definition-String" class="definition definition-scalar" data-traverse-target="definition-String">
@@ -11572,6 +13367,7 @@ is <span class="hljs-keyword">an</span> all-<span class="hljs-keyword">or</span>
                 </html>
               </div>
             </div>
+            <a href="#top">back to top</a>
           </div>
         </section>
         <section id="definition-StringOperatorRequest" class="definition definition-input-object" data-traverse-target="definition-StringOperatorRequest">
@@ -11616,6 +13412,7 @@ is <span class="hljs-keyword">an</span> all-<span class="hljs-keyword">or</span>
                 </html>
               </div>
             </div>
+            <a href="#top">back to top</a>
           </div>
         </section>
         <section id="definition-StringOperatorResponse" class="definition definition-object" data-traverse-target="definition-StringOperatorResponse">
@@ -11659,6 +13456,7 @@ is <span class="hljs-keyword">an</span> all-<span class="hljs-keyword">or</span>
                 </html>
               </div>
             </div>
+            <a href="#top">back to top</a>
           </div>
         </section>
         <section id="definition-StringOperatorType" class="definition definition-enum" data-traverse-target="definition-StringOperatorType">
@@ -11711,6 +13509,7 @@ is <span class="hljs-keyword">an</span> all-<span class="hljs-keyword">or</span>
                 </html>
               </div>
             </div>
+            <a href="#top">back to top</a>
           </div>
         </section>
         <section id="definition-SubcategoryOverridesQueryResponse" class="definition definition-object" data-traverse-target="definition-SubcategoryOverridesQueryResponse">
@@ -11753,12 +13552,13 @@ is <span class="hljs-keyword">an</span> all-<span class="hljs-keyword">or</span>
                 <h5>Example</h5>
                 <html>
                   <head></head>
-                  <body><pre><code class="hljs language-json"><span class="hljs-punctuation">{</span><span class="hljs-attr">"categoryRules"</span><span class="hljs-punctuation">:</span> <span class="hljs-punctuation">[</span><span class="hljs-string">CategoryRule</span><span class="hljs-punctuation">]</span><span class="hljs-punctuation">,</span> <span class="hljs-attr">"totalCount"</span><span class="hljs-punctuation">:</span> <span class="hljs-number">123</span><span class="hljs-punctuation">}</span>
+                  <body><pre><code class="hljs language-json"><span class="hljs-punctuation">{</span><span class="hljs-attr">"categoryRules"</span><span class="hljs-punctuation">:</span> <span class="hljs-punctuation">[</span><span class="hljs-string">CategoryRule</span><span class="hljs-punctuation">]</span><span class="hljs-punctuation">,</span> <span class="hljs-attr">"totalCount"</span><span class="hljs-punctuation">:</span> <span class="hljs-number">987</span><span class="hljs-punctuation">}</span>
 </code></pre>
                   </body>
                 </html>
               </div>
             </div>
+            <a href="#top">back to top</a>
           </div>
         </section>
         <section id="definition-SummaryResponse" class="definition definition-object" data-traverse-target="definition-SummaryResponse">
@@ -11822,8 +13622,8 @@ is <span class="hljs-keyword">an</span> all-<span class="hljs-keyword">or</span>
                   <body><pre><code class="hljs language-json"><span class="hljs-punctuation">{</span>
   <span class="hljs-attr">"averageClickPos"</span><span class="hljs-punctuation">:</span> <span class="hljs-number">987.65</span><span class="hljs-punctuation">,</span>
   <span class="hljs-attr">"clickThruRate"</span><span class="hljs-punctuation">:</span> <span class="hljs-number">123.45</span><span class="hljs-punctuation">,</span>
-  <span class="hljs-attr">"conversionRate"</span><span class="hljs-punctuation">:</span> <span class="hljs-number">987.65</span><span class="hljs-punctuation">,</span>
-  <span class="hljs-attr">"uniqueSearches"</span><span class="hljs-punctuation">:</span> <span class="hljs-number">123</span><span class="hljs-punctuation">,</span>
+  <span class="hljs-attr">"conversionRate"</span><span class="hljs-punctuation">:</span> <span class="hljs-number">123.45</span><span class="hljs-punctuation">,</span>
+  <span class="hljs-attr">"uniqueSearches"</span><span class="hljs-punctuation">:</span> <span class="hljs-number">987</span><span class="hljs-punctuation">,</span>
   <span class="hljs-attr">"zeroResultsRate"</span><span class="hljs-punctuation">:</span> <span class="hljs-number">987.65</span>
 <span class="hljs-punctuation">}</span>
 </code></pre>
@@ -11831,6 +13631,7 @@ is <span class="hljs-keyword">an</span> all-<span class="hljs-keyword">or</span>
                 </html>
               </div>
             </div>
+            <a href="#top">back to top</a>
           </div>
         </section>
         <section id="definition-SynonymsGroup" class="definition definition-object" data-traverse-target="definition-SynonymsGroup">
@@ -11884,9 +13685,9 @@ is <span class="hljs-keyword">an</span> all-<span class="hljs-keyword">or</span>
                 <html>
                   <head></head>
                   <body><pre><code class="hljs language-json"><span class="hljs-punctuation">{</span>
-  <span class="hljs-attr">"anchor"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"xyz789"</span><span class="hljs-punctuation">,</span>
-  <span class="hljs-attr">"id"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"xyz789"</span><span class="hljs-punctuation">,</span>
-  <span class="hljs-attr">"terms"</span><span class="hljs-punctuation">:</span> <span class="hljs-punctuation">[</span><span class="hljs-string">"abc123"</span><span class="hljs-punctuation">]</span><span class="hljs-punctuation">,</span>
+  <span class="hljs-attr">"anchor"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"abc123"</span><span class="hljs-punctuation">,</span>
+  <span class="hljs-attr">"id"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"abc123"</span><span class="hljs-punctuation">,</span>
+  <span class="hljs-attr">"terms"</span><span class="hljs-punctuation">:</span> <span class="hljs-punctuation">[</span><span class="hljs-string">"xyz789"</span><span class="hljs-punctuation">]</span><span class="hljs-punctuation">,</span>
   <span class="hljs-attr">"type"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"EQUIVALENT"</span>
 <span class="hljs-punctuation">}</span>
 </code></pre>
@@ -11894,6 +13695,7 @@ is <span class="hljs-keyword">an</span> all-<span class="hljs-keyword">or</span>
                 </html>
               </div>
             </div>
+            <a href="#top">back to top</a>
           </div>
         </section>
         <section id="definition-SynonymsInput" class="definition definition-input-object" data-traverse-target="definition-SynonymsInput">
@@ -11953,7 +13755,7 @@ is <span class="hljs-keyword">an</span> all-<span class="hljs-keyword">or</span>
                   <body><pre><code class="hljs language-json"><span class="hljs-punctuation">{</span>
   <span class="hljs-attr">"anchor"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"abc123"</span><span class="hljs-punctuation">,</span>
   <span class="hljs-attr">"id"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"xyz789"</span><span class="hljs-punctuation">,</span>
-  <span class="hljs-attr">"terms"</span><span class="hljs-punctuation">:</span> <span class="hljs-punctuation">[</span><span class="hljs-string">"xyz789"</span><span class="hljs-punctuation">]</span><span class="hljs-punctuation">,</span>
+  <span class="hljs-attr">"terms"</span><span class="hljs-punctuation">:</span> <span class="hljs-punctuation">[</span><span class="hljs-string">"abc123"</span><span class="hljs-punctuation">]</span><span class="hljs-punctuation">,</span>
   <span class="hljs-attr">"type"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"EQUIVALENT"</span>
 <span class="hljs-punctuation">}</span>
 </code></pre>
@@ -11961,6 +13763,7 @@ is <span class="hljs-keyword">an</span> all-<span class="hljs-keyword">or</span>
                 </html>
               </div>
             </div>
+            <a href="#top">back to top</a>
           </div>
         </section>
         <section id="definition-SynonymsMutationResponse" class="definition definition-object" data-traverse-target="definition-SynonymsMutationResponse">
@@ -12004,6 +13807,7 @@ is <span class="hljs-keyword">an</span> all-<span class="hljs-keyword">or</span>
                 </html>
               </div>
             </div>
+            <a href="#top">back to top</a>
           </div>
         </section>
         <section id="definition-SynonymsQueryResponse" class="definition definition-object" data-traverse-target="definition-SynonymsQueryResponse">
@@ -12047,6 +13851,7 @@ is <span class="hljs-keyword">an</span> all-<span class="hljs-keyword">or</span>
                 </html>
               </div>
             </div>
+            <a href="#top">back to top</a>
           </div>
         </section>
         <section id="definition-SynonymsType" class="definition definition-enum" data-traverse-target="definition-SynonymsType">
@@ -12099,6 +13904,7 @@ is <span class="hljs-keyword">an</span> all-<span class="hljs-keyword">or</span>
                 </html>
               </div>
             </div>
+            <a href="#top">back to top</a>
           </div>
         </section>
         <section id="definition-Timeframe" class="definition definition-object" data-traverse-target="definition-Timeframe">
@@ -12142,14 +13948,15 @@ is <span class="hljs-keyword">an</span> all-<span class="hljs-keyword">or</span>
                 <html>
                   <head></head>
                   <body><pre><code class="hljs language-json"><span class="hljs-punctuation">{</span>
-  <span class="hljs-attr">"end"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"abc123"</span><span class="hljs-punctuation">,</span>
-  <span class="hljs-attr">"start"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"abc123"</span>
+  <span class="hljs-attr">"end"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"xyz789"</span><span class="hljs-punctuation">,</span>
+  <span class="hljs-attr">"start"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"xyz789"</span>
 <span class="hljs-punctuation">}</span>
 </code></pre>
                   </body>
                 </html>
               </div>
             </div>
+            <a href="#top">back to top</a>
           </div>
         </section>
         <section id="definition-TimeframeInput" class="definition definition-input-object" data-traverse-target="definition-TimeframeInput">
@@ -12195,14 +14002,15 @@ is <span class="hljs-keyword">an</span> all-<span class="hljs-keyword">or</span>
                 <html>
                   <head></head>
                   <body><pre><code class="hljs language-json"><span class="hljs-punctuation">{</span>
-  <span class="hljs-attr">"end"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"abc123"</span><span class="hljs-punctuation">,</span>
-  <span class="hljs-attr">"start"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"xyz789"</span>
+  <span class="hljs-attr">"end"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"xyz789"</span><span class="hljs-punctuation">,</span>
+  <span class="hljs-attr">"start"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"abc123"</span>
 <span class="hljs-punctuation">}</span>
 </code></pre>
                   </body>
                 </html>
               </div>
             </div>
+            <a href="#top">back to top</a>
           </div>
         </section>
         <section id="definition-TransportType" class="definition definition-enum" data-traverse-target="definition-TransportType">
@@ -12248,6 +14056,7 @@ is <span class="hljs-keyword">an</span> all-<span class="hljs-keyword">or</span>
                 </html>
               </div>
             </div>
+            <a href="#top">back to top</a>
           </div>
         </section>
         <section id="definition-TrendingWindow" class="definition definition-enum" data-traverse-target="definition-TrendingWindow">
@@ -12307,6 +14116,7 @@ is <span class="hljs-keyword">an</span> all-<span class="hljs-keyword">or</span>
                 </html>
               </div>
             </div>
+            <a href="#top">back to top</a>
           </div>
         </section>
         <section id="definition-TriggerRequest" class="definition definition-input-object" data-traverse-target="definition-TriggerRequest">
@@ -12360,6 +14170,7 @@ is <span class="hljs-keyword">an</span> all-<span class="hljs-keyword">or</span>
                 </html>
               </div>
             </div>
+            <a href="#top">back to top</a>
           </div>
         </section>
         <section id="definition-TriggerResponse" class="definition definition-object" data-traverse-target="definition-TriggerResponse">
@@ -12411,6 +14222,7 @@ is <span class="hljs-keyword">an</span> all-<span class="hljs-keyword">or</span>
                 </html>
               </div>
             </div>
+            <a href="#top">back to top</a>
           </div>
         </section>
         <section id="definition-UniqueSearchesResponse" class="definition definition-object" data-traverse-target="definition-UniqueSearchesResponse">
@@ -12460,14 +14272,15 @@ is <span class="hljs-keyword">an</span> all-<span class="hljs-keyword">or</span>
                   <head></head>
                   <body><pre><code class="hljs language-json"><span class="hljs-punctuation">{</span>
   <span class="hljs-attr">"count"</span><span class="hljs-punctuation">:</span> <span class="hljs-number">123</span><span class="hljs-punctuation">,</span>
-  <span class="hljs-attr">"refinements"</span><span class="hljs-punctuation">:</span> <span class="hljs-number">987</span><span class="hljs-punctuation">,</span>
-  <span class="hljs-attr">"searchQuery"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"xyz789"</span>
+  <span class="hljs-attr">"refinements"</span><span class="hljs-punctuation">:</span> <span class="hljs-number">123</span><span class="hljs-punctuation">,</span>
+  <span class="hljs-attr">"searchQuery"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"abc123"</span>
 <span class="hljs-punctuation">}</span>
 </code></pre>
                   </body>
                 </html>
               </div>
             </div>
+            <a href="#top">back to top</a>
           </div>
         </section>
         <section id="definition-UnitPageType" class="definition definition-enum" data-traverse-target="definition-UnitPageType">
@@ -12548,6 +14361,7 @@ is <span class="hljs-keyword">an</span> all-<span class="hljs-keyword">or</span>
                 </html>
               </div>
             </div>
+            <a href="#top">back to top</a>
           </div>
         </section>
         <section id="definition-UnitResponse" class="definition definition-object" data-traverse-target="definition-UnitResponse">
@@ -12652,25 +14466,26 @@ is <span class="hljs-keyword">an</span> all-<span class="hljs-keyword">or</span>
                 <html>
                   <head></head>
                   <body><pre><code class="hljs language-json"><span class="hljs-punctuation">{</span>
-  <span class="hljs-attr">"createdAt"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"abc123"</span><span class="hljs-punctuation">,</span>
-  <span class="hljs-attr">"displayNumber"</span><span class="hljs-punctuation">:</span> <span class="hljs-number">987</span><span class="hljs-punctuation">,</span>
+  <span class="hljs-attr">"createdAt"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"xyz789"</span><span class="hljs-punctuation">,</span>
+  <span class="hljs-attr">"displayNumber"</span><span class="hljs-punctuation">:</span> <span class="hljs-number">123</span><span class="hljs-punctuation">,</span>
   <span class="hljs-attr">"displayOrder"</span><span class="hljs-punctuation">:</span> <span class="hljs-number">987</span><span class="hljs-punctuation">,</span>
   <span class="hljs-attr">"filterRules"</span><span class="hljs-punctuation">:</span> <span class="hljs-punctuation">[</span><span class="hljs-string">FilterRuleResponse</span><span class="hljs-punctuation">]</span><span class="hljs-punctuation">,</span>
-  <span class="hljs-attr">"id"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"xyz789"</span><span class="hljs-punctuation">,</span>
+  <span class="hljs-attr">"id"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"abc123"</span><span class="hljs-punctuation">,</span>
   <span class="hljs-attr">"metrics"</span><span class="hljs-punctuation">:</span> <span class="hljs-punctuation">[</span><span class="hljs-string">Metrics</span><span class="hljs-punctuation">]</span><span class="hljs-punctuation">,</span>
-  <span class="hljs-attr">"pagePlacement"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"abc123"</span><span class="hljs-punctuation">,</span>
+  <span class="hljs-attr">"pagePlacement"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"xyz789"</span><span class="hljs-punctuation">,</span>
   <span class="hljs-attr">"pageType"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"CART"</span><span class="hljs-punctuation">,</span>
   <span class="hljs-attr">"storefrontLabel"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"abc123"</span><span class="hljs-punctuation">,</span>
-  <span class="hljs-attr">"unitName"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"abc123"</span><span class="hljs-punctuation">,</span>
+  <span class="hljs-attr">"unitName"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"xyz789"</span><span class="hljs-punctuation">,</span>
   <span class="hljs-attr">"unitStatus"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"ACTIVE"</span><span class="hljs-punctuation">,</span>
   <span class="hljs-attr">"unitType"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"ADD_TO_CART_CONVERSION_RATE"</span><span class="hljs-punctuation">,</span>
-  <span class="hljs-attr">"updatedAt"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"xyz789"</span>
+  <span class="hljs-attr">"updatedAt"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"abc123"</span>
 <span class="hljs-punctuation">}</span>
 </code></pre>
                   </body>
                 </html>
               </div>
             </div>
+            <a href="#top">back to top</a>
           </div>
         </section>
         <section id="definition-UnitStatus" class="definition definition-enum" data-traverse-target="definition-UnitStatus">
@@ -12744,6 +14559,7 @@ is <span class="hljs-keyword">an</span> all-<span class="hljs-keyword">or</span>
                 </html>
               </div>
             </div>
+            <a href="#top">back to top</a>
           </div>
         </section>
         <section id="definition-UnitType" class="definition definition-enum" data-traverse-target="definition-UnitType">
@@ -12874,6 +14690,7 @@ is <span class="hljs-keyword">an</span> all-<span class="hljs-keyword">or</span>
                 </html>
               </div>
             </div>
+            <a href="#top">back to top</a>
           </div>
         </section>
         <section id="definition-UpdateChannelRequest" class="definition definition-input-object" data-traverse-target="definition-UpdateChannelRequest">
@@ -12913,13 +14730,13 @@ is <span class="hljs-keyword">an</span> all-<span class="hljs-keyword">or</span>
                       <td>
                         <span class="property-name"><code>policyIds</code></span> - <span class="property-type"><a href="#definition-String"><code>[String!]</code></a></span>
                       </td>
-                      <td> List of policy identifiers. If included, it cannot be empty. </td>
+                      <td> List of policy identifiers. Providing an empty list removes all policy links to the channel. </td>
                     </tr>
                     <tr>
                       <td>
                         <span class="property-name"><code>scopes</code></span> - <span class="property-type"><a href="#definition-ChannelScopeRequest"><code>[ChannelScopeRequest!]</code></a></span>
                       </td>
-                      <td> List of scopes. If included, it cannot be empty. </td>
+                      <td> List of scopes. Providing an empty list removes all scopes from the channel. </td>
                     </tr>
                   </tbody>
                 </table>
@@ -12933,7 +14750,7 @@ is <span class="hljs-keyword">an</span> all-<span class="hljs-keyword">or</span>
                   <body><pre><code class="hljs language-json"><span class="hljs-punctuation">{</span>
   <span class="hljs-attr">"channelId"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"abc123"</span><span class="hljs-punctuation">,</span>
   <span class="hljs-attr">"name"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"xyz789"</span><span class="hljs-punctuation">,</span>
-  <span class="hljs-attr">"policyIds"</span><span class="hljs-punctuation">:</span> <span class="hljs-punctuation">[</span><span class="hljs-string">"abc123"</span><span class="hljs-punctuation">]</span><span class="hljs-punctuation">,</span>
+  <span class="hljs-attr">"policyIds"</span><span class="hljs-punctuation">:</span> <span class="hljs-punctuation">[</span><span class="hljs-string">"xyz789"</span><span class="hljs-punctuation">]</span><span class="hljs-punctuation">,</span>
   <span class="hljs-attr">"scopes"</span><span class="hljs-punctuation">:</span> <span class="hljs-punctuation">[</span><span class="hljs-string">ChannelScopeRequest</span><span class="hljs-punctuation">]</span>
 <span class="hljs-punctuation">}</span>
 </code></pre>
@@ -12941,6 +14758,7 @@ is <span class="hljs-keyword">an</span> all-<span class="hljs-keyword">or</span>
                 </html>
               </div>
             </div>
+            <a href="#top">back to top</a>
           </div>
         </section>
         <section id="definition-UpdatePolicyRequest" class="definition definition-input-object" data-traverse-target="definition-UpdatePolicyRequest">
@@ -12999,15 +14817,16 @@ is <span class="hljs-keyword">an</span> all-<span class="hljs-keyword">or</span>
                   <head></head>
                   <body><pre><code class="hljs language-json"><span class="hljs-punctuation">{</span>
   <span class="hljs-attr">"actions"</span><span class="hljs-punctuation">:</span> <span class="hljs-punctuation">[</span><span class="hljs-string">ActionRequest</span><span class="hljs-punctuation">]</span><span class="hljs-punctuation">,</span>
-  <span class="hljs-attr">"mandatory"</span><span class="hljs-punctuation">:</span> <span class="hljs-literal"><span class="hljs-keyword">true</span></span><span class="hljs-punctuation">,</span>
+  <span class="hljs-attr">"mandatory"</span><span class="hljs-punctuation">:</span> <span class="hljs-literal"><span class="hljs-keyword">false</span></span><span class="hljs-punctuation">,</span>
   <span class="hljs-attr">"name"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"abc123"</span><span class="hljs-punctuation">,</span>
-  <span class="hljs-attr">"policyId"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"abc123"</span>
+  <span class="hljs-attr">"policyId"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"xyz789"</span>
 <span class="hljs-punctuation">}</span>
 </code></pre>
                   </body>
                 </html>
               </div>
             </div>
+            <a href="#top">back to top</a>
           </div>
         </section>
         <section id="definition-UpdateUnitRequest" class="definition definition-input-object" data-traverse-target="definition-UpdateUnitRequest">
@@ -13108,13 +14927,13 @@ is <span class="hljs-keyword">an</span> all-<span class="hljs-keyword">or</span>
                 <html>
                   <head></head>
                   <body><pre><code class="hljs language-json"><span class="hljs-punctuation">{</span>
-  <span class="hljs-attr">"displayNumber"</span><span class="hljs-punctuation">:</span> <span class="hljs-number">987</span><span class="hljs-punctuation">,</span>
+  <span class="hljs-attr">"displayNumber"</span><span class="hljs-punctuation">:</span> <span class="hljs-number">123</span><span class="hljs-punctuation">,</span>
   <span class="hljs-attr">"displayOrder"</span><span class="hljs-punctuation">:</span> <span class="hljs-number">123</span><span class="hljs-punctuation">,</span>
   <span class="hljs-attr">"filterRules"</span><span class="hljs-punctuation">:</span> <span class="hljs-punctuation">[</span><span class="hljs-string">FilterRuleRequest</span><span class="hljs-punctuation">]</span><span class="hljs-punctuation">,</span>
-  <span class="hljs-attr">"id"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"xyz789"</span><span class="hljs-punctuation">,</span>
-  <span class="hljs-attr">"pagePlacement"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"abc123"</span><span class="hljs-punctuation">,</span>
+  <span class="hljs-attr">"id"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"abc123"</span><span class="hljs-punctuation">,</span>
+  <span class="hljs-attr">"pagePlacement"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"xyz789"</span><span class="hljs-punctuation">,</span>
   <span class="hljs-attr">"pageType"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"CART"</span><span class="hljs-punctuation">,</span>
-  <span class="hljs-attr">"storefrontLabel"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"abc123"</span><span class="hljs-punctuation">,</span>
+  <span class="hljs-attr">"storefrontLabel"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"xyz789"</span><span class="hljs-punctuation">,</span>
   <span class="hljs-attr">"unitName"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"xyz789"</span><span class="hljs-punctuation">,</span>
   <span class="hljs-attr">"unitStatus"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"ACTIVE"</span><span class="hljs-punctuation">,</span>
   <span class="hljs-attr">"unitType"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"ADD_TO_CART_CONVERSION_RATE"</span>
@@ -13124,6 +14943,7 @@ is <span class="hljs-keyword">an</span> all-<span class="hljs-keyword">or</span>
                 </html>
               </div>
             </div>
+            <a href="#top">back to top</a>
           </div>
         </section>
         <section id="definition-ZeroResultsResponse" class="definition definition-object" data-traverse-target="definition-ZeroResultsResponse">
@@ -13166,12 +14986,13 @@ is <span class="hljs-keyword">an</span> all-<span class="hljs-keyword">or</span>
                 <h5>Example</h5>
                 <html>
                   <head></head>
-                  <body><pre><code class="hljs language-json"><span class="hljs-punctuation">{</span><span class="hljs-attr">"count"</span><span class="hljs-punctuation">:</span> <span class="hljs-number">123</span><span class="hljs-punctuation">,</span> <span class="hljs-attr">"searchQuery"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"abc123"</span><span class="hljs-punctuation">}</span>
+                  <body><pre><code class="hljs language-json"><span class="hljs-punctuation">{</span><span class="hljs-attr">"count"</span><span class="hljs-punctuation">:</span> <span class="hljs-number">987</span><span class="hljs-punctuation">,</span> <span class="hljs-attr">"searchQuery"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"xyz789"</span><span class="hljs-punctuation">}</span>
 </code></pre>
                   </body>
                 </html>
               </div>
             </div>
+            <a href="#top">back to top</a>
           </div>
         </section>
         <div class="doc-row no-margin">

--- a/static/graphql-api/storefront-api/index.html
+++ b/static/graphql-api/storefront-api/index.html
@@ -208,6 +208,7 @@ Authorization: Bearer &lt;YOUR_TOKEN_HERE&gt;</code></pre>
                 </html>
               </div>
             </div>
+            <a href="#top">back to top</a>
           </div>
         </section>
         <section id="query-productSearch" class="operation operation-query" data-traverse-target="query-productSearch">
@@ -349,8 +350,8 @@ Authorization: Bearer &lt;YOUR_TOKEN_HERE&gt;</code></pre>
       <span class="hljs-attr">"items"</span><span class="hljs-punctuation">:</span> <span class="hljs-punctuation">[</span><span class="hljs-string">ProductSearchItem</span><span class="hljs-punctuation">]</span><span class="hljs-punctuation">,</span>
       <span class="hljs-attr">"page_info"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">SearchResultPageInfo</span><span class="hljs-punctuation">,</span>
       <span class="hljs-attr">"related_terms"</span><span class="hljs-punctuation">:</span> <span class="hljs-punctuation">[</span><span class="hljs-string">"abc123"</span><span class="hljs-punctuation">]</span><span class="hljs-punctuation">,</span>
-      <span class="hljs-attr">"suggestions"</span><span class="hljs-punctuation">:</span> <span class="hljs-punctuation">[</span><span class="hljs-string">"abc123"</span><span class="hljs-punctuation">]</span><span class="hljs-punctuation">,</span>
-      <span class="hljs-attr">"total_count"</span><span class="hljs-punctuation">:</span> <span class="hljs-number">123</span>
+      <span class="hljs-attr">"suggestions"</span><span class="hljs-punctuation">:</span> <span class="hljs-punctuation">[</span><span class="hljs-string">"xyz789"</span><span class="hljs-punctuation">]</span><span class="hljs-punctuation">,</span>
+      <span class="hljs-attr">"total_count"</span><span class="hljs-punctuation">:</span> <span class="hljs-number">987</span>
     <span class="hljs-punctuation">}</span>
   <span class="hljs-punctuation">}</span>
 <span class="hljs-punctuation">}</span>
@@ -359,6 +360,7 @@ Authorization: Bearer &lt;YOUR_TOKEN_HERE&gt;</code></pre>
                 </html>
               </div>
             </div>
+            <a href="#top">back to top</a>
           </div>
         </section>
         <section id="query-products" class="operation operation-query" data-traverse-target="query-products">
@@ -457,7 +459,7 @@ Authorization: Bearer &lt;YOUR_TOKEN_HERE&gt;</code></pre>
                 <h5>Variables</h5>
                 <html>
                   <head></head>
-                  <body><pre><code class="hljs language-json"><span class="hljs-punctuation">{</span><span class="hljs-attr">"skus"</span><span class="hljs-punctuation">:</span> <span class="hljs-punctuation">[</span><span class="hljs-string">"abc123"</span><span class="hljs-punctuation">]</span><span class="hljs-punctuation">}</span>
+                  <body><pre><code class="hljs language-json"><span class="hljs-punctuation">{</span><span class="hljs-attr">"skus"</span><span class="hljs-punctuation">:</span> <span class="hljs-punctuation">[</span><span class="hljs-string">"xyz789"</span><span class="hljs-punctuation">]</span><span class="hljs-punctuation">}</span>
 </code></pre>
                   </body>
                 </html>
@@ -471,16 +473,16 @@ Authorization: Bearer &lt;YOUR_TOKEN_HERE&gt;</code></pre>
     <span class="hljs-attr">"products"</span><span class="hljs-punctuation">:</span> <span class="hljs-punctuation">[</span>
       <span class="hljs-punctuation">{</span>
         <span class="hljs-attr">"addToCartAllowed"</span><span class="hljs-punctuation">:</span> <span class="hljs-literal"><span class="hljs-keyword">false</span></span><span class="hljs-punctuation">,</span>
-        <span class="hljs-attr">"inStock"</span><span class="hljs-punctuation">:</span> <span class="hljs-literal"><span class="hljs-keyword">false</span></span><span class="hljs-punctuation">,</span>
-        <span class="hljs-attr">"lowStock"</span><span class="hljs-punctuation">:</span> <span class="hljs-literal"><span class="hljs-keyword">false</span></span><span class="hljs-punctuation">,</span>
+        <span class="hljs-attr">"inStock"</span><span class="hljs-punctuation">:</span> <span class="hljs-literal"><span class="hljs-keyword">true</span></span><span class="hljs-punctuation">,</span>
+        <span class="hljs-attr">"lowStock"</span><span class="hljs-punctuation">:</span> <span class="hljs-literal"><span class="hljs-keyword">true</span></span><span class="hljs-punctuation">,</span>
         <span class="hljs-attr">"attributes"</span><span class="hljs-punctuation">:</span> <span class="hljs-punctuation">[</span><span class="hljs-string">ProductViewAttribute</span><span class="hljs-punctuation">]</span><span class="hljs-punctuation">,</span>
         <span class="hljs-attr">"description"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"xyz789"</span><span class="hljs-punctuation">,</span>
-        <span class="hljs-attr">"id"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"4"</span><span class="hljs-punctuation">,</span>
+        <span class="hljs-attr">"id"</span><span class="hljs-punctuation">:</span> <span class="hljs-number">4</span><span class="hljs-punctuation">,</span>
         <span class="hljs-attr">"images"</span><span class="hljs-punctuation">:</span> <span class="hljs-punctuation">[</span><span class="hljs-string">ProductViewImage</span><span class="hljs-punctuation">]</span><span class="hljs-punctuation">,</span>
         <span class="hljs-attr">"videos"</span><span class="hljs-punctuation">:</span> <span class="hljs-punctuation">[</span><span class="hljs-string">ProductViewVideo</span><span class="hljs-punctuation">]</span><span class="hljs-punctuation">,</span>
         <span class="hljs-attr">"lastModifiedAt"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"2007-12-03T10:15:30Z"</span><span class="hljs-punctuation">,</span>
         <span class="hljs-attr">"metaDescription"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"abc123"</span><span class="hljs-punctuation">,</span>
-        <span class="hljs-attr">"metaKeyword"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"xyz789"</span><span class="hljs-punctuation">,</span>
+        <span class="hljs-attr">"metaKeyword"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"abc123"</span><span class="hljs-punctuation">,</span>
         <span class="hljs-attr">"metaTitle"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"xyz789"</span><span class="hljs-punctuation">,</span>
         <span class="hljs-attr">"name"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"abc123"</span><span class="hljs-punctuation">,</span>
         <span class="hljs-attr">"shortDescription"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"xyz789"</span><span class="hljs-punctuation">,</span>
@@ -490,11 +492,11 @@ Authorization: Bearer &lt;YOUR_TOKEN_HERE&gt;</code></pre>
         <span class="hljs-attr">"url"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"xyz789"</span><span class="hljs-punctuation">,</span>
         <span class="hljs-attr">"urlKey"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"abc123"</span><span class="hljs-punctuation">,</span>
         <span class="hljs-attr">"links"</span><span class="hljs-punctuation">:</span> <span class="hljs-punctuation">[</span><span class="hljs-string">ProductViewLink</span><span class="hljs-punctuation">]</span><span class="hljs-punctuation">,</span>
-        <span class="hljs-attr">"categories"</span><span class="hljs-punctuation">:</span> <span class="hljs-punctuation">[</span><span class="hljs-string">"xyz789"</span><span class="hljs-punctuation">]</span><span class="hljs-punctuation">,</span>
+        <span class="hljs-attr">"categories"</span><span class="hljs-punctuation">:</span> <span class="hljs-punctuation">[</span><span class="hljs-string">"abc123"</span><span class="hljs-punctuation">]</span><span class="hljs-punctuation">,</span>
         <span class="hljs-attr">"queryType"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"xyz789"</span><span class="hljs-punctuation">,</span>
         <span class="hljs-attr">"rank"</span><span class="hljs-punctuation">:</span> <span class="hljs-number">123</span><span class="hljs-punctuation">,</span>
         <span class="hljs-attr">"score"</span><span class="hljs-punctuation">:</span> <span class="hljs-number">987.65</span><span class="hljs-punctuation">,</span>
-        <span class="hljs-attr">"visibility"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"xyz789"</span>
+        <span class="hljs-attr">"visibility"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"abc123"</span>
       <span class="hljs-punctuation">}</span>
     <span class="hljs-punctuation">]</span>
   <span class="hljs-punctuation">}</span>
@@ -504,6 +506,7 @@ Authorization: Bearer &lt;YOUR_TOKEN_HERE&gt;</code></pre>
                 </html>
               </div>
             </div>
+            <a href="#top">back to top</a>
           </div>
         </section>
         <section id="query-recommendations" class="operation operation-query" data-traverse-target="query-recommendations">
@@ -616,8 +619,8 @@ Authorization: Bearer &lt;YOUR_TOKEN_HERE&gt;</code></pre>
                   <head></head>
                   <body><pre><code class="hljs language-json"><span class="hljs-punctuation">{</span>
   <span class="hljs-attr">"cartSkus"</span><span class="hljs-punctuation">:</span> <span class="hljs-punctuation">[</span><span class="hljs-string">"abc123"</span><span class="hljs-punctuation">]</span><span class="hljs-punctuation">,</span>
-  <span class="hljs-attr">"category"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"abc123"</span><span class="hljs-punctuation">,</span>
-  <span class="hljs-attr">"currentSku"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"abc123"</span><span class="hljs-punctuation">,</span>
+  <span class="hljs-attr">"category"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"xyz789"</span><span class="hljs-punctuation">,</span>
+  <span class="hljs-attr">"currentSku"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"xyz789"</span><span class="hljs-punctuation">,</span>
   <span class="hljs-attr">"pageType"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"CMS"</span><span class="hljs-punctuation">,</span>
   <span class="hljs-attr">"userPurchaseHistory"</span><span class="hljs-punctuation">:</span> <span class="hljs-punctuation">[</span><span class="hljs-string">PurchaseHistory</span><span class="hljs-punctuation">]</span><span class="hljs-punctuation">,</span>
   <span class="hljs-attr">"userViewHistory"</span><span class="hljs-punctuation">:</span> <span class="hljs-punctuation">[</span><span class="hljs-string">ViewHistory</span><span class="hljs-punctuation">]</span>
@@ -634,7 +637,7 @@ Authorization: Bearer &lt;YOUR_TOKEN_HERE&gt;</code></pre>
   <span class="hljs-attr">"data"</span><span class="hljs-punctuation">:</span> <span class="hljs-punctuation">{</span>
     <span class="hljs-attr">"recommendations"</span><span class="hljs-punctuation">:</span> <span class="hljs-punctuation">{</span>
       <span class="hljs-attr">"results"</span><span class="hljs-punctuation">:</span> <span class="hljs-punctuation">[</span><span class="hljs-string">RecommendationUnit</span><span class="hljs-punctuation">]</span><span class="hljs-punctuation">,</span>
-      <span class="hljs-attr">"totalResults"</span><span class="hljs-punctuation">:</span> <span class="hljs-number">123</span>
+      <span class="hljs-attr">"totalResults"</span><span class="hljs-punctuation">:</span> <span class="hljs-number">987</span>
     <span class="hljs-punctuation">}</span>
   <span class="hljs-punctuation">}</span>
 <span class="hljs-punctuation">}</span>
@@ -643,6 +646,7 @@ Authorization: Bearer &lt;YOUR_TOKEN_HERE&gt;</code></pre>
                 </html>
               </div>
             </div>
+            <a href="#top">back to top</a>
           </div>
         </section>
         <section id="query-refineProduct" class="operation operation-query" data-traverse-target="query-refineProduct">
@@ -748,7 +752,7 @@ Authorization: Bearer &lt;YOUR_TOKEN_HERE&gt;</code></pre>
                   <head></head>
                   <body><pre><code class="hljs language-json"><span class="hljs-punctuation">{</span>
   <span class="hljs-attr">"optionIds"</span><span class="hljs-punctuation">:</span> <span class="hljs-punctuation">[</span><span class="hljs-string">"xyz789"</span><span class="hljs-punctuation">]</span><span class="hljs-punctuation">,</span>
-  <span class="hljs-attr">"sku"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"xyz789"</span>
+  <span class="hljs-attr">"sku"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"abc123"</span>
 <span class="hljs-punctuation">}</span>
 </code></pre>
                   </body>
@@ -761,30 +765,30 @@ Authorization: Bearer &lt;YOUR_TOKEN_HERE&gt;</code></pre>
                   <body><pre><code class="hljs language-json"><span class="hljs-punctuation">{</span>
   <span class="hljs-attr">"data"</span><span class="hljs-punctuation">:</span> <span class="hljs-punctuation">{</span>
     <span class="hljs-attr">"refineProduct"</span><span class="hljs-punctuation">:</span> <span class="hljs-punctuation">{</span>
-      <span class="hljs-attr">"addToCartAllowed"</span><span class="hljs-punctuation">:</span> <span class="hljs-literal"><span class="hljs-keyword">true</span></span><span class="hljs-punctuation">,</span>
-      <span class="hljs-attr">"inStock"</span><span class="hljs-punctuation">:</span> <span class="hljs-literal"><span class="hljs-keyword">true</span></span><span class="hljs-punctuation">,</span>
-      <span class="hljs-attr">"lowStock"</span><span class="hljs-punctuation">:</span> <span class="hljs-literal"><span class="hljs-keyword">false</span></span><span class="hljs-punctuation">,</span>
+      <span class="hljs-attr">"addToCartAllowed"</span><span class="hljs-punctuation">:</span> <span class="hljs-literal"><span class="hljs-keyword">false</span></span><span class="hljs-punctuation">,</span>
+      <span class="hljs-attr">"inStock"</span><span class="hljs-punctuation">:</span> <span class="hljs-literal"><span class="hljs-keyword">false</span></span><span class="hljs-punctuation">,</span>
+      <span class="hljs-attr">"lowStock"</span><span class="hljs-punctuation">:</span> <span class="hljs-literal"><span class="hljs-keyword">true</span></span><span class="hljs-punctuation">,</span>
       <span class="hljs-attr">"attributes"</span><span class="hljs-punctuation">:</span> <span class="hljs-punctuation">[</span><span class="hljs-string">ProductViewAttribute</span><span class="hljs-punctuation">]</span><span class="hljs-punctuation">,</span>
-      <span class="hljs-attr">"description"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"abc123"</span><span class="hljs-punctuation">,</span>
-      <span class="hljs-attr">"id"</span><span class="hljs-punctuation">:</span> <span class="hljs-number">4</span><span class="hljs-punctuation">,</span>
+      <span class="hljs-attr">"description"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"xyz789"</span><span class="hljs-punctuation">,</span>
+      <span class="hljs-attr">"id"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"4"</span><span class="hljs-punctuation">,</span>
       <span class="hljs-attr">"images"</span><span class="hljs-punctuation">:</span> <span class="hljs-punctuation">[</span><span class="hljs-string">ProductViewImage</span><span class="hljs-punctuation">]</span><span class="hljs-punctuation">,</span>
       <span class="hljs-attr">"videos"</span><span class="hljs-punctuation">:</span> <span class="hljs-punctuation">[</span><span class="hljs-string">ProductViewVideo</span><span class="hljs-punctuation">]</span><span class="hljs-punctuation">,</span>
       <span class="hljs-attr">"lastModifiedAt"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"2007-12-03T10:15:30Z"</span><span class="hljs-punctuation">,</span>
-      <span class="hljs-attr">"metaDescription"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"xyz789"</span><span class="hljs-punctuation">,</span>
+      <span class="hljs-attr">"metaDescription"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"abc123"</span><span class="hljs-punctuation">,</span>
       <span class="hljs-attr">"metaKeyword"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"xyz789"</span><span class="hljs-punctuation">,</span>
-      <span class="hljs-attr">"metaTitle"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"abc123"</span><span class="hljs-punctuation">,</span>
+      <span class="hljs-attr">"metaTitle"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"xyz789"</span><span class="hljs-punctuation">,</span>
       <span class="hljs-attr">"name"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"xyz789"</span><span class="hljs-punctuation">,</span>
       <span class="hljs-attr">"shortDescription"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"abc123"</span><span class="hljs-punctuation">,</span>
       <span class="hljs-attr">"inputOptions"</span><span class="hljs-punctuation">:</span> <span class="hljs-punctuation">[</span><span class="hljs-string">ProductViewInputOption</span><span class="hljs-punctuation">]</span><span class="hljs-punctuation">,</span>
       <span class="hljs-attr">"sku"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"abc123"</span><span class="hljs-punctuation">,</span>
-      <span class="hljs-attr">"externalId"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"xyz789"</span><span class="hljs-punctuation">,</span>
-      <span class="hljs-attr">"url"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"abc123"</span><span class="hljs-punctuation">,</span>
-      <span class="hljs-attr">"urlKey"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"abc123"</span><span class="hljs-punctuation">,</span>
+      <span class="hljs-attr">"externalId"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"abc123"</span><span class="hljs-punctuation">,</span>
+      <span class="hljs-attr">"url"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"xyz789"</span><span class="hljs-punctuation">,</span>
+      <span class="hljs-attr">"urlKey"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"xyz789"</span><span class="hljs-punctuation">,</span>
       <span class="hljs-attr">"links"</span><span class="hljs-punctuation">:</span> <span class="hljs-punctuation">[</span><span class="hljs-string">ProductViewLink</span><span class="hljs-punctuation">]</span><span class="hljs-punctuation">,</span>
       <span class="hljs-attr">"categories"</span><span class="hljs-punctuation">:</span> <span class="hljs-punctuation">[</span><span class="hljs-string">"xyz789"</span><span class="hljs-punctuation">]</span><span class="hljs-punctuation">,</span>
       <span class="hljs-attr">"queryType"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"xyz789"</span><span class="hljs-punctuation">,</span>
-      <span class="hljs-attr">"rank"</span><span class="hljs-punctuation">:</span> <span class="hljs-number">987</span><span class="hljs-punctuation">,</span>
-      <span class="hljs-attr">"score"</span><span class="hljs-punctuation">:</span> <span class="hljs-number">123.45</span><span class="hljs-punctuation">,</span>
+      <span class="hljs-attr">"rank"</span><span class="hljs-punctuation">:</span> <span class="hljs-number">123</span><span class="hljs-punctuation">,</span>
+      <span class="hljs-attr">"score"</span><span class="hljs-punctuation">:</span> <span class="hljs-number">987.65</span><span class="hljs-punctuation">,</span>
       <span class="hljs-attr">"visibility"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"xyz789"</span>
     <span class="hljs-punctuation">}</span>
   <span class="hljs-punctuation">}</span>
@@ -794,6 +798,7 @@ Authorization: Bearer &lt;YOUR_TOKEN_HERE&gt;</code></pre>
                 </html>
               </div>
             </div>
+            <a href="#top">back to top</a>
           </div>
         </section>
         <section id="query-variants" class="operation operation-query" data-traverse-target="query-variants">
@@ -885,10 +890,10 @@ Authorization: Bearer &lt;YOUR_TOKEN_HERE&gt;</code></pre>
                 <html>
                   <head></head>
                   <body><pre><code class="hljs language-json"><span class="hljs-punctuation">{</span>
-  <span class="hljs-attr">"sku"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"xyz789"</span><span class="hljs-punctuation">,</span>
+  <span class="hljs-attr">"sku"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"abc123"</span><span class="hljs-punctuation">,</span>
   <span class="hljs-attr">"optionIds"</span><span class="hljs-punctuation">:</span> <span class="hljs-punctuation">[</span><span class="hljs-string">"xyz789"</span><span class="hljs-punctuation">]</span><span class="hljs-punctuation">,</span>
   <span class="hljs-attr">"pageSize"</span><span class="hljs-punctuation">:</span> <span class="hljs-number">123</span><span class="hljs-punctuation">,</span>
-  <span class="hljs-attr">"cursor"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"xyz789"</span>
+  <span class="hljs-attr">"cursor"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"abc123"</span>
 <span class="hljs-punctuation">}</span>
 </code></pre>
                   </body>
@@ -902,7 +907,7 @@ Authorization: Bearer &lt;YOUR_TOKEN_HERE&gt;</code></pre>
   <span class="hljs-attr">"data"</span><span class="hljs-punctuation">:</span> <span class="hljs-punctuation">{</span>
     <span class="hljs-attr">"variants"</span><span class="hljs-punctuation">:</span> <span class="hljs-punctuation">{</span>
       <span class="hljs-attr">"variants"</span><span class="hljs-punctuation">:</span> <span class="hljs-punctuation">[</span><span class="hljs-string">ProductViewVariant</span><span class="hljs-punctuation">]</span><span class="hljs-punctuation">,</span>
-      <span class="hljs-attr">"cursor"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"abc123"</span>
+      <span class="hljs-attr">"cursor"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"xyz789"</span>
     <span class="hljs-punctuation">}</span>
   <span class="hljs-punctuation">}</span>
 <span class="hljs-punctuation">}</span>
@@ -911,6 +916,7 @@ Authorization: Bearer &lt;YOUR_TOKEN_HERE&gt;</code></pre>
                 </html>
               </div>
             </div>
+            <a href="#top">back to top</a>
           </div>
         </section>
         <h1 id="group-Types" class="group-heading" data-traverse-target="group-Types">Types</h1>
@@ -962,7 +968,7 @@ Authorization: Bearer &lt;YOUR_TOKEN_HERE&gt;</code></pre>
                 <html>
                   <head></head>
                   <body><pre><code class="hljs language-json"><span class="hljs-punctuation">{</span>
-  <span class="hljs-attr">"attribute"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"xyz789"</span><span class="hljs-punctuation">,</span>
+  <span class="hljs-attr">"attribute"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"abc123"</span><span class="hljs-punctuation">,</span>
   <span class="hljs-attr">"buckets"</span><span class="hljs-punctuation">:</span> <span class="hljs-punctuation">[</span><span class="hljs-string">Bucket</span><span class="hljs-punctuation">]</span><span class="hljs-punctuation">,</span>
   <span class="hljs-attr">"title"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"xyz789"</span><span class="hljs-punctuation">,</span>
   <span class="hljs-attr">"type"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"INTELLIGENT"</span>
@@ -972,6 +978,7 @@ Authorization: Bearer &lt;YOUR_TOKEN_HERE&gt;</code></pre>
                 </html>
               </div>
             </div>
+            <a href="#top">back to top</a>
           </div>
         </section>
         <section id="definition-AggregationType" class="definition definition-enum" data-traverse-target="definition-AggregationType">
@@ -1031,6 +1038,7 @@ Authorization: Bearer &lt;YOUR_TOKEN_HERE&gt;</code></pre>
                 </html>
               </div>
             </div>
+            <a href="#top">back to top</a>
           </div>
         </section>
         <section id="definition-AppliedQueryRule" class="definition definition-object" data-traverse-target="definition-AppliedQueryRule">
@@ -1088,6 +1096,7 @@ Authorization: Bearer &lt;YOUR_TOKEN_HERE&gt;</code></pre>
                 </html>
               </div>
             </div>
+            <a href="#top">back to top</a>
           </div>
         </section>
         <section id="definition-AppliedQueryRuleActionType" class="definition definition-enum" data-traverse-target="definition-AppliedQueryRuleActionType">
@@ -1147,6 +1156,7 @@ Authorization: Bearer &lt;YOUR_TOKEN_HERE&gt;</code></pre>
                 </html>
               </div>
             </div>
+            <a href="#top">back to top</a>
           </div>
         </section>
         <section id="definition-AttributeMetadataResponse" class="definition definition-object" data-traverse-target="definition-AttributeMetadataResponse">
@@ -1198,6 +1208,7 @@ Authorization: Bearer &lt;YOUR_TOKEN_HERE&gt;</code></pre>
                 </html>
               </div>
             </div>
+            <a href="#top">back to top</a>
           </div>
         </section>
         <section id="definition-Boolean" class="definition definition-scalar" data-traverse-target="definition-Boolean">
@@ -1213,16 +1224,8 @@ Authorization: Bearer &lt;YOUR_TOKEN_HERE&gt;</code></pre>
               </div>
             </div>
             <div class="doc-examples">
-              <div class="example-section example-section-is-code">
-                <h5>Example</h5>
-                <html>
-                  <head></head>
-                  <body><pre><code class="hljs language-json"><span class="hljs-literal"><span class="hljs-keyword">true</span></span>
-</code></pre>
-                  </body>
-                </html>
-              </div>
             </div>
+            <a href="#top">back to top</a>
           </div>
         </section>
         <section id="definition-Bucket" class="definition definition-interface" data-traverse-target="definition-Bucket">
@@ -1298,6 +1301,7 @@ Authorization: Bearer &lt;YOUR_TOKEN_HERE&gt;</code></pre>
                 </html>
               </div>
             </div>
+            <a href="#top">back to top</a>
           </div>
         </section>
         <section id="definition-BundleProduct" class="definition definition-object" data-traverse-target="definition-BundleProduct">
@@ -1453,7 +1457,7 @@ Authorization: Bearer &lt;YOUR_TOKEN_HERE&gt;</code></pre>
                   <head></head>
                   <body><pre><code class="hljs language-json"><span class="hljs-punctuation">{</span>
   <span class="hljs-attr">"add_to_cart_allowed"</span><span class="hljs-punctuation">:</span> <span class="hljs-literal"><span class="hljs-keyword">true</span></span><span class="hljs-punctuation">,</span>
-  <span class="hljs-attr">"attribute_set_id"</span><span class="hljs-punctuation">:</span> <span class="hljs-number">123</span><span class="hljs-punctuation">,</span>
+  <span class="hljs-attr">"attribute_set_id"</span><span class="hljs-punctuation">:</span> <span class="hljs-number">987</span><span class="hljs-punctuation">,</span>
   <span class="hljs-attr">"canonical_url"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"xyz789"</span><span class="hljs-punctuation">,</span>
   <span class="hljs-attr">"created_at"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"xyz789"</span><span class="hljs-punctuation">,</span>
   <span class="hljs-attr">"custom_attributes"</span><span class="hljs-punctuation">:</span> <span class="hljs-punctuation">[</span><span class="hljs-string">CustomAttribute</span><span class="hljs-punctuation">]</span><span class="hljs-punctuation">,</span>
@@ -1464,17 +1468,17 @@ Authorization: Bearer &lt;YOUR_TOKEN_HERE&gt;</code></pre>
   <span class="hljs-attr">"media_gallery"</span><span class="hljs-punctuation">:</span> <span class="hljs-punctuation">[</span><span class="hljs-string">MediaGalleryInterface</span><span class="hljs-punctuation">]</span><span class="hljs-punctuation">,</span>
   <span class="hljs-attr">"meta_description"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"abc123"</span><span class="hljs-punctuation">,</span>
   <span class="hljs-attr">"meta_keyword"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"xyz789"</span><span class="hljs-punctuation">,</span>
-  <span class="hljs-attr">"meta_title"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"xyz789"</span><span class="hljs-punctuation">,</span>
+  <span class="hljs-attr">"meta_title"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"abc123"</span><span class="hljs-punctuation">,</span>
   <span class="hljs-attr">"name"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"xyz789"</span><span class="hljs-punctuation">,</span>
   <span class="hljs-attr">"new_from_date"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"xyz789"</span><span class="hljs-punctuation">,</span>
-  <span class="hljs-attr">"new_to_date"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"xyz789"</span><span class="hljs-punctuation">,</span>
+  <span class="hljs-attr">"new_to_date"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"abc123"</span><span class="hljs-punctuation">,</span>
   <span class="hljs-attr">"price_range"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">PriceRange</span><span class="hljs-punctuation">,</span>
   <span class="hljs-attr">"short_description"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">ComplexTextValue</span><span class="hljs-punctuation">,</span>
-  <span class="hljs-attr">"sku"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"xyz789"</span><span class="hljs-punctuation">,</span>
+  <span class="hljs-attr">"sku"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"abc123"</span><span class="hljs-punctuation">,</span>
   <span class="hljs-attr">"small_image"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">ProductImage</span><span class="hljs-punctuation">,</span>
   <span class="hljs-attr">"thumbnail"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">ProductImage</span><span class="hljs-punctuation">,</span>
-  <span class="hljs-attr">"uid"</span><span class="hljs-punctuation">:</span> <span class="hljs-number">4</span><span class="hljs-punctuation">,</span>
-  <span class="hljs-attr">"updated_at"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"xyz789"</span><span class="hljs-punctuation">,</span>
+  <span class="hljs-attr">"uid"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"4"</span><span class="hljs-punctuation">,</span>
+  <span class="hljs-attr">"updated_at"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"abc123"</span><span class="hljs-punctuation">,</span>
   <span class="hljs-attr">"weight"</span><span class="hljs-punctuation">:</span> <span class="hljs-number">123.45</span>
 <span class="hljs-punctuation">}</span>
 </code></pre>
@@ -1482,6 +1486,7 @@ Authorization: Bearer &lt;YOUR_TOKEN_HERE&gt;</code></pre>
                 </html>
               </div>
             </div>
+            <a href="#top">back to top</a>
           </div>
         </section>
         <section id="definition-CategoryView" class="definition definition-object" data-traverse-target="definition-CategoryView">
@@ -1593,18 +1598,18 @@ Authorization: Bearer &lt;YOUR_TOKEN_HERE&gt;</code></pre>
                 <html>
                   <head></head>
                   <body><pre><code class="hljs language-json"><span class="hljs-punctuation">{</span>
-  <span class="hljs-attr">"availableSortBy"</span><span class="hljs-punctuation">:</span> <span class="hljs-punctuation">[</span><span class="hljs-string">"xyz789"</span><span class="hljs-punctuation">]</span><span class="hljs-punctuation">,</span>
-  <span class="hljs-attr">"children"</span><span class="hljs-punctuation">:</span> <span class="hljs-punctuation">[</span><span class="hljs-string">"xyz789"</span><span class="hljs-punctuation">]</span><span class="hljs-punctuation">,</span>
-  <span class="hljs-attr">"defaultSortBy"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"xyz789"</span><span class="hljs-punctuation">,</span>
+  <span class="hljs-attr">"availableSortBy"</span><span class="hljs-punctuation">:</span> <span class="hljs-punctuation">[</span><span class="hljs-string">"abc123"</span><span class="hljs-punctuation">]</span><span class="hljs-punctuation">,</span>
+  <span class="hljs-attr">"children"</span><span class="hljs-punctuation">:</span> <span class="hljs-punctuation">[</span><span class="hljs-string">"abc123"</span><span class="hljs-punctuation">]</span><span class="hljs-punctuation">,</span>
+  <span class="hljs-attr">"defaultSortBy"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"abc123"</span><span class="hljs-punctuation">,</span>
   <span class="hljs-attr">"id"</span><span class="hljs-punctuation">:</span> <span class="hljs-number">4</span><span class="hljs-punctuation">,</span>
   <span class="hljs-attr">"level"</span><span class="hljs-punctuation">:</span> <span class="hljs-number">123</span><span class="hljs-punctuation">,</span>
-  <span class="hljs-attr">"name"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"abc123"</span><span class="hljs-punctuation">,</span>
-  <span class="hljs-attr">"parentId"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"abc123"</span><span class="hljs-punctuation">,</span>
-  <span class="hljs-attr">"path"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"xyz789"</span><span class="hljs-punctuation">,</span>
-  <span class="hljs-attr">"roles"</span><span class="hljs-punctuation">:</span> <span class="hljs-punctuation">[</span><span class="hljs-string">"xyz789"</span><span class="hljs-punctuation">]</span><span class="hljs-punctuation">,</span>
-  <span class="hljs-attr">"urlKey"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"xyz789"</span><span class="hljs-punctuation">,</span>
-  <span class="hljs-attr">"urlPath"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"abc123"</span><span class="hljs-punctuation">,</span>
-  <span class="hljs-attr">"count"</span><span class="hljs-punctuation">:</span> <span class="hljs-number">987</span><span class="hljs-punctuation">,</span>
+  <span class="hljs-attr">"name"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"xyz789"</span><span class="hljs-punctuation">,</span>
+  <span class="hljs-attr">"parentId"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"xyz789"</span><span class="hljs-punctuation">,</span>
+  <span class="hljs-attr">"path"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"abc123"</span><span class="hljs-punctuation">,</span>
+  <span class="hljs-attr">"roles"</span><span class="hljs-punctuation">:</span> <span class="hljs-punctuation">[</span><span class="hljs-string">"abc123"</span><span class="hljs-punctuation">]</span><span class="hljs-punctuation">,</span>
+  <span class="hljs-attr">"urlKey"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"abc123"</span><span class="hljs-punctuation">,</span>
+  <span class="hljs-attr">"urlPath"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"xyz789"</span><span class="hljs-punctuation">,</span>
+  <span class="hljs-attr">"count"</span><span class="hljs-punctuation">:</span> <span class="hljs-number">123</span><span class="hljs-punctuation">,</span>
   <span class="hljs-attr">"title"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"xyz789"</span>
 <span class="hljs-punctuation">}</span>
 </code></pre>
@@ -1612,6 +1617,7 @@ Authorization: Bearer &lt;YOUR_TOKEN_HERE&gt;</code></pre>
                 </html>
               </div>
             </div>
+            <a href="#top">back to top</a>
           </div>
         </section>
         <section id="definition-CategoryViewInterface" class="definition definition-interface" data-traverse-target="definition-CategoryViewInterface">
@@ -1712,14 +1718,14 @@ Authorization: Bearer &lt;YOUR_TOKEN_HERE&gt;</code></pre>
                 <html>
                   <head></head>
                   <body><pre><code class="hljs language-json"><span class="hljs-punctuation">{</span>
-  <span class="hljs-attr">"availableSortBy"</span><span class="hljs-punctuation">:</span> <span class="hljs-punctuation">[</span><span class="hljs-string">"abc123"</span><span class="hljs-punctuation">]</span><span class="hljs-punctuation">,</span>
+  <span class="hljs-attr">"availableSortBy"</span><span class="hljs-punctuation">:</span> <span class="hljs-punctuation">[</span><span class="hljs-string">"xyz789"</span><span class="hljs-punctuation">]</span><span class="hljs-punctuation">,</span>
   <span class="hljs-attr">"defaultSortBy"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"abc123"</span><span class="hljs-punctuation">,</span>
   <span class="hljs-attr">"id"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"4"</span><span class="hljs-punctuation">,</span>
   <span class="hljs-attr">"level"</span><span class="hljs-punctuation">:</span> <span class="hljs-number">987</span><span class="hljs-punctuation">,</span>
-  <span class="hljs-attr">"name"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"xyz789"</span><span class="hljs-punctuation">,</span>
+  <span class="hljs-attr">"name"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"abc123"</span><span class="hljs-punctuation">,</span>
   <span class="hljs-attr">"path"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"xyz789"</span><span class="hljs-punctuation">,</span>
   <span class="hljs-attr">"roles"</span><span class="hljs-punctuation">:</span> <span class="hljs-punctuation">[</span><span class="hljs-string">"xyz789"</span><span class="hljs-punctuation">]</span><span class="hljs-punctuation">,</span>
-  <span class="hljs-attr">"urlKey"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"abc123"</span><span class="hljs-punctuation">,</span>
+  <span class="hljs-attr">"urlKey"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"xyz789"</span><span class="hljs-punctuation">,</span>
   <span class="hljs-attr">"urlPath"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"abc123"</span>
 <span class="hljs-punctuation">}</span>
 </code></pre>
@@ -1727,6 +1733,7 @@ Authorization: Bearer &lt;YOUR_TOKEN_HERE&gt;</code></pre>
                 </html>
               </div>
             </div>
+            <a href="#top">back to top</a>
           </div>
         </section>
         <section id="definition-ComplexProductView" class="definition definition-object" data-traverse-target="definition-ComplexProductView">
@@ -1937,31 +1944,31 @@ Authorization: Bearer &lt;YOUR_TOKEN_HERE&gt;</code></pre>
                 <html>
                   <head></head>
                   <body><pre><code class="hljs language-json"><span class="hljs-punctuation">{</span>
-  <span class="hljs-attr">"addToCartAllowed"</span><span class="hljs-punctuation">:</span> <span class="hljs-literal"><span class="hljs-keyword">false</span></span><span class="hljs-punctuation">,</span>
-  <span class="hljs-attr">"inStock"</span><span class="hljs-punctuation">:</span> <span class="hljs-literal"><span class="hljs-keyword">true</span></span><span class="hljs-punctuation">,</span>
-  <span class="hljs-attr">"lowStock"</span><span class="hljs-punctuation">:</span> <span class="hljs-literal"><span class="hljs-keyword">false</span></span><span class="hljs-punctuation">,</span>
+  <span class="hljs-attr">"addToCartAllowed"</span><span class="hljs-punctuation">:</span> <span class="hljs-literal"><span class="hljs-keyword">true</span></span><span class="hljs-punctuation">,</span>
+  <span class="hljs-attr">"inStock"</span><span class="hljs-punctuation">:</span> <span class="hljs-literal"><span class="hljs-keyword">false</span></span><span class="hljs-punctuation">,</span>
+  <span class="hljs-attr">"lowStock"</span><span class="hljs-punctuation">:</span> <span class="hljs-literal"><span class="hljs-keyword">true</span></span><span class="hljs-punctuation">,</span>
   <span class="hljs-attr">"attributes"</span><span class="hljs-punctuation">:</span> <span class="hljs-punctuation">[</span><span class="hljs-string">ProductViewAttribute</span><span class="hljs-punctuation">]</span><span class="hljs-punctuation">,</span>
-  <span class="hljs-attr">"description"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"xyz789"</span><span class="hljs-punctuation">,</span>
+  <span class="hljs-attr">"description"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"abc123"</span><span class="hljs-punctuation">,</span>
   <span class="hljs-attr">"id"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"4"</span><span class="hljs-punctuation">,</span>
   <span class="hljs-attr">"images"</span><span class="hljs-punctuation">:</span> <span class="hljs-punctuation">[</span><span class="hljs-string">ProductViewImage</span><span class="hljs-punctuation">]</span><span class="hljs-punctuation">,</span>
   <span class="hljs-attr">"videos"</span><span class="hljs-punctuation">:</span> <span class="hljs-punctuation">[</span><span class="hljs-string">ProductViewVideo</span><span class="hljs-punctuation">]</span><span class="hljs-punctuation">,</span>
   <span class="hljs-attr">"lastModifiedAt"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"2007-12-03T10:15:30Z"</span><span class="hljs-punctuation">,</span>
   <span class="hljs-attr">"metaDescription"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"xyz789"</span><span class="hljs-punctuation">,</span>
-  <span class="hljs-attr">"metaKeyword"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"abc123"</span><span class="hljs-punctuation">,</span>
+  <span class="hljs-attr">"metaKeyword"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"xyz789"</span><span class="hljs-punctuation">,</span>
   <span class="hljs-attr">"metaTitle"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"abc123"</span><span class="hljs-punctuation">,</span>
-  <span class="hljs-attr">"name"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"xyz789"</span><span class="hljs-punctuation">,</span>
+  <span class="hljs-attr">"name"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"abc123"</span><span class="hljs-punctuation">,</span>
   <span class="hljs-attr">"inputOptions"</span><span class="hljs-punctuation">:</span> <span class="hljs-punctuation">[</span><span class="hljs-string">ProductViewInputOption</span><span class="hljs-punctuation">]</span><span class="hljs-punctuation">,</span>
   <span class="hljs-attr">"options"</span><span class="hljs-punctuation">:</span> <span class="hljs-punctuation">[</span><span class="hljs-string">ProductViewOption</span><span class="hljs-punctuation">]</span><span class="hljs-punctuation">,</span>
   <span class="hljs-attr">"priceRange"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">ProductViewPriceRange</span><span class="hljs-punctuation">,</span>
-  <span class="hljs-attr">"shortDescription"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"xyz789"</span><span class="hljs-punctuation">,</span>
+  <span class="hljs-attr">"shortDescription"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"abc123"</span><span class="hljs-punctuation">,</span>
   <span class="hljs-attr">"sku"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"abc123"</span><span class="hljs-punctuation">,</span>
   <span class="hljs-attr">"externalId"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"abc123"</span><span class="hljs-punctuation">,</span>
-  <span class="hljs-attr">"url"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"abc123"</span><span class="hljs-punctuation">,</span>
-  <span class="hljs-attr">"urlKey"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"abc123"</span><span class="hljs-punctuation">,</span>
+  <span class="hljs-attr">"url"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"xyz789"</span><span class="hljs-punctuation">,</span>
+  <span class="hljs-attr">"urlKey"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"xyz789"</span><span class="hljs-punctuation">,</span>
   <span class="hljs-attr">"links"</span><span class="hljs-punctuation">:</span> <span class="hljs-punctuation">[</span><span class="hljs-string">ProductViewLink</span><span class="hljs-punctuation">]</span><span class="hljs-punctuation">,</span>
   <span class="hljs-attr">"categories"</span><span class="hljs-punctuation">:</span> <span class="hljs-punctuation">[</span><span class="hljs-string">"xyz789"</span><span class="hljs-punctuation">]</span><span class="hljs-punctuation">,</span>
-  <span class="hljs-attr">"queryType"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"xyz789"</span><span class="hljs-punctuation">,</span>
-  <span class="hljs-attr">"rank"</span><span class="hljs-punctuation">:</span> <span class="hljs-number">123</span><span class="hljs-punctuation">,</span>
+  <span class="hljs-attr">"queryType"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"abc123"</span><span class="hljs-punctuation">,</span>
+  <span class="hljs-attr">"rank"</span><span class="hljs-punctuation">:</span> <span class="hljs-number">987</span><span class="hljs-punctuation">,</span>
   <span class="hljs-attr">"score"</span><span class="hljs-punctuation">:</span> <span class="hljs-number">123.45</span><span class="hljs-punctuation">,</span>
   <span class="hljs-attr">"visibility"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"xyz789"</span>
 <span class="hljs-punctuation">}</span>
@@ -1970,6 +1977,7 @@ Authorization: Bearer &lt;YOUR_TOKEN_HERE&gt;</code></pre>
                 </html>
               </div>
             </div>
+            <a href="#top">back to top</a>
           </div>
         </section>
         <section id="definition-ComplexTextValue" class="definition definition-object" data-traverse-target="definition-ComplexTextValue">
@@ -2007,12 +2015,13 @@ Authorization: Bearer &lt;YOUR_TOKEN_HERE&gt;</code></pre>
                 <h5>Example</h5>
                 <html>
                   <head></head>
-                  <body><pre><code class="hljs language-json"><span class="hljs-punctuation">{</span><span class="hljs-attr">"html"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"xyz789"</span><span class="hljs-punctuation">}</span>
+                  <body><pre><code class="hljs language-json"><span class="hljs-punctuation">{</span><span class="hljs-attr">"html"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"abc123"</span><span class="hljs-punctuation">}</span>
 </code></pre>
                   </body>
                 </html>
               </div>
             </div>
+            <a href="#top">back to top</a>
           </div>
         </section>
         <section id="definition-ConfigurableProduct" class="definition definition-object" data-traverse-target="definition-ConfigurableProduct">
@@ -2169,19 +2178,19 @@ Authorization: Bearer &lt;YOUR_TOKEN_HERE&gt;</code></pre>
                   <body><pre><code class="hljs language-json"><span class="hljs-punctuation">{</span>
   <span class="hljs-attr">"add_to_cart_allowed"</span><span class="hljs-punctuation">:</span> <span class="hljs-literal"><span class="hljs-keyword">false</span></span><span class="hljs-punctuation">,</span>
   <span class="hljs-attr">"attribute_set_id"</span><span class="hljs-punctuation">:</span> <span class="hljs-number">123</span><span class="hljs-punctuation">,</span>
-  <span class="hljs-attr">"canonical_url"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"xyz789"</span><span class="hljs-punctuation">,</span>
+  <span class="hljs-attr">"canonical_url"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"abc123"</span><span class="hljs-punctuation">,</span>
   <span class="hljs-attr">"created_at"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"abc123"</span><span class="hljs-punctuation">,</span>
   <span class="hljs-attr">"custom_attributes"</span><span class="hljs-punctuation">:</span> <span class="hljs-punctuation">[</span><span class="hljs-string">CustomAttribute</span><span class="hljs-punctuation">]</span><span class="hljs-punctuation">,</span>
   <span class="hljs-attr">"description"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">ComplexTextValue</span><span class="hljs-punctuation">,</span>
-  <span class="hljs-attr">"gift_message_available"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"xyz789"</span><span class="hljs-punctuation">,</span>
-  <span class="hljs-attr">"id"</span><span class="hljs-punctuation">:</span> <span class="hljs-number">987</span><span class="hljs-punctuation">,</span>
+  <span class="hljs-attr">"gift_message_available"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"abc123"</span><span class="hljs-punctuation">,</span>
+  <span class="hljs-attr">"id"</span><span class="hljs-punctuation">:</span> <span class="hljs-number">123</span><span class="hljs-punctuation">,</span>
   <span class="hljs-attr">"image"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">ProductImage</span><span class="hljs-punctuation">,</span>
   <span class="hljs-attr">"media_gallery"</span><span class="hljs-punctuation">:</span> <span class="hljs-punctuation">[</span><span class="hljs-string">MediaGalleryInterface</span><span class="hljs-punctuation">]</span><span class="hljs-punctuation">,</span>
   <span class="hljs-attr">"meta_description"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"abc123"</span><span class="hljs-punctuation">,</span>
   <span class="hljs-attr">"meta_keyword"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"xyz789"</span><span class="hljs-punctuation">,</span>
   <span class="hljs-attr">"meta_title"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"xyz789"</span><span class="hljs-punctuation">,</span>
   <span class="hljs-attr">"name"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"xyz789"</span><span class="hljs-punctuation">,</span>
-  <span class="hljs-attr">"new_from_date"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"abc123"</span><span class="hljs-punctuation">,</span>
+  <span class="hljs-attr">"new_from_date"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"xyz789"</span><span class="hljs-punctuation">,</span>
   <span class="hljs-attr">"new_to_date"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"xyz789"</span><span class="hljs-punctuation">,</span>
   <span class="hljs-attr">"price_range"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">PriceRange</span><span class="hljs-punctuation">,</span>
   <span class="hljs-attr">"short_description"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">ComplexTextValue</span><span class="hljs-punctuation">,</span>
@@ -2190,13 +2199,14 @@ Authorization: Bearer &lt;YOUR_TOKEN_HERE&gt;</code></pre>
   <span class="hljs-attr">"thumbnail"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">ProductImage</span><span class="hljs-punctuation">,</span>
   <span class="hljs-attr">"uid"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"4"</span><span class="hljs-punctuation">,</span>
   <span class="hljs-attr">"updated_at"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"xyz789"</span><span class="hljs-punctuation">,</span>
-  <span class="hljs-attr">"weight"</span><span class="hljs-punctuation">:</span> <span class="hljs-number">123.45</span>
+  <span class="hljs-attr">"weight"</span><span class="hljs-punctuation">:</span> <span class="hljs-number">987.65</span>
 <span class="hljs-punctuation">}</span>
 </code></pre>
                   </body>
                 </html>
               </div>
             </div>
+            <a href="#top">back to top</a>
           </div>
         </section>
         <section id="definition-CurrencyEnum" class="definition definition-enum" data-traverse-target="definition-CurrencyEnum">
@@ -3421,6 +3431,7 @@ Authorization: Bearer &lt;YOUR_TOKEN_HERE&gt;</code></pre>
                 </html>
               </div>
             </div>
+            <a href="#top">back to top</a>
           </div>
         </section>
         <section id="definition-CustomAttribute" class="definition definition-object" data-traverse-target="definition-CustomAttribute">
@@ -3464,14 +3475,15 @@ Authorization: Bearer &lt;YOUR_TOKEN_HERE&gt;</code></pre>
                 <html>
                   <head></head>
                   <body><pre><code class="hljs language-json"><span class="hljs-punctuation">{</span>
-  <span class="hljs-attr">"code"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"xyz789"</span><span class="hljs-punctuation">,</span>
-  <span class="hljs-attr">"value"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"xyz789"</span>
+  <span class="hljs-attr">"code"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"abc123"</span><span class="hljs-punctuation">,</span>
+  <span class="hljs-attr">"value"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"abc123"</span>
 <span class="hljs-punctuation">}</span>
 </code></pre>
                   </body>
                 </html>
               </div>
             </div>
+            <a href="#top">back to top</a>
           </div>
         </section>
         <section id="definition-DateTime" class="definition definition-scalar" data-traverse-target="definition-DateTime">
@@ -3497,6 +3509,7 @@ Authorization: Bearer &lt;YOUR_TOKEN_HERE&gt;</code></pre>
                 </html>
               </div>
             </div>
+            <a href="#top">back to top</a>
           </div>
         </section>
         <section id="definition-DownloadableProduct" class="definition definition-object" data-traverse-target="definition-DownloadableProduct">
@@ -3647,7 +3660,7 @@ Authorization: Bearer &lt;YOUR_TOKEN_HERE&gt;</code></pre>
                   <head></head>
                   <body><pre><code class="hljs language-json"><span class="hljs-punctuation">{</span>
   <span class="hljs-attr">"add_to_cart_allowed"</span><span class="hljs-punctuation">:</span> <span class="hljs-literal"><span class="hljs-keyword">false</span></span><span class="hljs-punctuation">,</span>
-  <span class="hljs-attr">"attribute_set_id"</span><span class="hljs-punctuation">:</span> <span class="hljs-number">987</span><span class="hljs-punctuation">,</span>
+  <span class="hljs-attr">"attribute_set_id"</span><span class="hljs-punctuation">:</span> <span class="hljs-number">123</span><span class="hljs-punctuation">,</span>
   <span class="hljs-attr">"canonical_url"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"xyz789"</span><span class="hljs-punctuation">,</span>
   <span class="hljs-attr">"created_at"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"xyz789"</span><span class="hljs-punctuation">,</span>
   <span class="hljs-attr">"custom_attributes"</span><span class="hljs-punctuation">:</span> <span class="hljs-punctuation">[</span><span class="hljs-string">CustomAttribute</span><span class="hljs-punctuation">]</span><span class="hljs-punctuation">,</span>
@@ -3657,14 +3670,14 @@ Authorization: Bearer &lt;YOUR_TOKEN_HERE&gt;</code></pre>
   <span class="hljs-attr">"image"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">ProductImage</span><span class="hljs-punctuation">,</span>
   <span class="hljs-attr">"media_gallery"</span><span class="hljs-punctuation">:</span> <span class="hljs-punctuation">[</span><span class="hljs-string">MediaGalleryInterface</span><span class="hljs-punctuation">]</span><span class="hljs-punctuation">,</span>
   <span class="hljs-attr">"meta_description"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"xyz789"</span><span class="hljs-punctuation">,</span>
-  <span class="hljs-attr">"meta_keyword"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"xyz789"</span><span class="hljs-punctuation">,</span>
-  <span class="hljs-attr">"meta_title"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"xyz789"</span><span class="hljs-punctuation">,</span>
-  <span class="hljs-attr">"name"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"abc123"</span><span class="hljs-punctuation">,</span>
+  <span class="hljs-attr">"meta_keyword"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"abc123"</span><span class="hljs-punctuation">,</span>
+  <span class="hljs-attr">"meta_title"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"abc123"</span><span class="hljs-punctuation">,</span>
+  <span class="hljs-attr">"name"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"xyz789"</span><span class="hljs-punctuation">,</span>
   <span class="hljs-attr">"new_from_date"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"xyz789"</span><span class="hljs-punctuation">,</span>
-  <span class="hljs-attr">"new_to_date"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"abc123"</span><span class="hljs-punctuation">,</span>
+  <span class="hljs-attr">"new_to_date"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"xyz789"</span><span class="hljs-punctuation">,</span>
   <span class="hljs-attr">"price_range"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">PriceRange</span><span class="hljs-punctuation">,</span>
   <span class="hljs-attr">"short_description"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">ComplexTextValue</span><span class="hljs-punctuation">,</span>
-  <span class="hljs-attr">"sku"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"abc123"</span><span class="hljs-punctuation">,</span>
+  <span class="hljs-attr">"sku"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"xyz789"</span><span class="hljs-punctuation">,</span>
   <span class="hljs-attr">"small_image"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">ProductImage</span><span class="hljs-punctuation">,</span>
   <span class="hljs-attr">"thumbnail"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">ProductImage</span><span class="hljs-punctuation">,</span>
   <span class="hljs-attr">"uid"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"4"</span><span class="hljs-punctuation">,</span>
@@ -3675,6 +3688,7 @@ Authorization: Bearer &lt;YOUR_TOKEN_HERE&gt;</code></pre>
                 </html>
               </div>
             </div>
+            <a href="#top">back to top</a>
           </div>
         </section>
         <section id="definition-FilterableInSearchAttribute" class="definition definition-object" data-traverse-target="definition-FilterableInSearchAttribute">
@@ -3728,16 +3742,17 @@ Authorization: Bearer &lt;YOUR_TOKEN_HERE&gt;</code></pre>
                 <html>
                   <head></head>
                   <body><pre><code class="hljs language-json"><span class="hljs-punctuation">{</span>
-  <span class="hljs-attr">"attribute"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"xyz789"</span><span class="hljs-punctuation">,</span>
-  <span class="hljs-attr">"frontendInput"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"abc123"</span><span class="hljs-punctuation">,</span>
-  <span class="hljs-attr">"label"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"abc123"</span><span class="hljs-punctuation">,</span>
-  <span class="hljs-attr">"numeric"</span><span class="hljs-punctuation">:</span> <span class="hljs-literal"><span class="hljs-keyword">false</span></span>
+  <span class="hljs-attr">"attribute"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"abc123"</span><span class="hljs-punctuation">,</span>
+  <span class="hljs-attr">"frontendInput"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"xyz789"</span><span class="hljs-punctuation">,</span>
+  <span class="hljs-attr">"label"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"xyz789"</span><span class="hljs-punctuation">,</span>
+  <span class="hljs-attr">"numeric"</span><span class="hljs-punctuation">:</span> <span class="hljs-literal"><span class="hljs-keyword">true</span></span>
 <span class="hljs-punctuation">}</span>
 </code></pre>
                   </body>
                 </html>
               </div>
             </div>
+            <a href="#top">back to top</a>
           </div>
         </section>
         <section id="definition-FixedProductTax" class="definition definition-object" data-traverse-target="definition-FixedProductTax">
@@ -3782,13 +3797,14 @@ Authorization: Bearer &lt;YOUR_TOKEN_HERE&gt;</code></pre>
                   <head></head>
                   <body><pre><code class="hljs language-json"><span class="hljs-punctuation">{</span>
   <span class="hljs-attr">"amount"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">Money</span><span class="hljs-punctuation">,</span>
-  <span class="hljs-attr">"label"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"abc123"</span>
+  <span class="hljs-attr">"label"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"xyz789"</span>
 <span class="hljs-punctuation">}</span>
 </code></pre>
                   </body>
                 </html>
               </div>
             </div>
+            <a href="#top">back to top</a>
           </div>
         </section>
         <section id="definition-Float" class="definition definition-scalar" data-traverse-target="definition-Float">
@@ -3808,12 +3824,13 @@ Authorization: Bearer &lt;YOUR_TOKEN_HERE&gt;</code></pre>
                 <h5>Example</h5>
                 <html>
                   <head></head>
-                  <body><pre><code class="hljs language-json"><span class="hljs-number">123.45</span>
+                  <body><pre><code class="hljs language-json"><span class="hljs-number">987.65</span>
 </code></pre>
                   </body>
                 </html>
               </div>
             </div>
+            <a href="#top">back to top</a>
           </div>
         </section>
         <section id="definition-GiftCardProduct" class="definition definition-object" data-traverse-target="definition-GiftCardProduct">
@@ -3969,21 +3986,21 @@ Authorization: Bearer &lt;YOUR_TOKEN_HERE&gt;</code></pre>
                   <head></head>
                   <body><pre><code class="hljs language-json"><span class="hljs-punctuation">{</span>
   <span class="hljs-attr">"add_to_cart_allowed"</span><span class="hljs-punctuation">:</span> <span class="hljs-literal"><span class="hljs-keyword">false</span></span><span class="hljs-punctuation">,</span>
-  <span class="hljs-attr">"attribute_set_id"</span><span class="hljs-punctuation">:</span> <span class="hljs-number">123</span><span class="hljs-punctuation">,</span>
+  <span class="hljs-attr">"attribute_set_id"</span><span class="hljs-punctuation">:</span> <span class="hljs-number">987</span><span class="hljs-punctuation">,</span>
   <span class="hljs-attr">"canonical_url"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"xyz789"</span><span class="hljs-punctuation">,</span>
-  <span class="hljs-attr">"created_at"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"xyz789"</span><span class="hljs-punctuation">,</span>
+  <span class="hljs-attr">"created_at"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"abc123"</span><span class="hljs-punctuation">,</span>
   <span class="hljs-attr">"custom_attributes"</span><span class="hljs-punctuation">:</span> <span class="hljs-punctuation">[</span><span class="hljs-string">CustomAttribute</span><span class="hljs-punctuation">]</span><span class="hljs-punctuation">,</span>
   <span class="hljs-attr">"description"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">ComplexTextValue</span><span class="hljs-punctuation">,</span>
   <span class="hljs-attr">"gift_message_available"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"xyz789"</span><span class="hljs-punctuation">,</span>
-  <span class="hljs-attr">"id"</span><span class="hljs-punctuation">:</span> <span class="hljs-number">123</span><span class="hljs-punctuation">,</span>
+  <span class="hljs-attr">"id"</span><span class="hljs-punctuation">:</span> <span class="hljs-number">987</span><span class="hljs-punctuation">,</span>
   <span class="hljs-attr">"image"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">ProductImage</span><span class="hljs-punctuation">,</span>
   <span class="hljs-attr">"media_gallery"</span><span class="hljs-punctuation">:</span> <span class="hljs-punctuation">[</span><span class="hljs-string">MediaGalleryInterface</span><span class="hljs-punctuation">]</span><span class="hljs-punctuation">,</span>
-  <span class="hljs-attr">"meta_description"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"xyz789"</span><span class="hljs-punctuation">,</span>
-  <span class="hljs-attr">"meta_keyword"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"xyz789"</span><span class="hljs-punctuation">,</span>
-  <span class="hljs-attr">"meta_title"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"abc123"</span><span class="hljs-punctuation">,</span>
+  <span class="hljs-attr">"meta_description"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"abc123"</span><span class="hljs-punctuation">,</span>
+  <span class="hljs-attr">"meta_keyword"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"abc123"</span><span class="hljs-punctuation">,</span>
+  <span class="hljs-attr">"meta_title"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"xyz789"</span><span class="hljs-punctuation">,</span>
   <span class="hljs-attr">"name"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"xyz789"</span><span class="hljs-punctuation">,</span>
   <span class="hljs-attr">"new_from_date"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"xyz789"</span><span class="hljs-punctuation">,</span>
-  <span class="hljs-attr">"new_to_date"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"xyz789"</span><span class="hljs-punctuation">,</span>
+  <span class="hljs-attr">"new_to_date"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"abc123"</span><span class="hljs-punctuation">,</span>
   <span class="hljs-attr">"price_range"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">PriceRange</span><span class="hljs-punctuation">,</span>
   <span class="hljs-attr">"short_description"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">ComplexTextValue</span><span class="hljs-punctuation">,</span>
   <span class="hljs-attr">"sku"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"abc123"</span><span class="hljs-punctuation">,</span>
@@ -3998,6 +4015,7 @@ Authorization: Bearer &lt;YOUR_TOKEN_HERE&gt;</code></pre>
                 </html>
               </div>
             </div>
+            <a href="#top">back to top</a>
           </div>
         </section>
         <section id="definition-GroupedProduct" class="definition definition-object" data-traverse-target="definition-GroupedProduct">
@@ -4152,28 +4170,28 @@ Authorization: Bearer &lt;YOUR_TOKEN_HERE&gt;</code></pre>
                 <html>
                   <head></head>
                   <body><pre><code class="hljs language-json"><span class="hljs-punctuation">{</span>
-  <span class="hljs-attr">"add_to_cart_allowed"</span><span class="hljs-punctuation">:</span> <span class="hljs-literal"><span class="hljs-keyword">false</span></span><span class="hljs-punctuation">,</span>
-  <span class="hljs-attr">"attribute_set_id"</span><span class="hljs-punctuation">:</span> <span class="hljs-number">123</span><span class="hljs-punctuation">,</span>
+  <span class="hljs-attr">"add_to_cart_allowed"</span><span class="hljs-punctuation">:</span> <span class="hljs-literal"><span class="hljs-keyword">true</span></span><span class="hljs-punctuation">,</span>
+  <span class="hljs-attr">"attribute_set_id"</span><span class="hljs-punctuation">:</span> <span class="hljs-number">987</span><span class="hljs-punctuation">,</span>
   <span class="hljs-attr">"canonical_url"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"xyz789"</span><span class="hljs-punctuation">,</span>
-  <span class="hljs-attr">"created_at"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"abc123"</span><span class="hljs-punctuation">,</span>
+  <span class="hljs-attr">"created_at"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"xyz789"</span><span class="hljs-punctuation">,</span>
   <span class="hljs-attr">"custom_attributes"</span><span class="hljs-punctuation">:</span> <span class="hljs-punctuation">[</span><span class="hljs-string">CustomAttribute</span><span class="hljs-punctuation">]</span><span class="hljs-punctuation">,</span>
   <span class="hljs-attr">"description"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">ComplexTextValue</span><span class="hljs-punctuation">,</span>
   <span class="hljs-attr">"gift_message_available"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"abc123"</span><span class="hljs-punctuation">,</span>
-  <span class="hljs-attr">"id"</span><span class="hljs-punctuation">:</span> <span class="hljs-number">123</span><span class="hljs-punctuation">,</span>
+  <span class="hljs-attr">"id"</span><span class="hljs-punctuation">:</span> <span class="hljs-number">987</span><span class="hljs-punctuation">,</span>
   <span class="hljs-attr">"image"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">ProductImage</span><span class="hljs-punctuation">,</span>
   <span class="hljs-attr">"media_gallery"</span><span class="hljs-punctuation">:</span> <span class="hljs-punctuation">[</span><span class="hljs-string">MediaGalleryInterface</span><span class="hljs-punctuation">]</span><span class="hljs-punctuation">,</span>
   <span class="hljs-attr">"meta_description"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"abc123"</span><span class="hljs-punctuation">,</span>
-  <span class="hljs-attr">"meta_keyword"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"xyz789"</span><span class="hljs-punctuation">,</span>
-  <span class="hljs-attr">"meta_title"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"xyz789"</span><span class="hljs-punctuation">,</span>
-  <span class="hljs-attr">"name"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"abc123"</span><span class="hljs-punctuation">,</span>
+  <span class="hljs-attr">"meta_keyword"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"abc123"</span><span class="hljs-punctuation">,</span>
+  <span class="hljs-attr">"meta_title"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"abc123"</span><span class="hljs-punctuation">,</span>
+  <span class="hljs-attr">"name"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"xyz789"</span><span class="hljs-punctuation">,</span>
   <span class="hljs-attr">"new_from_date"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"xyz789"</span><span class="hljs-punctuation">,</span>
-  <span class="hljs-attr">"new_to_date"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"xyz789"</span><span class="hljs-punctuation">,</span>
+  <span class="hljs-attr">"new_to_date"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"abc123"</span><span class="hljs-punctuation">,</span>
   <span class="hljs-attr">"price_range"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">PriceRange</span><span class="hljs-punctuation">,</span>
   <span class="hljs-attr">"short_description"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">ComplexTextValue</span><span class="hljs-punctuation">,</span>
   <span class="hljs-attr">"sku"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"abc123"</span><span class="hljs-punctuation">,</span>
   <span class="hljs-attr">"small_image"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">ProductImage</span><span class="hljs-punctuation">,</span>
   <span class="hljs-attr">"thumbnail"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">ProductImage</span><span class="hljs-punctuation">,</span>
-  <span class="hljs-attr">"uid"</span><span class="hljs-punctuation">:</span> <span class="hljs-number">4</span><span class="hljs-punctuation">,</span>
+  <span class="hljs-attr">"uid"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"4"</span><span class="hljs-punctuation">,</span>
   <span class="hljs-attr">"updated_at"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"xyz789"</span><span class="hljs-punctuation">,</span>
   <span class="hljs-attr">"weight"</span><span class="hljs-punctuation">:</span> <span class="hljs-number">987.65</span>
 <span class="hljs-punctuation">}</span>
@@ -4182,6 +4200,7 @@ Authorization: Bearer &lt;YOUR_TOKEN_HERE&gt;</code></pre>
                 </html>
               </div>
             </div>
+            <a href="#top">back to top</a>
           </div>
         </section>
         <section id="definition-Highlight" class="definition definition-object" data-traverse-target="definition-Highlight">
@@ -4231,14 +4250,15 @@ Authorization: Bearer &lt;YOUR_TOKEN_HERE&gt;</code></pre>
                   <head></head>
                   <body><pre><code class="hljs language-json"><span class="hljs-punctuation">{</span>
   <span class="hljs-attr">"attribute"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"abc123"</span><span class="hljs-punctuation">,</span>
-  <span class="hljs-attr">"matched_words"</span><span class="hljs-punctuation">:</span> <span class="hljs-punctuation">[</span><span class="hljs-string">"xyz789"</span><span class="hljs-punctuation">]</span><span class="hljs-punctuation">,</span>
-  <span class="hljs-attr">"value"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"xyz789"</span>
+  <span class="hljs-attr">"matched_words"</span><span class="hljs-punctuation">:</span> <span class="hljs-punctuation">[</span><span class="hljs-string">"abc123"</span><span class="hljs-punctuation">]</span><span class="hljs-punctuation">,</span>
+  <span class="hljs-attr">"value"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"abc123"</span>
 <span class="hljs-punctuation">}</span>
 </code></pre>
                   </body>
                 </html>
               </div>
             </div>
+            <a href="#top">back to top</a>
           </div>
         </section>
         <section id="definition-ID" class="definition definition-scalar" data-traverse-target="definition-ID">
@@ -4264,6 +4284,7 @@ Authorization: Bearer &lt;YOUR_TOKEN_HERE&gt;</code></pre>
                 </html>
               </div>
             </div>
+            <a href="#top">back to top</a>
           </div>
         </section>
         <section id="definition-Int" class="definition definition-scalar" data-traverse-target="definition-Int">
@@ -4289,6 +4310,7 @@ Authorization: Bearer &lt;YOUR_TOKEN_HERE&gt;</code></pre>
                 </html>
               </div>
             </div>
+            <a href="#top">back to top</a>
           </div>
         </section>
         <section id="definition-JSON" class="definition definition-scalar" data-traverse-target="definition-JSON">
@@ -4314,6 +4336,7 @@ Authorization: Bearer &lt;YOUR_TOKEN_HERE&gt;</code></pre>
                 </html>
               </div>
             </div>
+            <a href="#top">back to top</a>
           </div>
         </section>
         <section id="definition-MediaGalleryInterface" class="definition definition-interface" data-traverse-target="definition-MediaGalleryInterface">
@@ -4385,7 +4408,7 @@ Authorization: Bearer &lt;YOUR_TOKEN_HERE&gt;</code></pre>
                   <head></head>
                   <body><pre><code class="hljs language-json"><span class="hljs-punctuation">{</span>
   <span class="hljs-attr">"disabled"</span><span class="hljs-punctuation">:</span> <span class="hljs-literal"><span class="hljs-keyword">true</span></span><span class="hljs-punctuation">,</span>
-  <span class="hljs-attr">"label"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"xyz789"</span><span class="hljs-punctuation">,</span>
+  <span class="hljs-attr">"label"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"abc123"</span><span class="hljs-punctuation">,</span>
   <span class="hljs-attr">"position"</span><span class="hljs-punctuation">:</span> <span class="hljs-number">123</span><span class="hljs-punctuation">,</span>
   <span class="hljs-attr">"url"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"abc123"</span>
 <span class="hljs-punctuation">}</span>
@@ -4394,6 +4417,7 @@ Authorization: Bearer &lt;YOUR_TOKEN_HERE&gt;</code></pre>
                 </html>
               </div>
             </div>
+            <a href="#top">back to top</a>
           </div>
         </section>
         <section id="definition-Money" class="definition definition-object" data-traverse-target="definition-Money">
@@ -4442,6 +4466,7 @@ Authorization: Bearer &lt;YOUR_TOKEN_HERE&gt;</code></pre>
                 </html>
               </div>
             </div>
+            <a href="#top">back to top</a>
           </div>
         </section>
         <section id="definition-PageType" class="definition definition-enum" data-traverse-target="definition-PageType">
@@ -4522,6 +4547,7 @@ Authorization: Bearer &lt;YOUR_TOKEN_HERE&gt;</code></pre>
                 </html>
               </div>
             </div>
+            <a href="#top">back to top</a>
           </div>
         </section>
         <section id="definition-PhysicalProductInterface" class="definition definition-interface" data-traverse-target="definition-PhysicalProductInterface">
@@ -4596,12 +4622,13 @@ Authorization: Bearer &lt;YOUR_TOKEN_HERE&gt;</code></pre>
                 <h5>Example</h5>
                 <html>
                   <head></head>
-                  <body><pre><code class="hljs language-json"><span class="hljs-punctuation">{</span><span class="hljs-attr">"weight"</span><span class="hljs-punctuation">:</span> <span class="hljs-number">123.45</span><span class="hljs-punctuation">}</span>
+                  <body><pre><code class="hljs language-json"><span class="hljs-punctuation">{</span><span class="hljs-attr">"weight"</span><span class="hljs-punctuation">:</span> <span class="hljs-number">987.65</span><span class="hljs-punctuation">}</span>
 </code></pre>
                   </body>
                 </html>
               </div>
             </div>
+            <a href="#top">back to top</a>
           </div>
         </section>
         <section id="definition-Price" class="definition definition-object" data-traverse-target="definition-Price">
@@ -4653,6 +4680,7 @@ Authorization: Bearer &lt;YOUR_TOKEN_HERE&gt;</code></pre>
                 </html>
               </div>
             </div>
+            <a href="#top">back to top</a>
           </div>
         </section>
         <section id="definition-PriceAdjustment" class="definition definition-object" data-traverse-target="definition-PriceAdjustment">
@@ -4695,12 +4723,13 @@ Authorization: Bearer &lt;YOUR_TOKEN_HERE&gt;</code></pre>
                 <h5>Example</h5>
                 <html>
                   <head></head>
-                  <body><pre><code class="hljs language-json"><span class="hljs-punctuation">{</span><span class="hljs-attr">"amount"</span><span class="hljs-punctuation">:</span> <span class="hljs-number">987.65</span><span class="hljs-punctuation">,</span> <span class="hljs-attr">"code"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"xyz789"</span><span class="hljs-punctuation">}</span>
+                  <body><pre><code class="hljs language-json"><span class="hljs-punctuation">{</span><span class="hljs-attr">"amount"</span><span class="hljs-punctuation">:</span> <span class="hljs-number">987.65</span><span class="hljs-punctuation">,</span> <span class="hljs-attr">"code"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"abc123"</span><span class="hljs-punctuation">}</span>
 </code></pre>
                   </body>
                 </html>
               </div>
             </div>
+            <a href="#top">back to top</a>
           </div>
         </section>
         <section id="definition-PriceRange" class="definition definition-object" data-traverse-target="definition-PriceRange">
@@ -4752,6 +4781,7 @@ Authorization: Bearer &lt;YOUR_TOKEN_HERE&gt;</code></pre>
                 </html>
               </div>
             </div>
+            <a href="#top">back to top</a>
           </div>
         </section>
         <section id="definition-ProductDiscount" class="definition definition-object" data-traverse-target="definition-ProductDiscount">
@@ -4794,12 +4824,13 @@ Authorization: Bearer &lt;YOUR_TOKEN_HERE&gt;</code></pre>
                 <h5>Example</h5>
                 <html>
                   <head></head>
-                  <body><pre><code class="hljs language-json"><span class="hljs-punctuation">{</span><span class="hljs-attr">"amount_off"</span><span class="hljs-punctuation">:</span> <span class="hljs-number">123.45</span><span class="hljs-punctuation">,</span> <span class="hljs-attr">"percent_off"</span><span class="hljs-punctuation">:</span> <span class="hljs-number">123.45</span><span class="hljs-punctuation">}</span>
+                  <body><pre><code class="hljs language-json"><span class="hljs-punctuation">{</span><span class="hljs-attr">"amount_off"</span><span class="hljs-punctuation">:</span> <span class="hljs-number">987.65</span><span class="hljs-punctuation">,</span> <span class="hljs-attr">"percent_off"</span><span class="hljs-punctuation">:</span> <span class="hljs-number">987.65</span><span class="hljs-punctuation">}</span>
 </code></pre>
                   </body>
                 </html>
               </div>
             </div>
+            <a href="#top">back to top</a>
           </div>
         </section>
         <section id="definition-ProductImage" class="definition definition-object" data-traverse-target="definition-ProductImage">
@@ -4854,15 +4885,16 @@ Authorization: Bearer &lt;YOUR_TOKEN_HERE&gt;</code></pre>
                   <head></head>
                   <body><pre><code class="hljs language-json"><span class="hljs-punctuation">{</span>
   <span class="hljs-attr">"disabled"</span><span class="hljs-punctuation">:</span> <span class="hljs-literal"><span class="hljs-keyword">true</span></span><span class="hljs-punctuation">,</span>
-  <span class="hljs-attr">"label"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"abc123"</span><span class="hljs-punctuation">,</span>
-  <span class="hljs-attr">"position"</span><span class="hljs-punctuation">:</span> <span class="hljs-number">987</span><span class="hljs-punctuation">,</span>
-  <span class="hljs-attr">"url"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"xyz789"</span>
+  <span class="hljs-attr">"label"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"xyz789"</span><span class="hljs-punctuation">,</span>
+  <span class="hljs-attr">"position"</span><span class="hljs-punctuation">:</span> <span class="hljs-number">123</span><span class="hljs-punctuation">,</span>
+  <span class="hljs-attr">"url"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"abc123"</span>
 <span class="hljs-punctuation">}</span>
 </code></pre>
                   </body>
                 </html>
               </div>
             </div>
+            <a href="#top">back to top</a>
           </div>
         </section>
         <section id="definition-ProductInterface" class="definition definition-interface" data-traverse-target="definition-ProductInterface">
@@ -5062,19 +5094,19 @@ Authorization: Bearer &lt;YOUR_TOKEN_HERE&gt;</code></pre>
   <span class="hljs-attr">"add_to_cart_allowed"</span><span class="hljs-punctuation">:</span> <span class="hljs-literal"><span class="hljs-keyword">false</span></span><span class="hljs-punctuation">,</span>
   <span class="hljs-attr">"attribute_set_id"</span><span class="hljs-punctuation">:</span> <span class="hljs-number">123</span><span class="hljs-punctuation">,</span>
   <span class="hljs-attr">"canonical_url"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"xyz789"</span><span class="hljs-punctuation">,</span>
-  <span class="hljs-attr">"created_at"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"xyz789"</span><span class="hljs-punctuation">,</span>
+  <span class="hljs-attr">"created_at"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"abc123"</span><span class="hljs-punctuation">,</span>
   <span class="hljs-attr">"custom_attributes"</span><span class="hljs-punctuation">:</span> <span class="hljs-punctuation">[</span><span class="hljs-string">CustomAttribute</span><span class="hljs-punctuation">]</span><span class="hljs-punctuation">,</span>
   <span class="hljs-attr">"description"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">ComplexTextValue</span><span class="hljs-punctuation">,</span>
   <span class="hljs-attr">"gift_message_available"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"xyz789"</span><span class="hljs-punctuation">,</span>
   <span class="hljs-attr">"id"</span><span class="hljs-punctuation">:</span> <span class="hljs-number">123</span><span class="hljs-punctuation">,</span>
   <span class="hljs-attr">"image"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">ProductImage</span><span class="hljs-punctuation">,</span>
   <span class="hljs-attr">"media_gallery"</span><span class="hljs-punctuation">:</span> <span class="hljs-punctuation">[</span><span class="hljs-string">MediaGalleryInterface</span><span class="hljs-punctuation">]</span><span class="hljs-punctuation">,</span>
-  <span class="hljs-attr">"meta_description"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"xyz789"</span><span class="hljs-punctuation">,</span>
-  <span class="hljs-attr">"meta_keyword"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"xyz789"</span><span class="hljs-punctuation">,</span>
-  <span class="hljs-attr">"meta_title"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"xyz789"</span><span class="hljs-punctuation">,</span>
-  <span class="hljs-attr">"name"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"abc123"</span><span class="hljs-punctuation">,</span>
+  <span class="hljs-attr">"meta_description"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"abc123"</span><span class="hljs-punctuation">,</span>
+  <span class="hljs-attr">"meta_keyword"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"abc123"</span><span class="hljs-punctuation">,</span>
+  <span class="hljs-attr">"meta_title"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"abc123"</span><span class="hljs-punctuation">,</span>
+  <span class="hljs-attr">"name"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"xyz789"</span><span class="hljs-punctuation">,</span>
   <span class="hljs-attr">"new_from_date"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"xyz789"</span><span class="hljs-punctuation">,</span>
-  <span class="hljs-attr">"new_to_date"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"xyz789"</span><span class="hljs-punctuation">,</span>
+  <span class="hljs-attr">"new_to_date"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"abc123"</span><span class="hljs-punctuation">,</span>
   <span class="hljs-attr">"price_range"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">PriceRange</span><span class="hljs-punctuation">,</span>
   <span class="hljs-attr">"short_description"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">ComplexTextValue</span><span class="hljs-punctuation">,</span>
   <span class="hljs-attr">"sku"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"abc123"</span><span class="hljs-punctuation">,</span>
@@ -5088,6 +5120,7 @@ Authorization: Bearer &lt;YOUR_TOKEN_HERE&gt;</code></pre>
                 </html>
               </div>
             </div>
+            <a href="#top">back to top</a>
           </div>
         </section>
         <section id="definition-ProductPrice" class="definition definition-object" data-traverse-target="definition-ProductPrice">
@@ -5151,6 +5184,7 @@ Authorization: Bearer &lt;YOUR_TOKEN_HERE&gt;</code></pre>
                 </html>
               </div>
             </div>
+            <a href="#top">back to top</a>
           </div>
         </section>
         <section id="definition-ProductSearchItem" class="definition definition-object" data-traverse-target="definition-ProductSearchItem">
@@ -5214,6 +5248,7 @@ Authorization: Bearer &lt;YOUR_TOKEN_HERE&gt;</code></pre>
                 </html>
               </div>
             </div>
+            <a href="#top">back to top</a>
           </div>
         </section>
         <section id="definition-ProductSearchResponse" class="definition definition-object" data-traverse-target="definition-ProductSearchResponse">
@@ -5289,6 +5324,7 @@ Authorization: Bearer &lt;YOUR_TOKEN_HERE&gt;</code></pre>
                 </html>
               </div>
             </div>
+            <a href="#top">back to top</a>
           </div>
         </section>
         <section id="definition-ProductSearchSortInput" class="definition definition-input-object" data-traverse-target="definition-ProductSearchSortInput">
@@ -5339,6 +5375,7 @@ Authorization: Bearer &lt;YOUR_TOKEN_HERE&gt;</code></pre>
                 </html>
               </div>
             </div>
+            <a href="#top">back to top</a>
           </div>
         </section>
         <section id="definition-ProductView" class="definition definition-interface" data-traverse-target="definition-ProductView">
@@ -5563,35 +5600,36 @@ Authorization: Bearer &lt;YOUR_TOKEN_HERE&gt;</code></pre>
                   <body><pre><code class="hljs language-json"><span class="hljs-punctuation">{</span>
   <span class="hljs-attr">"addToCartAllowed"</span><span class="hljs-punctuation">:</span> <span class="hljs-literal"><span class="hljs-keyword">true</span></span><span class="hljs-punctuation">,</span>
   <span class="hljs-attr">"inStock"</span><span class="hljs-punctuation">:</span> <span class="hljs-literal"><span class="hljs-keyword">true</span></span><span class="hljs-punctuation">,</span>
-  <span class="hljs-attr">"lowStock"</span><span class="hljs-punctuation">:</span> <span class="hljs-literal"><span class="hljs-keyword">false</span></span><span class="hljs-punctuation">,</span>
+  <span class="hljs-attr">"lowStock"</span><span class="hljs-punctuation">:</span> <span class="hljs-literal"><span class="hljs-keyword">true</span></span><span class="hljs-punctuation">,</span>
   <span class="hljs-attr">"attributes"</span><span class="hljs-punctuation">:</span> <span class="hljs-punctuation">[</span><span class="hljs-string">ProductViewAttribute</span><span class="hljs-punctuation">]</span><span class="hljs-punctuation">,</span>
-  <span class="hljs-attr">"description"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"xyz789"</span><span class="hljs-punctuation">,</span>
-  <span class="hljs-attr">"id"</span><span class="hljs-punctuation">:</span> <span class="hljs-number">4</span><span class="hljs-punctuation">,</span>
+  <span class="hljs-attr">"description"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"abc123"</span><span class="hljs-punctuation">,</span>
+  <span class="hljs-attr">"id"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"4"</span><span class="hljs-punctuation">,</span>
   <span class="hljs-attr">"images"</span><span class="hljs-punctuation">:</span> <span class="hljs-punctuation">[</span><span class="hljs-string">ProductViewImage</span><span class="hljs-punctuation">]</span><span class="hljs-punctuation">,</span>
   <span class="hljs-attr">"videos"</span><span class="hljs-punctuation">:</span> <span class="hljs-punctuation">[</span><span class="hljs-string">ProductViewVideo</span><span class="hljs-punctuation">]</span><span class="hljs-punctuation">,</span>
   <span class="hljs-attr">"lastModifiedAt"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"2007-12-03T10:15:30Z"</span><span class="hljs-punctuation">,</span>
-  <span class="hljs-attr">"metaDescription"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"abc123"</span><span class="hljs-punctuation">,</span>
-  <span class="hljs-attr">"metaKeyword"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"abc123"</span><span class="hljs-punctuation">,</span>
-  <span class="hljs-attr">"metaTitle"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"xyz789"</span><span class="hljs-punctuation">,</span>
+  <span class="hljs-attr">"metaDescription"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"xyz789"</span><span class="hljs-punctuation">,</span>
+  <span class="hljs-attr">"metaKeyword"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"xyz789"</span><span class="hljs-punctuation">,</span>
+  <span class="hljs-attr">"metaTitle"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"abc123"</span><span class="hljs-punctuation">,</span>
   <span class="hljs-attr">"name"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"xyz789"</span><span class="hljs-punctuation">,</span>
-  <span class="hljs-attr">"shortDescription"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"abc123"</span><span class="hljs-punctuation">,</span>
+  <span class="hljs-attr">"shortDescription"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"xyz789"</span><span class="hljs-punctuation">,</span>
   <span class="hljs-attr">"inputOptions"</span><span class="hljs-punctuation">:</span> <span class="hljs-punctuation">[</span><span class="hljs-string">ProductViewInputOption</span><span class="hljs-punctuation">]</span><span class="hljs-punctuation">,</span>
   <span class="hljs-attr">"sku"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"abc123"</span><span class="hljs-punctuation">,</span>
   <span class="hljs-attr">"externalId"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"abc123"</span><span class="hljs-punctuation">,</span>
   <span class="hljs-attr">"url"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"abc123"</span><span class="hljs-punctuation">,</span>
-  <span class="hljs-attr">"urlKey"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"xyz789"</span><span class="hljs-punctuation">,</span>
+  <span class="hljs-attr">"urlKey"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"abc123"</span><span class="hljs-punctuation">,</span>
   <span class="hljs-attr">"links"</span><span class="hljs-punctuation">:</span> <span class="hljs-punctuation">[</span><span class="hljs-string">ProductViewLink</span><span class="hljs-punctuation">]</span><span class="hljs-punctuation">,</span>
-  <span class="hljs-attr">"categories"</span><span class="hljs-punctuation">:</span> <span class="hljs-punctuation">[</span><span class="hljs-string">"abc123"</span><span class="hljs-punctuation">]</span><span class="hljs-punctuation">,</span>
-  <span class="hljs-attr">"queryType"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"abc123"</span><span class="hljs-punctuation">,</span>
-  <span class="hljs-attr">"rank"</span><span class="hljs-punctuation">:</span> <span class="hljs-number">987</span><span class="hljs-punctuation">,</span>
-  <span class="hljs-attr">"score"</span><span class="hljs-punctuation">:</span> <span class="hljs-number">987.65</span><span class="hljs-punctuation">,</span>
-  <span class="hljs-attr">"visibility"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"abc123"</span>
+  <span class="hljs-attr">"categories"</span><span class="hljs-punctuation">:</span> <span class="hljs-punctuation">[</span><span class="hljs-string">"xyz789"</span><span class="hljs-punctuation">]</span><span class="hljs-punctuation">,</span>
+  <span class="hljs-attr">"queryType"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"xyz789"</span><span class="hljs-punctuation">,</span>
+  <span class="hljs-attr">"rank"</span><span class="hljs-punctuation">:</span> <span class="hljs-number">123</span><span class="hljs-punctuation">,</span>
+  <span class="hljs-attr">"score"</span><span class="hljs-punctuation">:</span> <span class="hljs-number">123.45</span><span class="hljs-punctuation">,</span>
+  <span class="hljs-attr">"visibility"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"xyz789"</span>
 <span class="hljs-punctuation">}</span>
 </code></pre>
                   </body>
                 </html>
               </div>
             </div>
+            <a href="#top">back to top</a>
           </div>
         </section>
         <section id="definition-ProductViewAttribute" class="definition definition-object" data-traverse-target="definition-ProductViewAttribute">
@@ -5646,7 +5684,7 @@ Authorization: Bearer &lt;YOUR_TOKEN_HERE&gt;</code></pre>
                   <head></head>
                   <body><pre><code class="hljs language-json"><span class="hljs-punctuation">{</span>
   <span class="hljs-attr">"label"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"abc123"</span><span class="hljs-punctuation">,</span>
-  <span class="hljs-attr">"name"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"abc123"</span><span class="hljs-punctuation">,</span>
+  <span class="hljs-attr">"name"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"xyz789"</span><span class="hljs-punctuation">,</span>
   <span class="hljs-attr">"roles"</span><span class="hljs-punctuation">:</span> <span class="hljs-punctuation">[</span><span class="hljs-string">"xyz789"</span><span class="hljs-punctuation">]</span><span class="hljs-punctuation">,</span>
   <span class="hljs-attr">"value"</span><span class="hljs-punctuation">:</span> <span class="hljs-punctuation">{</span><span class="hljs-punctuation">}</span>
 <span class="hljs-punctuation">}</span>
@@ -5655,6 +5693,7 @@ Authorization: Bearer &lt;YOUR_TOKEN_HERE&gt;</code></pre>
                 </html>
               </div>
             </div>
+            <a href="#top">back to top</a>
           </div>
         </section>
         <section id="definition-ProductViewCurrency" class="definition definition-enum" data-traverse-target="definition-ProductViewCurrency">
@@ -6883,6 +6922,7 @@ Authorization: Bearer &lt;YOUR_TOKEN_HERE&gt;</code></pre>
                 </html>
               </div>
             </div>
+            <a href="#top">back to top</a>
           </div>
         </section>
         <section id="definition-ProductViewImage" class="definition definition-object" data-traverse-target="definition-ProductViewImage">
@@ -6932,14 +6972,15 @@ Authorization: Bearer &lt;YOUR_TOKEN_HERE&gt;</code></pre>
                   <head></head>
                   <body><pre><code class="hljs language-json"><span class="hljs-punctuation">{</span>
   <span class="hljs-attr">"label"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"abc123"</span><span class="hljs-punctuation">,</span>
-  <span class="hljs-attr">"roles"</span><span class="hljs-punctuation">:</span> <span class="hljs-punctuation">[</span><span class="hljs-string">"abc123"</span><span class="hljs-punctuation">]</span><span class="hljs-punctuation">,</span>
-  <span class="hljs-attr">"url"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"xyz789"</span>
+  <span class="hljs-attr">"roles"</span><span class="hljs-punctuation">:</span> <span class="hljs-punctuation">[</span><span class="hljs-string">"xyz789"</span><span class="hljs-punctuation">]</span><span class="hljs-punctuation">,</span>
+  <span class="hljs-attr">"url"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"abc123"</span>
 <span class="hljs-punctuation">}</span>
 </code></pre>
                   </body>
                 </html>
               </div>
             </div>
+            <a href="#top">back to top</a>
           </div>
         </section>
         <section id="definition-ProductViewInputOption" class="definition definition-object" data-traverse-target="definition-ProductViewInputOption">
@@ -7028,7 +7069,7 @@ Authorization: Bearer &lt;YOUR_TOKEN_HERE&gt;</code></pre>
                   <body><pre><code class="hljs language-json"><span class="hljs-punctuation">{</span>
   <span class="hljs-attr">"id"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"4"</span><span class="hljs-punctuation">,</span>
   <span class="hljs-attr">"title"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"xyz789"</span><span class="hljs-punctuation">,</span>
-  <span class="hljs-attr">"required"</span><span class="hljs-punctuation">:</span> <span class="hljs-literal"><span class="hljs-keyword">true</span></span><span class="hljs-punctuation">,</span>
+  <span class="hljs-attr">"required"</span><span class="hljs-punctuation">:</span> <span class="hljs-literal"><span class="hljs-keyword">false</span></span><span class="hljs-punctuation">,</span>
   <span class="hljs-attr">"type"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"abc123"</span><span class="hljs-punctuation">,</span>
   <span class="hljs-attr">"markupAmount"</span><span class="hljs-punctuation">:</span> <span class="hljs-number">123.45</span><span class="hljs-punctuation">,</span>
   <span class="hljs-attr">"suffix"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"abc123"</span><span class="hljs-punctuation">,</span>
@@ -7042,6 +7083,7 @@ Authorization: Bearer &lt;YOUR_TOKEN_HERE&gt;</code></pre>
                 </html>
               </div>
             </div>
+            <a href="#top">back to top</a>
           </div>
         </section>
         <section id="definition-ProductViewInputOptionImageSize" class="definition definition-object" data-traverse-target="definition-ProductViewInputOptionImageSize">
@@ -7082,12 +7124,13 @@ Authorization: Bearer &lt;YOUR_TOKEN_HERE&gt;</code></pre>
                 <h5>Example</h5>
                 <html>
                   <head></head>
-                  <body><pre><code class="hljs language-json"><span class="hljs-punctuation">{</span><span class="hljs-attr">"width"</span><span class="hljs-punctuation">:</span> <span class="hljs-number">987</span><span class="hljs-punctuation">,</span> <span class="hljs-attr">"height"</span><span class="hljs-punctuation">:</span> <span class="hljs-number">987</span><span class="hljs-punctuation">}</span>
+                  <body><pre><code class="hljs language-json"><span class="hljs-punctuation">{</span><span class="hljs-attr">"width"</span><span class="hljs-punctuation">:</span> <span class="hljs-number">987</span><span class="hljs-punctuation">,</span> <span class="hljs-attr">"height"</span><span class="hljs-punctuation">:</span> <span class="hljs-number">123</span><span class="hljs-punctuation">}</span>
 </code></pre>
                   </body>
                 </html>
               </div>
             </div>
+            <a href="#top">back to top</a>
           </div>
         </section>
         <section id="definition-ProductViewInputOptionRange" class="definition definition-object" data-traverse-target="definition-ProductViewInputOptionRange">
@@ -7134,6 +7177,7 @@ Authorization: Bearer &lt;YOUR_TOKEN_HERE&gt;</code></pre>
                 </html>
               </div>
             </div>
+            <a href="#top">back to top</a>
           </div>
         </section>
         <section id="definition-ProductViewLink" class="definition definition-object" data-traverse-target="definition-ProductViewLink">
@@ -7185,6 +7229,7 @@ Authorization: Bearer &lt;YOUR_TOKEN_HERE&gt;</code></pre>
                 </html>
               </div>
             </div>
+            <a href="#top">back to top</a>
           </div>
         </section>
         <section id="definition-ProductViewMoney" class="definition definition-object" data-traverse-target="definition-ProductViewMoney">
@@ -7233,6 +7278,7 @@ Authorization: Bearer &lt;YOUR_TOKEN_HERE&gt;</code></pre>
                 </html>
               </div>
             </div>
+            <a href="#top">back to top</a>
           </div>
         </section>
         <section id="definition-ProductViewOption" class="definition definition-object" data-traverse-target="definition-ProductViewOption">
@@ -7292,8 +7338,8 @@ Authorization: Bearer &lt;YOUR_TOKEN_HERE&gt;</code></pre>
                   <head></head>
                   <body><pre><code class="hljs language-json"><span class="hljs-punctuation">{</span>
   <span class="hljs-attr">"id"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"4"</span><span class="hljs-punctuation">,</span>
-  <span class="hljs-attr">"multi"</span><span class="hljs-punctuation">:</span> <span class="hljs-literal"><span class="hljs-keyword">false</span></span><span class="hljs-punctuation">,</span>
-  <span class="hljs-attr">"required"</span><span class="hljs-punctuation">:</span> <span class="hljs-literal"><span class="hljs-keyword">true</span></span><span class="hljs-punctuation">,</span>
+  <span class="hljs-attr">"multi"</span><span class="hljs-punctuation">:</span> <span class="hljs-literal"><span class="hljs-keyword">true</span></span><span class="hljs-punctuation">,</span>
+  <span class="hljs-attr">"required"</span><span class="hljs-punctuation">:</span> <span class="hljs-literal"><span class="hljs-keyword">false</span></span><span class="hljs-punctuation">,</span>
   <span class="hljs-attr">"title"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"abc123"</span><span class="hljs-punctuation">,</span>
   <span class="hljs-attr">"values"</span><span class="hljs-punctuation">:</span> <span class="hljs-punctuation">[</span><span class="hljs-string">ProductViewOptionValue</span><span class="hljs-punctuation">]</span>
 <span class="hljs-punctuation">}</span>
@@ -7302,6 +7348,7 @@ Authorization: Bearer &lt;YOUR_TOKEN_HERE&gt;</code></pre>
                 </html>
               </div>
             </div>
+            <a href="#top">back to top</a>
           </div>
         </section>
         <section id="definition-ProductViewOptionValue" class="definition definition-interface" data-traverse-target="definition-ProductViewOptionValue">
@@ -7377,15 +7424,16 @@ Authorization: Bearer &lt;YOUR_TOKEN_HERE&gt;</code></pre>
                 <html>
                   <head></head>
                   <body><pre><code class="hljs language-json"><span class="hljs-punctuation">{</span>
-  <span class="hljs-attr">"id"</span><span class="hljs-punctuation">:</span> <span class="hljs-number">4</span><span class="hljs-punctuation">,</span>
+  <span class="hljs-attr">"id"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"4"</span><span class="hljs-punctuation">,</span>
   <span class="hljs-attr">"title"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"xyz789"</span><span class="hljs-punctuation">,</span>
-  <span class="hljs-attr">"inStock"</span><span class="hljs-punctuation">:</span> <span class="hljs-literal"><span class="hljs-keyword">false</span></span>
+  <span class="hljs-attr">"inStock"</span><span class="hljs-punctuation">:</span> <span class="hljs-literal"><span class="hljs-keyword">true</span></span>
 <span class="hljs-punctuation">}</span>
 </code></pre>
                   </body>
                 </html>
               </div>
             </div>
+            <a href="#top">back to top</a>
           </div>
         </section>
         <section id="definition-ProductViewOptionValueConfiguration" class="definition definition-object" data-traverse-target="definition-ProductViewOptionValueConfiguration">
@@ -7434,8 +7482,8 @@ Authorization: Bearer &lt;YOUR_TOKEN_HERE&gt;</code></pre>
                 <html>
                   <head></head>
                   <body><pre><code class="hljs language-json"><span class="hljs-punctuation">{</span>
-  <span class="hljs-attr">"id"</span><span class="hljs-punctuation">:</span> <span class="hljs-number">4</span><span class="hljs-punctuation">,</span>
-  <span class="hljs-attr">"title"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"abc123"</span><span class="hljs-punctuation">,</span>
+  <span class="hljs-attr">"id"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"4"</span><span class="hljs-punctuation">,</span>
+  <span class="hljs-attr">"title"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"xyz789"</span><span class="hljs-punctuation">,</span>
   <span class="hljs-attr">"inStock"</span><span class="hljs-punctuation">:</span> <span class="hljs-literal"><span class="hljs-keyword">false</span></span>
 <span class="hljs-punctuation">}</span>
 </code></pre>
@@ -7443,6 +7491,7 @@ Authorization: Bearer &lt;YOUR_TOKEN_HERE&gt;</code></pre>
                 </html>
               </div>
             </div>
+            <a href="#top">back to top</a>
           </div>
         </section>
         <section id="definition-ProductViewOptionValueProduct" class="definition definition-object" data-traverse-target="definition-ProductViewOptionValueProduct">
@@ -7496,6 +7545,11 @@ Authorization: Bearer &lt;YOUR_TOKEN_HERE&gt;</code></pre>
                       </td>
                       <td> Indicates if the option is in stock. </td>
                     </tr>
+                    <tr>
+                      <td data-property-name=""><span class="property-name"><code>enabled</code></span> - <span class="property-type"><a href="#definition-Boolean"><code>Boolean</code></a></span>
+                      </td>
+                      <td> Indicates if the associated product is enabled. </td>
+                    </tr>
                   </tbody>
                 </table>
               </div>
@@ -7506,18 +7560,20 @@ Authorization: Bearer &lt;YOUR_TOKEN_HERE&gt;</code></pre>
                 <html>
                   <head></head>
                   <body><pre><code class="hljs language-json"><span class="hljs-punctuation">{</span>
-  <span class="hljs-attr">"id"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"4"</span><span class="hljs-punctuation">,</span>
+  <span class="hljs-attr">"id"</span><span class="hljs-punctuation">:</span> <span class="hljs-number">4</span><span class="hljs-punctuation">,</span>
   <span class="hljs-attr">"isDefault"</span><span class="hljs-punctuation">:</span> <span class="hljs-literal"><span class="hljs-keyword">false</span></span><span class="hljs-punctuation">,</span>
   <span class="hljs-attr">"product"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">SimpleProductView</span><span class="hljs-punctuation">,</span>
   <span class="hljs-attr">"quantity"</span><span class="hljs-punctuation">:</span> <span class="hljs-number">123.45</span><span class="hljs-punctuation">,</span>
-  <span class="hljs-attr">"title"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"abc123"</span><span class="hljs-punctuation">,</span>
-  <span class="hljs-attr">"inStock"</span><span class="hljs-punctuation">:</span> <span class="hljs-literal"><span class="hljs-keyword">false</span></span>
+  <span class="hljs-attr">"title"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"xyz789"</span><span class="hljs-punctuation">,</span>
+  <span class="hljs-attr">"inStock"</span><span class="hljs-punctuation">:</span> <span class="hljs-literal"><span class="hljs-keyword">true</span></span><span class="hljs-punctuation">,</span>
+  <span class="hljs-attr">"enabled"</span><span class="hljs-punctuation">:</span> <span class="hljs-literal"><span class="hljs-keyword">false</span></span>
 <span class="hljs-punctuation">}</span>
 </code></pre>
                   </body>
                 </html>
               </div>
             </div>
+            <a href="#top">back to top</a>
           </div>
         </section>
         <section id="definition-ProductViewOptionValueSwatch" class="definition definition-object" data-traverse-target="definition-ProductViewOptionValueSwatch">
@@ -7576,17 +7632,18 @@ Authorization: Bearer &lt;YOUR_TOKEN_HERE&gt;</code></pre>
                 <html>
                   <head></head>
                   <body><pre><code class="hljs language-json"><span class="hljs-punctuation">{</span>
-  <span class="hljs-attr">"id"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"4"</span><span class="hljs-punctuation">,</span>
+  <span class="hljs-attr">"id"</span><span class="hljs-punctuation">:</span> <span class="hljs-number">4</span><span class="hljs-punctuation">,</span>
   <span class="hljs-attr">"title"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"abc123"</span><span class="hljs-punctuation">,</span>
   <span class="hljs-attr">"type"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"TEXT"</span><span class="hljs-punctuation">,</span>
-  <span class="hljs-attr">"value"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"xyz789"</span><span class="hljs-punctuation">,</span>
-  <span class="hljs-attr">"inStock"</span><span class="hljs-punctuation">:</span> <span class="hljs-literal"><span class="hljs-keyword">true</span></span>
+  <span class="hljs-attr">"value"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"abc123"</span><span class="hljs-punctuation">,</span>
+  <span class="hljs-attr">"inStock"</span><span class="hljs-punctuation">:</span> <span class="hljs-literal"><span class="hljs-keyword">false</span></span>
 <span class="hljs-punctuation">}</span>
 </code></pre>
                   </body>
                 </html>
               </div>
             </div>
+            <a href="#top">back to top</a>
           </div>
         </section>
         <section id="definition-ProductViewPrice" class="definition definition-object" data-traverse-target="definition-ProductViewPrice">
@@ -7644,6 +7701,7 @@ Authorization: Bearer &lt;YOUR_TOKEN_HERE&gt;</code></pre>
                 </html>
               </div>
             </div>
+            <a href="#top">back to top</a>
           </div>
         </section>
         <section id="definition-ProductViewPriceRange" class="definition definition-object" data-traverse-target="definition-ProductViewPriceRange">
@@ -7695,6 +7753,7 @@ Authorization: Bearer &lt;YOUR_TOKEN_HERE&gt;</code></pre>
                 </html>
               </div>
             </div>
+            <a href="#top">back to top</a>
           </div>
         </section>
         <section id="definition-ProductViewVariant" class="definition definition-object" data-traverse-target="definition-ProductViewVariant">
@@ -7734,7 +7793,7 @@ Authorization: Bearer &lt;YOUR_TOKEN_HERE&gt;</code></pre>
                 <html>
                   <head></head>
                   <body><pre><code class="hljs language-json"><span class="hljs-punctuation">{</span>
-  <span class="hljs-attr">"selections"</span><span class="hljs-punctuation">:</span> <span class="hljs-punctuation">[</span><span class="hljs-string">"abc123"</span><span class="hljs-punctuation">]</span><span class="hljs-punctuation">,</span>
+  <span class="hljs-attr">"selections"</span><span class="hljs-punctuation">:</span> <span class="hljs-punctuation">[</span><span class="hljs-string">"xyz789"</span><span class="hljs-punctuation">]</span><span class="hljs-punctuation">,</span>
   <span class="hljs-attr">"product"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">ProductView</span>
 <span class="hljs-punctuation">}</span>
 </code></pre>
@@ -7742,6 +7801,7 @@ Authorization: Bearer &lt;YOUR_TOKEN_HERE&gt;</code></pre>
                 </html>
               </div>
             </div>
+            <a href="#top">back to top</a>
           </div>
         </section>
         <section id="definition-ProductViewVariantResults" class="definition definition-object" data-traverse-target="definition-ProductViewVariantResults">
@@ -7789,6 +7849,7 @@ Authorization: Bearer &lt;YOUR_TOKEN_HERE&gt;</code></pre>
                 </html>
               </div>
             </div>
+            <a href="#top">back to top</a>
           </div>
         </section>
         <section id="definition-ProductViewVideo" class="definition definition-object" data-traverse-target="definition-ProductViewVideo">
@@ -7844,14 +7905,15 @@ Authorization: Bearer &lt;YOUR_TOKEN_HERE&gt;</code></pre>
                   <body><pre><code class="hljs language-json"><span class="hljs-punctuation">{</span>
   <span class="hljs-attr">"preview"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">ProductViewImage</span><span class="hljs-punctuation">,</span>
   <span class="hljs-attr">"url"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"abc123"</span><span class="hljs-punctuation">,</span>
-  <span class="hljs-attr">"description"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"xyz789"</span><span class="hljs-punctuation">,</span>
-  <span class="hljs-attr">"title"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"abc123"</span>
+  <span class="hljs-attr">"description"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"abc123"</span><span class="hljs-punctuation">,</span>
+  <span class="hljs-attr">"title"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"xyz789"</span>
 <span class="hljs-punctuation">}</span>
 </code></pre>
                   </body>
                 </html>
               </div>
             </div>
+            <a href="#top">back to top</a>
           </div>
         </section>
         <section id="definition-PurchaseHistory" class="definition definition-input-object" data-traverse-target="definition-PurchaseHistory">
@@ -7907,6 +7969,7 @@ Authorization: Bearer &lt;YOUR_TOKEN_HERE&gt;</code></pre>
                 </html>
               </div>
             </div>
+            <a href="#top">back to top</a>
           </div>
         </section>
         <section id="definition-QueryContextInput" class="definition definition-input-object" data-traverse-target="definition-QueryContextInput">
@@ -7956,6 +8019,7 @@ Authorization: Bearer &lt;YOUR_TOKEN_HERE&gt;</code></pre>
                 </html>
               </div>
             </div>
+            <a href="#top">back to top</a>
           </div>
         </section>
         <section id="definition-RangeBucket" class="definition definition-object" data-traverse-target="definition-RangeBucket">
@@ -8009,16 +8073,17 @@ Authorization: Bearer &lt;YOUR_TOKEN_HERE&gt;</code></pre>
                 <html>
                   <head></head>
                   <body><pre><code class="hljs language-json"><span class="hljs-punctuation">{</span>
-  <span class="hljs-attr">"count"</span><span class="hljs-punctuation">:</span> <span class="hljs-number">123</span><span class="hljs-punctuation">,</span>
+  <span class="hljs-attr">"count"</span><span class="hljs-punctuation">:</span> <span class="hljs-number">987</span><span class="hljs-punctuation">,</span>
   <span class="hljs-attr">"from"</span><span class="hljs-punctuation">:</span> <span class="hljs-number">123.45</span><span class="hljs-punctuation">,</span>
   <span class="hljs-attr">"title"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"xyz789"</span><span class="hljs-punctuation">,</span>
-  <span class="hljs-attr">"to"</span><span class="hljs-punctuation">:</span> <span class="hljs-number">987.65</span>
+  <span class="hljs-attr">"to"</span><span class="hljs-punctuation">:</span> <span class="hljs-number">123.45</span>
 <span class="hljs-punctuation">}</span>
 </code></pre>
                   </body>
                 </html>
               </div>
             </div>
+            <a href="#top">back to top</a>
           </div>
         </section>
         <section id="definition-RecommendationUnit" class="definition definition-object" data-traverse-target="definition-RecommendationUnit">
@@ -8098,7 +8163,7 @@ Authorization: Bearer &lt;YOUR_TOKEN_HERE&gt;</code></pre>
   <span class="hljs-attr">"storefrontLabel"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"abc123"</span><span class="hljs-punctuation">,</span>
   <span class="hljs-attr">"totalProducts"</span><span class="hljs-punctuation">:</span> <span class="hljs-number">123</span><span class="hljs-punctuation">,</span>
   <span class="hljs-attr">"typeId"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"xyz789"</span><span class="hljs-punctuation">,</span>
-  <span class="hljs-attr">"unitId"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"xyz789"</span><span class="hljs-punctuation">,</span>
+  <span class="hljs-attr">"unitId"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"abc123"</span><span class="hljs-punctuation">,</span>
   <span class="hljs-attr">"unitName"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"xyz789"</span>
 <span class="hljs-punctuation">}</span>
 </code></pre>
@@ -8106,6 +8171,7 @@ Authorization: Bearer &lt;YOUR_TOKEN_HERE&gt;</code></pre>
                 </html>
               </div>
             </div>
+            <a href="#top">back to top</a>
           </div>
         </section>
         <section id="definition-Recommendations" class="definition definition-object" data-traverse-target="definition-Recommendations">
@@ -8148,12 +8214,13 @@ Authorization: Bearer &lt;YOUR_TOKEN_HERE&gt;</code></pre>
                 <h5>Example</h5>
                 <html>
                   <head></head>
-                  <body><pre><code class="hljs language-json"><span class="hljs-punctuation">{</span><span class="hljs-attr">"results"</span><span class="hljs-punctuation">:</span> <span class="hljs-punctuation">[</span><span class="hljs-string">RecommendationUnit</span><span class="hljs-punctuation">]</span><span class="hljs-punctuation">,</span> <span class="hljs-attr">"totalResults"</span><span class="hljs-punctuation">:</span> <span class="hljs-number">987</span><span class="hljs-punctuation">}</span>
+                  <body><pre><code class="hljs language-json"><span class="hljs-punctuation">{</span><span class="hljs-attr">"results"</span><span class="hljs-punctuation">:</span> <span class="hljs-punctuation">[</span><span class="hljs-string">RecommendationUnit</span><span class="hljs-punctuation">]</span><span class="hljs-punctuation">,</span> <span class="hljs-attr">"totalResults"</span><span class="hljs-punctuation">:</span> <span class="hljs-number">123</span><span class="hljs-punctuation">}</span>
 </code></pre>
                   </body>
                 </html>
               </div>
             </div>
+            <a href="#top">back to top</a>
           </div>
         </section>
         <section id="definition-ScalarBucket" class="definition definition-object" data-traverse-target="definition-ScalarBucket">
@@ -8211,6 +8278,7 @@ Authorization: Bearer &lt;YOUR_TOKEN_HERE&gt;</code></pre>
                 </html>
               </div>
             </div>
+            <a href="#top">back to top</a>
           </div>
         </section>
         <section id="definition-SearchClauseInput" class="definition definition-input-object" data-traverse-target="definition-SearchClauseInput">
@@ -8280,18 +8348,19 @@ Authorization: Bearer &lt;YOUR_TOKEN_HERE&gt;</code></pre>
                 <html>
                   <head></head>
                   <body><pre><code class="hljs language-json"><span class="hljs-punctuation">{</span>
-  <span class="hljs-attr">"attribute"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"abc123"</span><span class="hljs-punctuation">,</span>
-  <span class="hljs-attr">"eq"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"xyz789"</span><span class="hljs-punctuation">,</span>
-  <span class="hljs-attr">"in"</span><span class="hljs-punctuation">:</span> <span class="hljs-punctuation">[</span><span class="hljs-string">"xyz789"</span><span class="hljs-punctuation">]</span><span class="hljs-punctuation">,</span>
+  <span class="hljs-attr">"attribute"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"xyz789"</span><span class="hljs-punctuation">,</span>
+  <span class="hljs-attr">"eq"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"abc123"</span><span class="hljs-punctuation">,</span>
+  <span class="hljs-attr">"in"</span><span class="hljs-punctuation">:</span> <span class="hljs-punctuation">[</span><span class="hljs-string">"abc123"</span><span class="hljs-punctuation">]</span><span class="hljs-punctuation">,</span>
   <span class="hljs-attr">"range"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">SearchRangeInput</span><span class="hljs-punctuation">,</span>
   <span class="hljs-attr">"startsWith"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"abc123"</span><span class="hljs-punctuation">,</span>
-  <span class="hljs-attr">"contains"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"xyz789"</span>
+  <span class="hljs-attr">"contains"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"abc123"</span>
 <span class="hljs-punctuation">}</span>
 </code></pre>
                   </body>
                 </html>
               </div>
             </div>
+            <a href="#top">back to top</a>
           </div>
         </section>
         <section id="definition-SearchRangeInput" class="definition definition-input-object" data-traverse-target="definition-SearchRangeInput">
@@ -8336,12 +8405,13 @@ Authorization: Bearer &lt;YOUR_TOKEN_HERE&gt;</code></pre>
                 <h5>Example</h5>
                 <html>
                   <head></head>
-                  <body><pre><code class="hljs language-json"><span class="hljs-punctuation">{</span><span class="hljs-attr">"from"</span><span class="hljs-punctuation">:</span> <span class="hljs-number">987.65</span><span class="hljs-punctuation">,</span> <span class="hljs-attr">"to"</span><span class="hljs-punctuation">:</span> <span class="hljs-number">987.65</span><span class="hljs-punctuation">}</span>
+                  <body><pre><code class="hljs language-json"><span class="hljs-punctuation">{</span><span class="hljs-attr">"from"</span><span class="hljs-punctuation">:</span> <span class="hljs-number">123.45</span><span class="hljs-punctuation">,</span> <span class="hljs-attr">"to"</span><span class="hljs-punctuation">:</span> <span class="hljs-number">123.45</span><span class="hljs-punctuation">}</span>
 </code></pre>
                   </body>
                 </html>
               </div>
             </div>
+            <a href="#top">back to top</a>
           </div>
         </section>
         <section id="definition-SearchResultPageInfo" class="definition definition-object" data-traverse-target="definition-SearchResultPageInfo">
@@ -8389,12 +8459,13 @@ Authorization: Bearer &lt;YOUR_TOKEN_HERE&gt;</code></pre>
                 <h5>Example</h5>
                 <html>
                   <head></head>
-                  <body><pre><code class="hljs language-json"><span class="hljs-punctuation">{</span><span class="hljs-attr">"current_page"</span><span class="hljs-punctuation">:</span> <span class="hljs-number">987</span><span class="hljs-punctuation">,</span> <span class="hljs-attr">"page_size"</span><span class="hljs-punctuation">:</span> <span class="hljs-number">987</span><span class="hljs-punctuation">,</span> <span class="hljs-attr">"total_pages"</span><span class="hljs-punctuation">:</span> <span class="hljs-number">987</span><span class="hljs-punctuation">}</span>
+                  <body><pre><code class="hljs language-json"><span class="hljs-punctuation">{</span><span class="hljs-attr">"current_page"</span><span class="hljs-punctuation">:</span> <span class="hljs-number">123</span><span class="hljs-punctuation">,</span> <span class="hljs-attr">"page_size"</span><span class="hljs-punctuation">:</span> <span class="hljs-number">987</span><span class="hljs-punctuation">,</span> <span class="hljs-attr">"total_pages"</span><span class="hljs-punctuation">:</span> <span class="hljs-number">987</span><span class="hljs-punctuation">}</span>
 </code></pre>
                   </body>
                 </html>
               </div>
             </div>
+            <a href="#top">back to top</a>
           </div>
         </section>
         <section id="definition-SimpleProduct" class="definition definition-object" data-traverse-target="definition-SimpleProduct">
@@ -8550,28 +8621,28 @@ Authorization: Bearer &lt;YOUR_TOKEN_HERE&gt;</code></pre>
                 <html>
                   <head></head>
                   <body><pre><code class="hljs language-json"><span class="hljs-punctuation">{</span>
-  <span class="hljs-attr">"add_to_cart_allowed"</span><span class="hljs-punctuation">:</span> <span class="hljs-literal"><span class="hljs-keyword">true</span></span><span class="hljs-punctuation">,</span>
-  <span class="hljs-attr">"attribute_set_id"</span><span class="hljs-punctuation">:</span> <span class="hljs-number">987</span><span class="hljs-punctuation">,</span>
+  <span class="hljs-attr">"add_to_cart_allowed"</span><span class="hljs-punctuation">:</span> <span class="hljs-literal"><span class="hljs-keyword">false</span></span><span class="hljs-punctuation">,</span>
+  <span class="hljs-attr">"attribute_set_id"</span><span class="hljs-punctuation">:</span> <span class="hljs-number">123</span><span class="hljs-punctuation">,</span>
   <span class="hljs-attr">"canonical_url"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"xyz789"</span><span class="hljs-punctuation">,</span>
-  <span class="hljs-attr">"created_at"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"abc123"</span><span class="hljs-punctuation">,</span>
+  <span class="hljs-attr">"created_at"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"xyz789"</span><span class="hljs-punctuation">,</span>
   <span class="hljs-attr">"custom_attributes"</span><span class="hljs-punctuation">:</span> <span class="hljs-punctuation">[</span><span class="hljs-string">CustomAttribute</span><span class="hljs-punctuation">]</span><span class="hljs-punctuation">,</span>
   <span class="hljs-attr">"description"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">ComplexTextValue</span><span class="hljs-punctuation">,</span>
-  <span class="hljs-attr">"gift_message_available"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"abc123"</span><span class="hljs-punctuation">,</span>
-  <span class="hljs-attr">"id"</span><span class="hljs-punctuation">:</span> <span class="hljs-number">123</span><span class="hljs-punctuation">,</span>
+  <span class="hljs-attr">"gift_message_available"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"xyz789"</span><span class="hljs-punctuation">,</span>
+  <span class="hljs-attr">"id"</span><span class="hljs-punctuation">:</span> <span class="hljs-number">987</span><span class="hljs-punctuation">,</span>
   <span class="hljs-attr">"image"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">ProductImage</span><span class="hljs-punctuation">,</span>
   <span class="hljs-attr">"media_gallery"</span><span class="hljs-punctuation">:</span> <span class="hljs-punctuation">[</span><span class="hljs-string">MediaGalleryInterface</span><span class="hljs-punctuation">]</span><span class="hljs-punctuation">,</span>
   <span class="hljs-attr">"meta_description"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"abc123"</span><span class="hljs-punctuation">,</span>
-  <span class="hljs-attr">"meta_keyword"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"xyz789"</span><span class="hljs-punctuation">,</span>
-  <span class="hljs-attr">"meta_title"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"abc123"</span><span class="hljs-punctuation">,</span>
-  <span class="hljs-attr">"name"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"xyz789"</span><span class="hljs-punctuation">,</span>
-  <span class="hljs-attr">"new_from_date"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"xyz789"</span><span class="hljs-punctuation">,</span>
-  <span class="hljs-attr">"new_to_date"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"xyz789"</span><span class="hljs-punctuation">,</span>
+  <span class="hljs-attr">"meta_keyword"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"abc123"</span><span class="hljs-punctuation">,</span>
+  <span class="hljs-attr">"meta_title"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"xyz789"</span><span class="hljs-punctuation">,</span>
+  <span class="hljs-attr">"name"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"abc123"</span><span class="hljs-punctuation">,</span>
+  <span class="hljs-attr">"new_from_date"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"abc123"</span><span class="hljs-punctuation">,</span>
+  <span class="hljs-attr">"new_to_date"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"abc123"</span><span class="hljs-punctuation">,</span>
   <span class="hljs-attr">"price_range"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">PriceRange</span><span class="hljs-punctuation">,</span>
   <span class="hljs-attr">"short_description"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">ComplexTextValue</span><span class="hljs-punctuation">,</span>
   <span class="hljs-attr">"sku"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"xyz789"</span><span class="hljs-punctuation">,</span>
   <span class="hljs-attr">"small_image"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">ProductImage</span><span class="hljs-punctuation">,</span>
   <span class="hljs-attr">"thumbnail"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">ProductImage</span><span class="hljs-punctuation">,</span>
-  <span class="hljs-attr">"uid"</span><span class="hljs-punctuation">:</span> <span class="hljs-number">4</span><span class="hljs-punctuation">,</span>
+  <span class="hljs-attr">"uid"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"4"</span><span class="hljs-punctuation">,</span>
   <span class="hljs-attr">"updated_at"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"xyz789"</span><span class="hljs-punctuation">,</span>
   <span class="hljs-attr">"weight"</span><span class="hljs-punctuation">:</span> <span class="hljs-number">987.65</span>
 <span class="hljs-punctuation">}</span>
@@ -8580,6 +8651,7 @@ Authorization: Bearer &lt;YOUR_TOKEN_HERE&gt;</code></pre>
                 </html>
               </div>
             </div>
+            <a href="#top">back to top</a>
           </div>
         </section>
         <section id="definition-SimpleProductView" class="definition definition-object" data-traverse-target="definition-SimpleProductView">
@@ -8785,38 +8857,39 @@ Authorization: Bearer &lt;YOUR_TOKEN_HERE&gt;</code></pre>
                 <html>
                   <head></head>
                   <body><pre><code class="hljs language-json"><span class="hljs-punctuation">{</span>
-  <span class="hljs-attr">"addToCartAllowed"</span><span class="hljs-punctuation">:</span> <span class="hljs-literal"><span class="hljs-keyword">false</span></span><span class="hljs-punctuation">,</span>
-  <span class="hljs-attr">"inStock"</span><span class="hljs-punctuation">:</span> <span class="hljs-literal"><span class="hljs-keyword">true</span></span><span class="hljs-punctuation">,</span>
+  <span class="hljs-attr">"addToCartAllowed"</span><span class="hljs-punctuation">:</span> <span class="hljs-literal"><span class="hljs-keyword">true</span></span><span class="hljs-punctuation">,</span>
+  <span class="hljs-attr">"inStock"</span><span class="hljs-punctuation">:</span> <span class="hljs-literal"><span class="hljs-keyword">false</span></span><span class="hljs-punctuation">,</span>
   <span class="hljs-attr">"lowStock"</span><span class="hljs-punctuation">:</span> <span class="hljs-literal"><span class="hljs-keyword">true</span></span><span class="hljs-punctuation">,</span>
   <span class="hljs-attr">"attributes"</span><span class="hljs-punctuation">:</span> <span class="hljs-punctuation">[</span><span class="hljs-string">ProductViewAttribute</span><span class="hljs-punctuation">]</span><span class="hljs-punctuation">,</span>
-  <span class="hljs-attr">"description"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"abc123"</span><span class="hljs-punctuation">,</span>
-  <span class="hljs-attr">"id"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"4"</span><span class="hljs-punctuation">,</span>
+  <span class="hljs-attr">"description"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"xyz789"</span><span class="hljs-punctuation">,</span>
+  <span class="hljs-attr">"id"</span><span class="hljs-punctuation">:</span> <span class="hljs-number">4</span><span class="hljs-punctuation">,</span>
   <span class="hljs-attr">"images"</span><span class="hljs-punctuation">:</span> <span class="hljs-punctuation">[</span><span class="hljs-string">ProductViewImage</span><span class="hljs-punctuation">]</span><span class="hljs-punctuation">,</span>
   <span class="hljs-attr">"videos"</span><span class="hljs-punctuation">:</span> <span class="hljs-punctuation">[</span><span class="hljs-string">ProductViewVideo</span><span class="hljs-punctuation">]</span><span class="hljs-punctuation">,</span>
   <span class="hljs-attr">"inputOptions"</span><span class="hljs-punctuation">:</span> <span class="hljs-punctuation">[</span><span class="hljs-string">ProductViewInputOption</span><span class="hljs-punctuation">]</span><span class="hljs-punctuation">,</span>
   <span class="hljs-attr">"lastModifiedAt"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"2007-12-03T10:15:30Z"</span><span class="hljs-punctuation">,</span>
-  <span class="hljs-attr">"metaDescription"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"xyz789"</span><span class="hljs-punctuation">,</span>
+  <span class="hljs-attr">"metaDescription"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"abc123"</span><span class="hljs-punctuation">,</span>
   <span class="hljs-attr">"metaKeyword"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"xyz789"</span><span class="hljs-punctuation">,</span>
-  <span class="hljs-attr">"metaTitle"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"abc123"</span><span class="hljs-punctuation">,</span>
+  <span class="hljs-attr">"metaTitle"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"xyz789"</span><span class="hljs-punctuation">,</span>
   <span class="hljs-attr">"name"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"abc123"</span><span class="hljs-punctuation">,</span>
   <span class="hljs-attr">"price"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">ProductViewPrice</span><span class="hljs-punctuation">,</span>
-  <span class="hljs-attr">"shortDescription"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"abc123"</span><span class="hljs-punctuation">,</span>
+  <span class="hljs-attr">"shortDescription"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"xyz789"</span><span class="hljs-punctuation">,</span>
   <span class="hljs-attr">"sku"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"abc123"</span><span class="hljs-punctuation">,</span>
   <span class="hljs-attr">"externalId"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"abc123"</span><span class="hljs-punctuation">,</span>
-  <span class="hljs-attr">"url"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"xyz789"</span><span class="hljs-punctuation">,</span>
-  <span class="hljs-attr">"urlKey"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"xyz789"</span><span class="hljs-punctuation">,</span>
+  <span class="hljs-attr">"url"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"abc123"</span><span class="hljs-punctuation">,</span>
+  <span class="hljs-attr">"urlKey"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"abc123"</span><span class="hljs-punctuation">,</span>
   <span class="hljs-attr">"links"</span><span class="hljs-punctuation">:</span> <span class="hljs-punctuation">[</span><span class="hljs-string">ProductViewLink</span><span class="hljs-punctuation">]</span><span class="hljs-punctuation">,</span>
-  <span class="hljs-attr">"categories"</span><span class="hljs-punctuation">:</span> <span class="hljs-punctuation">[</span><span class="hljs-string">"xyz789"</span><span class="hljs-punctuation">]</span><span class="hljs-punctuation">,</span>
+  <span class="hljs-attr">"categories"</span><span class="hljs-punctuation">:</span> <span class="hljs-punctuation">[</span><span class="hljs-string">"abc123"</span><span class="hljs-punctuation">]</span><span class="hljs-punctuation">,</span>
   <span class="hljs-attr">"queryType"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"xyz789"</span><span class="hljs-punctuation">,</span>
-  <span class="hljs-attr">"rank"</span><span class="hljs-punctuation">:</span> <span class="hljs-number">123</span><span class="hljs-punctuation">,</span>
-  <span class="hljs-attr">"score"</span><span class="hljs-punctuation">:</span> <span class="hljs-number">987.65</span><span class="hljs-punctuation">,</span>
-  <span class="hljs-attr">"visibility"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"abc123"</span>
+  <span class="hljs-attr">"rank"</span><span class="hljs-punctuation">:</span> <span class="hljs-number">987</span><span class="hljs-punctuation">,</span>
+  <span class="hljs-attr">"score"</span><span class="hljs-punctuation">:</span> <span class="hljs-number">123.45</span><span class="hljs-punctuation">,</span>
+  <span class="hljs-attr">"visibility"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"xyz789"</span>
 <span class="hljs-punctuation">}</span>
 </code></pre>
                   </body>
                 </html>
               </div>
             </div>
+            <a href="#top">back to top</a>
           </div>
         </section>
         <section id="definition-SortEnum" class="definition definition-enum" data-traverse-target="definition-SortEnum">
@@ -8869,6 +8942,7 @@ Authorization: Bearer &lt;YOUR_TOKEN_HERE&gt;</code></pre>
                 </html>
               </div>
             </div>
+            <a href="#top">back to top</a>
           </div>
         </section>
         <section id="definition-SortableAttribute" class="definition definition-object" data-traverse-target="definition-SortableAttribute">
@@ -8925,13 +8999,14 @@ Authorization: Bearer &lt;YOUR_TOKEN_HERE&gt;</code></pre>
   <span class="hljs-attr">"attribute"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"xyz789"</span><span class="hljs-punctuation">,</span>
   <span class="hljs-attr">"frontendInput"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"xyz789"</span><span class="hljs-punctuation">,</span>
   <span class="hljs-attr">"label"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"abc123"</span><span class="hljs-punctuation">,</span>
-  <span class="hljs-attr">"numeric"</span><span class="hljs-punctuation">:</span> <span class="hljs-literal"><span class="hljs-keyword">false</span></span>
+  <span class="hljs-attr">"numeric"</span><span class="hljs-punctuation">:</span> <span class="hljs-literal"><span class="hljs-keyword">true</span></span>
 <span class="hljs-punctuation">}</span>
 </code></pre>
                   </body>
                 </html>
               </div>
             </div>
+            <a href="#top">back to top</a>
           </div>
         </section>
         <section id="definition-StatsBucket" class="definition definition-object" data-traverse-target="definition-StatsBucket">
@@ -8980,15 +9055,16 @@ Authorization: Bearer &lt;YOUR_TOKEN_HERE&gt;</code></pre>
                 <html>
                   <head></head>
                   <body><pre><code class="hljs language-json"><span class="hljs-punctuation">{</span>
-  <span class="hljs-attr">"max"</span><span class="hljs-punctuation">:</span> <span class="hljs-number">987.65</span><span class="hljs-punctuation">,</span>
-  <span class="hljs-attr">"min"</span><span class="hljs-punctuation">:</span> <span class="hljs-number">123.45</span><span class="hljs-punctuation">,</span>
-  <span class="hljs-attr">"title"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"abc123"</span>
+  <span class="hljs-attr">"max"</span><span class="hljs-punctuation">:</span> <span class="hljs-number">123.45</span><span class="hljs-punctuation">,</span>
+  <span class="hljs-attr">"min"</span><span class="hljs-punctuation">:</span> <span class="hljs-number">987.65</span><span class="hljs-punctuation">,</span>
+  <span class="hljs-attr">"title"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"xyz789"</span>
 <span class="hljs-punctuation">}</span>
 </code></pre>
                   </body>
                 </html>
               </div>
             </div>
+            <a href="#top">back to top</a>
           </div>
         </section>
         <section id="definition-String" class="definition definition-scalar" data-traverse-target="definition-String">
@@ -9014,6 +9090,7 @@ Authorization: Bearer &lt;YOUR_TOKEN_HERE&gt;</code></pre>
                 </html>
               </div>
             </div>
+            <a href="#top">back to top</a>
           </div>
         </section>
         <section id="definition-SwatchType" class="definition definition-enum" data-traverse-target="definition-SwatchType">
@@ -9076,6 +9153,7 @@ Authorization: Bearer &lt;YOUR_TOKEN_HERE&gt;</code></pre>
                 </html>
               </div>
             </div>
+            <a href="#top">back to top</a>
           </div>
         </section>
         <section id="definition-ViewHistory" class="definition definition-input-object" data-traverse-target="definition-ViewHistory">
@@ -9131,6 +9209,7 @@ Authorization: Bearer &lt;YOUR_TOKEN_HERE&gt;</code></pre>
                 </html>
               </div>
             </div>
+            <a href="#top">back to top</a>
           </div>
         </section>
         <section id="definition-ViewHistoryInput" class="definition definition-input-object" data-traverse-target="definition-ViewHistoryInput">
@@ -9179,13 +9258,14 @@ Authorization: Bearer &lt;YOUR_TOKEN_HERE&gt;</code></pre>
                   <head></head>
                   <body><pre><code class="hljs language-json"><span class="hljs-punctuation">{</span>
   <span class="hljs-attr">"dateTime"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"2007-12-03T10:15:30Z"</span><span class="hljs-punctuation">,</span>
-  <span class="hljs-attr">"sku"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"xyz789"</span>
+  <span class="hljs-attr">"sku"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"abc123"</span>
 <span class="hljs-punctuation">}</span>
 </code></pre>
                   </body>
                 </html>
               </div>
             </div>
+            <a href="#top">back to top</a>
           </div>
         </section>
         <section id="definition-VirtualProduct" class="definition definition-object" data-traverse-target="definition-VirtualProduct">
@@ -9335,9 +9415,9 @@ Authorization: Bearer &lt;YOUR_TOKEN_HERE&gt;</code></pre>
                 <html>
                   <head></head>
                   <body><pre><code class="hljs language-json"><span class="hljs-punctuation">{</span>
-  <span class="hljs-attr">"add_to_cart_allowed"</span><span class="hljs-punctuation">:</span> <span class="hljs-literal"><span class="hljs-keyword">true</span></span><span class="hljs-punctuation">,</span>
-  <span class="hljs-attr">"attribute_set_id"</span><span class="hljs-punctuation">:</span> <span class="hljs-number">987</span><span class="hljs-punctuation">,</span>
-  <span class="hljs-attr">"canonical_url"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"abc123"</span><span class="hljs-punctuation">,</span>
+  <span class="hljs-attr">"add_to_cart_allowed"</span><span class="hljs-punctuation">:</span> <span class="hljs-literal"><span class="hljs-keyword">false</span></span><span class="hljs-punctuation">,</span>
+  <span class="hljs-attr">"attribute_set_id"</span><span class="hljs-punctuation">:</span> <span class="hljs-number">123</span><span class="hljs-punctuation">,</span>
+  <span class="hljs-attr">"canonical_url"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"xyz789"</span><span class="hljs-punctuation">,</span>
   <span class="hljs-attr">"created_at"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"abc123"</span><span class="hljs-punctuation">,</span>
   <span class="hljs-attr">"custom_attributes"</span><span class="hljs-punctuation">:</span> <span class="hljs-punctuation">[</span><span class="hljs-string">CustomAttribute</span><span class="hljs-punctuation">]</span><span class="hljs-punctuation">,</span>
   <span class="hljs-attr">"description"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">ComplexTextValue</span><span class="hljs-punctuation">,</span>
@@ -9347,9 +9427,9 @@ Authorization: Bearer &lt;YOUR_TOKEN_HERE&gt;</code></pre>
   <span class="hljs-attr">"media_gallery"</span><span class="hljs-punctuation">:</span> <span class="hljs-punctuation">[</span><span class="hljs-string">MediaGalleryInterface</span><span class="hljs-punctuation">]</span><span class="hljs-punctuation">,</span>
   <span class="hljs-attr">"meta_description"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"abc123"</span><span class="hljs-punctuation">,</span>
   <span class="hljs-attr">"meta_keyword"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"xyz789"</span><span class="hljs-punctuation">,</span>
-  <span class="hljs-attr">"meta_title"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"abc123"</span><span class="hljs-punctuation">,</span>
-  <span class="hljs-attr">"name"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"abc123"</span><span class="hljs-punctuation">,</span>
-  <span class="hljs-attr">"new_from_date"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"abc123"</span><span class="hljs-punctuation">,</span>
+  <span class="hljs-attr">"meta_title"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"xyz789"</span><span class="hljs-punctuation">,</span>
+  <span class="hljs-attr">"name"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"xyz789"</span><span class="hljs-punctuation">,</span>
+  <span class="hljs-attr">"new_from_date"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"xyz789"</span><span class="hljs-punctuation">,</span>
   <span class="hljs-attr">"new_to_date"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"xyz789"</span><span class="hljs-punctuation">,</span>
   <span class="hljs-attr">"price_range"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">PriceRange</span><span class="hljs-punctuation">,</span>
   <span class="hljs-attr">"short_description"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">ComplexTextValue</span><span class="hljs-punctuation">,</span>
@@ -9364,6 +9444,7 @@ Authorization: Bearer &lt;YOUR_TOKEN_HERE&gt;</code></pre>
                 </html>
               </div>
             </div>
+            <a href="#top">back to top</a>
           </div>
         </section>
         <div class="doc-row no-margin">


### PR DESCRIPTION
## Purpose of this pull request

This pull request (PR) adds 'back to top' hyperlink to GraphQL API reference at the end of each doc row for instant navigation to the top of the page which can be annoying for long pages via scrolling.

Related pull request: https://github.com/AdobeDocs/commerce-webapi/pull/394

## Affected pages

<!-- REQUIRED List the affected pages on developer.adobe.com (URLs). Not necessary for large numbers of files. -->

- https://developer-stage.adobe.com/commerce/services/composable-catalog/data-ingestion/api-reference/
- https://developer-stage.adobe.com/commerce/services/composable-catalog/storefront-services/api-reference/

## Preview

- https://commerce-docs.github.io/commerce-services/composable-catalog/admin/api-reference/
- https://commerce-docs.github.io/commerce-services/composable-catalog/storefront-services/api-reference/