### PR TITLE
DCAT-2283: Changing feed CCDM API to move tenantId to beginning of path

### DIFF
--- a/src/openapi/data-ingestion-schema-v1.yaml
+++ b/src/openapi/data-ingestion-schema-v1.yaml
@@ -33,7 +33,7 @@ tags:
       Define prices for product SKUs. The scope identifies the price books and price tiers where the price is used.
       is used.
 paths:
-  /v1/catalog/products/metadata/{DATA_SPACE_ID}:
+  /{DATA_SPACE_ID}/v1/catalog/products/metadata:
     post:
       tags:
         - Metadata
@@ -217,7 +217,7 @@ paths:
             application/json;charset=UTF-8:
               schema:
                 $ref: '#/components/schemas/403Response'
-  /v1/catalog/products/metadata/{DATA_SPACE_ID}/delete:
+  /{DATA_SPACE_ID}/v1/catalog/products/metadata/delete:
     post:
       tags:
         - Metadata
@@ -297,7 +297,7 @@ paths:
               schema:
                 $ref: '#/components/schemas/403Response'
 
-  /v1/catalog/products/{DATA_SPACE_ID}:
+  /{DATA_SPACE_ID}/v1/catalog/products:
     post:
       tags:
         - Products
@@ -710,7 +710,7 @@ paths:
                       "links": []
                     }
                   ]
-  /v1/catalog/products/{DATA_SPACE_ID}/delete:
+  /{DATA_SPACE_ID}/v1/catalog/products/delete:
     post:
       tags:
         - Products
@@ -753,7 +753,7 @@ paths:
                     }
                   ]
 
-  /v1/catalog/price-books/{DATA_SPACE_ID}:
+  /{DATA_SPACE_ID}/v1/catalog/price-books:
     post:
       tags:
         - Price Books
@@ -922,7 +922,7 @@ paths:
             application/json;charset=UTF-8:
               schema:
                 $ref: '#/components/schemas/403Response'
-  /v1/catalog/price-books/{DATA_SPACE_ID}/delete:
+  /{DATA_SPACE_ID}/v1/catalog/price-books/delete:
     post:
       tags:
         - Price Books
@@ -1001,7 +1001,7 @@ paths:
               schema:
                 $ref: '#/components/schemas/403Response'
 
-  /v1/catalog/products/prices/{DATA_SPACE_ID}:
+  /{DATA_SPACE_ID}/v1/catalog/products/prices:
     post:
       tags:
         - Prices
@@ -1188,7 +1188,7 @@ paths:
             application/json;charset=UTF-8:
               schema:
                 $ref: '#/components/schemas/403Response'
-  /v1/catalog/products/prices/{DATA_SPACE_ID}/delete:
+  /{DATA_SPACE_ID}/v1/catalog/products/prices/delete:
     post:
       tags:
         - Prices

--- a/src/pages/composable-catalog/ccdm-use-case.md
+++ b/src/pages/composable-catalog/ccdm-use-case.md
@@ -60,7 +60,7 @@ Create the metadata to define the search characteristics and filters for display
 
 ```shell
 curl --request POST \
-  --url https://commerce.adobe.io/api/v1/catalog/products/metadata/<DATA_SPACE_ID> \
+  --url https://commerce.adobe.io/<DATA_SPACE_ID>/api/v1/catalog/products/metadata \
   --header 'Content-Type: application/json' \
   --header 'x-api-key: <API_KEY>' \
   --header 'x-gw-signature: <JWT_TOKEN>' \
@@ -126,7 +126,7 @@ Add the simple product *Aurora Prism Battery* with two attribute codes, `Brand` 
 
 ```shell
 curl --request POST \
-  --url https://commerce.adobe.io/api/v1/catalog/products/<DATA_SPACE_ID> \
+  --url https://commerce.adobe.io/<DATA_SPACE_ID>/api/v1/catalog/products \
   --header 'Content-Type: application/json' \
   --header 'x-api-key: <API_KEY>' \
   --header 'x-gw-signature: <JWT_TOKEN>' \
@@ -206,7 +206,7 @@ Add the product *Bolt Atlas Battery* with two attribute codes, `Brand` set to *B
 
 ```shell
 curl --request POST \
-  --url https://commerce.adobe.io/api/v1/catalog/products/<DATA_SPACE_ID> \
+  --url https://commerce.adobe.io/<DATA_SPACE_ID>/api/v1/catalog/products \
   --header 'Content-Type: application/json' \
   --header 'x-api-key: <API_KEY>' \
   --header 'x-gw-signature: <JWT_TOKEN>' \

--- a/src/pages/composable-catalog/data-ingestion/using-the-api.md
+++ b/src/pages/composable-catalog/data-ingestion/using-the-api.md
@@ -90,7 +90,7 @@ curl --request POST \
 
 | Placeholder name | Description                                                                                                     |
 |------------------|-----------------------------------------------------------------------------------------------------------------|
-| API_ENDPOINT     | Endpoint for specific Data Ingestion API, for example: `/api/v1/catalog/products/prices/`  |
+| API_ENDPOINT     | Endpoint for specific Data Ingestion API, for example: `/{DATA_SPACE_ID}/api/v1/catalog/products/prices`  |
 | DATA_SPACE_ID    | [SaaS Data Space ID](#path-parameters).                                               |
 | API_KEY          | [Public API_KEY for Adobe Commerce account](#authentication).                              |
 | JWT_TOKEN        | [JWT token generated from Commerce API key](#generate-jwt-token)                                     |


### PR DESCRIPTION
## Purpose of this pull request

This pull request (PR) is to change the feed CCDM API to move tenantId to beginning of path

## Affected pages

- https://developer-stage.adobe.com/commerce/services/composable-catalog/data-ingestion/api-reference/
