### PR TITLE
DCAT-2283: Changing feed CCDM API to move tenantId to beginning of path

### DIFF
--- a/src/openapi/data-ingestion-schema-v1.yaml
+++ b/src/openapi/data-ingestion-schema-v1.yaml
@@ -13,7 +13,7 @@ info:
 
   version: 1.0.0
 servers:
-  - url: https://commerce.adobe.io/api/
+  - url: https://commerce.adobe.io/<DATA_SPACE_ID>/api/
     description: Production endpoint
 
 tags:
@@ -33,7 +33,7 @@ tags:
       Define prices for product SKUs. The scope identifies the price books and price tiers where the price is used.
       is used.
 paths:
-  /{DATA_SPACE_ID}/v1/catalog/products/metadata:
+  /v1/catalog/products/metadata:
     post:
       tags:
         - Metadata
@@ -217,7 +217,7 @@ paths:
             application/json;charset=UTF-8:
               schema:
                 $ref: '#/components/schemas/403Response'
-  /{DATA_SPACE_ID}/v1/catalog/products/metadata/delete:
+  /v1/catalog/products/metadata/delete:
     post:
       tags:
         - Metadata
@@ -297,7 +297,7 @@ paths:
               schema:
                 $ref: '#/components/schemas/403Response'
 
-  /{DATA_SPACE_ID}/v1/catalog/products:
+  /v1/catalog/products:
     post:
       tags:
         - Products
@@ -710,7 +710,7 @@ paths:
                       "links": []
                     }
                   ]
-  /{DATA_SPACE_ID}/v1/catalog/products/delete:
+  /v1/catalog/products/delete:
     post:
       tags:
         - Products
@@ -753,7 +753,7 @@ paths:
                     }
                   ]
 
-  /{DATA_SPACE_ID}/v1/catalog/price-books:
+  /v1/catalog/price-books:
     post:
       tags:
         - Price Books
@@ -922,7 +922,7 @@ paths:
             application/json;charset=UTF-8:
               schema:
                 $ref: '#/components/schemas/403Response'
-  /{DATA_SPACE_ID}/v1/catalog/price-books/delete:
+  /v1/catalog/price-books/delete:
     post:
       tags:
         - Price Books
@@ -1001,7 +1001,7 @@ paths:
               schema:
                 $ref: '#/components/schemas/403Response'
 
-  /{DATA_SPACE_ID}/v1/catalog/products/prices:
+  /v1/catalog/products/prices:
     post:
       tags:
         - Prices
@@ -1188,7 +1188,7 @@ paths:
             application/json;charset=UTF-8:
               schema:
                 $ref: '#/components/schemas/403Response'
-  /{DATA_SPACE_ID}/v1/catalog/products/prices/delete:
+  /v1/catalog/products/prices/delete:
     post:
       tags:
         - Prices

--- a/src/openapi/data-ingestion-schema-v1.yaml
+++ b/src/openapi/data-ingestion-schema-v1.yaml
@@ -14,7 +14,7 @@ info:
   version: 1.0.0
 servers:
   - url: https://commerce.adobe.io/<DATA_SPACE_ID>/api/
-    description: Production endpoint
+    description: Production endpoint. The DATA_SPACE_ID value is the  ID for the data space where commerce catalog data is stored. See [SaaS configuration](https://experienceleague.adobe.com/en/docs/commerce-merchant-services/user-guides/integration-services/saas#saasenv) in Adobe Experience League.
 
 tags:
   - name: Metadata

--- a/src/openapi/data-ingestion-schema-v1.yaml
+++ b/src/openapi/data-ingestion-schema-v1.yaml
@@ -44,16 +44,6 @@ paths:
         To update existing product attribute metadata, use the update operation.
       operationId: ProductMetadataPut
       parameters:
-        - name: DATA_SPACE_ID
-          in: path
-          description: |
-            The data space ID for the data space where commerce catalog data is stored.
-            See [SaaS configuration](https://experienceleague.adobe.com/en/docs/commerce-merchant-services/user-guides/integration-services/saas#saasenv)
-            in *Adobe Experience League*.
-          required: true
-          style: simple
-          schema:
-            type: string
         - name: Content-Type
           in: header
           required: true
@@ -135,17 +125,6 @@ paths:
         When the update is processed, the merge strategy is used to apply changes to `scalar` and `object` type fields. The replace strategy is used to apply changes for fields in an `array`.
       operationId: ProductMetadataPatch
       parameters:
-        - name: DATA_SPACE_ID
-          in: path
-          description: |
-            The data space ID for the data space where commerce catalog data is stored.
-
-            See [SaaS configuration](https://experienceleague.adobe.com/en/docs/commerce-merchant-services/user-guides/integration-services/saas#saasenv)
-            in *Adobe Experience League*.
-          required: true
-          style: simple
-          schema:
-            type: string
         - name: Content-Type
           in: header
           required: true
@@ -225,13 +204,6 @@ paths:
       description: Remove product attribute metadata resources from the catalog data.
       operationId: ProductMetadataDelete
       parameters:
-        - name: DATA_SPACE_ID
-          in: path
-          description: Data Space ID
-          required: true
-          style: simple
-          schema:
-            type: string
         - name: Content-Type
           in: header
           required: true
@@ -324,7 +296,6 @@ paths:
         - Use [Update Product API](#operation/ProductsPatch) to set the ["variantReferenceId"](#operation/ProductsPost!path=attributes/variantReferenceId&t=request) to `null` and unassign the product variant from the configurable product by removing the ["links"](#operation/ProductsPost!path=links&t=request) association.
       operationId: ProductsPost
       parameters:
-        - $ref: '#/components/parameters/DATA_SPACE_ID'
         - $ref: '#/components/parameters/ContentType'
         - $ref: '#/components/parameters/xApiKey'
         - $ref: '#/components/parameters/xGwSignature'
@@ -613,7 +584,6 @@ paths:
         The replace strategy is used to apply changes for fields in an `array`.
       operationId: ProductsPatch
       parameters:
-        - $ref: '#/components/parameters/DATA_SPACE_ID'
         - $ref: '#/components/parameters/ContentType'
         - $ref: '#/components/parameters/xApiKey'
         - $ref: '#/components/parameters/xGwSignature'
@@ -719,7 +689,6 @@ paths:
         Delete products with specified "sku" and "scope".
       operationId: ProductsDelete
       parameters:
-        - $ref: '#/components/parameters/DATA_SPACE_ID'
         - $ref: '#/components/parameters/ContentType'
         - $ref: '#/components/parameters/xApiKey'
         - $ref: '#/components/parameters/xGwSignature'
@@ -764,13 +733,6 @@ paths:
          Use the update operation to modify values for existing price books.
       operationId: PriceBooksPut
       parameters:
-        - name: DATA_SPACE_ID
-          in: path
-          description: Data Space ID
-          required: true
-          style: simple
-          schema:
-            type: string
         - name: Content-Type
           in: header
           required: true
@@ -849,13 +811,6 @@ paths:
         To update the currency for the default price book, use the price book id `main`.
       operationId: PriceBooksPatch
       parameters:
-        - name: DATA_SPACE_ID
-          in: path
-          description: Data Space ID
-          required: true
-          style: simple
-          schema:
-            type: string
         - name: Content-Type
           in: header
           required: true
@@ -932,13 +887,6 @@ paths:
          Note that you cannot delete the default price book with id `main`.
       operationId: PriceBooksDelete
       parameters:
-        - name: DATA_SPACE_ID
-          in: path
-          description: Data Space ID
-          required: true
-          style: simple
-          schema:
-            type: string
         - name: Content-Type
           in: header
           required: true
@@ -1018,13 +966,6 @@ paths:
 
       operationId: PricesPut
       parameters:
-        - name: DATA_SPACE_ID
-          in: path
-          description: Data Space ID
-          required: true
-          style: simple
-          schema:
-            type: string
         - name: Content-Type
           in: header
           required: true
@@ -1113,13 +1054,6 @@ paths:
         When the update is processed, the merge strategy is used to apply changes to `scalar` and `object` type fields. The replace strategy is used to apply changes for fields in an `array`.
       operationId: PricesPatch
       parameters:
-        - name: DATA_SPACE_ID
-          in: path
-          description: Data Space ID
-          required: true
-          style: simple
-          schema:
-            type: string
         - name: Content-Type
           in: header
           required: true
@@ -1197,13 +1131,6 @@ paths:
         Delete existing product prices
       operationId: PricesDelete
       parameters:
-        - name: DATA_SPACE_ID
-          in: path
-          description: Data Space ID
-          required: true
-          style: simple
-          schema:
-            type: string
         - name: Content-Type
           in: header
           required: true

--- a/src/openapi/data-ingestion-schema-v1.yaml
+++ b/src/openapi/data-ingestion-schema-v1.yaml
@@ -33,7 +33,7 @@ tags:
       Define prices for product SKUs. The scope identifies the price books and price tiers where the price is used.
       is used.
 paths:
-  /v1/catalog/products/metadata/{DATA_SPACE_ID}:
+  /{DATA_SPACE_ID}/v1/catalog/products/metadata:
     post:
       tags:
         - Metadata
@@ -217,7 +217,7 @@ paths:
             application/json;charset=UTF-8:
               schema:
                 $ref: '#/components/schemas/403Response'
-  /v1/catalog/products/metadata/{DATA_SPACE_ID}/delete:
+  /{DATA_SPACE_ID}/v1/catalog/products/metadata/delete:
     post:
       tags:
         - Metadata
@@ -297,7 +297,7 @@ paths:
               schema:
                 $ref: '#/components/schemas/403Response'
 
-  /v1/catalog/products/{DATA_SPACE_ID}:
+  /{DATA_SPACE_ID}/v1/catalog/products:
     post:
       tags:
         - Products
@@ -710,7 +710,7 @@ paths:
                       "links": []
                     }
                   ]
-  /v1/catalog/products/{DATA_SPACE_ID}/delete:
+  /{DATA_SPACE_ID}/v1/catalog/products/delete:
     post:
       tags:
         - Products
@@ -753,7 +753,7 @@ paths:
                     }
                   ]
 
-  /v1/catalog/price-books/{DATA_SPACE_ID}:
+  /{DATA_SPACE_ID}/v1/catalog/price-books:
     post:
       tags:
         - Price Books
@@ -922,7 +922,7 @@ paths:
             application/json;charset=UTF-8:
               schema:
                 $ref: '#/components/schemas/403Response'
-  /v1/catalog/price-books/{DATA_SPACE_ID}/delete:
+  /{DATA_SPACE_ID}/v1/catalog/price-books/delete:
     post:
       tags:
         - Price Books
@@ -1001,7 +1001,7 @@ paths:
               schema:
                 $ref: '#/components/schemas/403Response'
 
-  /v1/catalog/products/prices/{DATA_SPACE_ID}:
+  /{DATA_SPACE_ID}/v1/catalog/products/prices:
     post:
       tags:
         - Prices
@@ -1188,7 +1188,7 @@ paths:
             application/json;charset=UTF-8:
               schema:
                 $ref: '#/components/schemas/403Response'
-  /v1/catalog/products/prices/{DATA_SPACE_ID}/delete:
+  /{DATA_SPACE_ID}/v1/catalog/products/prices/delete:
     post:
       tags:
         - Prices

--- a/src/pages/composable-catalog/ccdm-use-case.md
+++ b/src/pages/composable-catalog/ccdm-use-case.md
@@ -60,7 +60,7 @@ Create the metadata to define the search characteristics and filters for display
 
 ```shell
 curl --request POST \
-  --url https://commerce.adobe.io/api/v1/catalog/products/metadata/<DATA_SPACE_ID> \
+  --url https://commerce.adobe.io/<DATA_SPACE_ID>/api/v1/catalog/products/metadata \
   --header 'Content-Type: application/json' \
   --header 'x-api-key: <API_KEY>' \
   --header 'x-gw-signature: <JWT_TOKEN>' \
@@ -126,7 +126,7 @@ Add the simple product *Aurora Prism Battery* with two attribute codes, `Brand` 
 
 ```shell
 curl --request POST \
-  --url https://commerce.adobe.io/api/v1/catalog/products/<DATA_SPACE_ID> \
+  --url https://commerce.adobe.io/<DATA_SPACE_ID>/api/v1/catalog/products \
   --header 'Content-Type: application/json' \
   --header 'x-api-key: <API_KEY>' \
   --header 'x-gw-signature: <JWT_TOKEN>' \
@@ -206,7 +206,7 @@ Add the product *Bolt Atlas Battery* with two attribute codes, `Brand` set to *B
 
 ```shell
 curl --request POST \
-  --url https://commerce.adobe.io/api/v1/catalog/products/<DATA_SPACE_ID> \
+  --url https://commerce.adobe.io/<DATA_SPACE_ID>/api/v1/catalog/products \
   --header 'Content-Type: application/json' \
   --header 'x-api-key: <API_KEY>' \
   --header 'x-gw-signature: <JWT_TOKEN>' \

--- a/src/pages/composable-catalog/data-ingestion/using-the-api.md
+++ b/src/pages/composable-catalog/data-ingestion/using-the-api.md
@@ -15,7 +15,7 @@ Use the data ingestion API to create and manage product data for your ecommerce 
 
 ## Endpoints
 
-Send all Data Ingestion requests to this endpoint: `https://commerce.adobe.io/api`
+Send all Data Ingestion requests to this endpoint: `https://commerce.adobe.io/<DATA_SPACE_ID>/api`
 
 <InlineAlert variant="info" slots="text"/>
 
@@ -81,19 +81,19 @@ Use the following template to submit requests using [cURL](https://curl.se/).
 
 ```shell
 curl --request POST \
-  --url https://commerce.adobe.io/api/v1/<API_ENDPOINT>/<DATA_SPACE_ID> \
+  --url https://commerce.adobe.io/<DATA_SPACE_ID>/api/<API_ENDPOINT> \
   --header 'Content-Type:  application/json' \
   --header 'x-api-key: <API_KEY>' \
   --header 'x-gw-signature: <JWT_TOKEN>' \
   --data '<API_PAYLOAD>'
 ```
 
-| Placeholder name | Description                                                                                                     |
-|------------------|-----------------------------------------------------------------------------------------------------------------|
-| API_ENDPOINT     | Endpoint for specific Data Ingestion API, for example: `/{DATA_SPACE_ID}/v1/catalog/products/prices`  |
+| Placeholder name | Description                                                                                                    |
+|------------------|----------------------------------------------------------------------------------------------------------------|
+| API_ENDPOINT     | Endpoint for specific Data Ingestion API, for example: `/v1/catalog/products/prices`  |
 | DATA_SPACE_ID    | [SaaS Data Space ID](#path-parameters).                                               |
-| API_KEY          | [Public API_KEY for Adobe Commerce account](#authentication).                              |
-| JWT_TOKEN        | [JWT token generated from Commerce API key](#generate-jwt-token)                                     |
-| API_PAYLOAD      | API payload see examples in the [tutorial](../ccdm-use-case.md)                                                                              |
+| API_KEY          | [Public API_KEY for Adobe Commerce account](#authentication).                             |
+| JWT_TOKEN        | [JWT token generated from Commerce API key](#generate-jwt-token)                                    |
+| API_PAYLOAD      | API payload see examples in the [tutorial](../ccdm-use-case.md)                                                                             |
 
 For sample requests, see the [tutorial](../ccdm-use-case.md).

--- a/src/pages/composable-catalog/data-ingestion/using-the-api.md
+++ b/src/pages/composable-catalog/data-ingestion/using-the-api.md
@@ -90,7 +90,7 @@ curl --request POST \
 
 | Placeholder name | Description                                                                                                     |
 |------------------|-----------------------------------------------------------------------------------------------------------------|
-| API_ENDPOINT     | Endpoint for specific Data Ingestion API, for example: `/api/v1/catalog/products/prices/`  |
+| API_ENDPOINT     | Endpoint for specific Data Ingestion API, for example: `/{DATA_SPACE_ID}/v1/catalog/products/prices`  |
 | DATA_SPACE_ID    | [SaaS Data Space ID](#path-parameters).                                               |
 | API_KEY          | [Public API_KEY for Adobe Commerce account](#authentication).                              |
 | JWT_TOKEN        | [JWT token generated from Commerce API key](#generate-jwt-token)                                     |


### PR DESCRIPTION
## Purpose of this pull request

This pull request (PR) is to change the feed CCDM API to move tenantId to beginning of path

## Affected pages

- https://developer-stage.adobe.com/commerce/services/composable-catalog/data-ingestion/api-reference/
