### PR TITLE
CCSAAS-861: Badges (shadowing Editions component) - simplified

### DIFF
--- a/gatsby-browser.js
+++ b/gatsby-browser.js
@@ -23,4 +23,4 @@ const components = {
 // Wrap the root element with the MDXProvider
 export const wrapRootElement = ({ element }) => {
   return <MDXProvider components={components}>{element}</MDXProvider>;
-};
+}; 

--- a/src/@adobe/gatsby-theme-aio/components/Edition/index.js
+++ b/src/@adobe/gatsby-theme-aio/components/Edition/index.js
@@ -1,0 +1,71 @@
+/*
+ * Copyright 2021 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+
+import React from 'react';
+import PropTypes from 'prop-types';
+import '@spectrum-css/badge';
+import '@spectrum-css/link';
+import '@spectrum-css/tooltip';
+
+let editionText = '';
+let editionColor = '';
+let editionTooltip = '';
+const EDITIONS_LINK = 'https://experienceleague.adobe.com/en/docs/commerce/user-guides/product-solutions';
+
+const Edition = ({ ...props }) => {
+  switch (props.name) {
+    case 'paas':
+      editionText = 'PaaS only';
+      editionColor = 'spectrum-Badge--informative';
+      editionTooltip = 'Applies to Adobe Commerce on Cloud projects (Adobe-managed PaaS infrastructure).';
+      break;
+    case 'saas':
+      editionText = 'SaaS only';
+      editionColor = 'spectrum-Badge--positive';
+      editionTooltip = 'Applies to Adobe Commerce as a Cloud Service and Adobe Commerce Optimizer projects (Adobe-managed SaaS infrastructure).';
+      break;
+    default:
+      editionText = 'Create an Edition tag';
+      editionColor = 'spectrum-Badge--yellow';
+      editionTooltip = '';
+  }
+
+  return (
+    <a 
+      href={EDITIONS_LINK}
+      className="spectrum-Link"
+      target="_blank"
+      rel="noreferrer"
+      style={{ 
+        textDecoration: 'none',
+        display: 'inline-block',
+        marginTop: '1rem',
+        marginRight: '0.5rem',
+        position: 'relative'
+      }}
+      title={editionTooltip}
+    >
+      <span 
+        className={`spectrum-Badge spectrum-Badge--sizeS ${editionColor}`} 
+        style={{ paddingBottom: '4px', cursor: 'pointer' }}
+      >
+        {editionText}
+      </span>
+    </a>
+  );
+};
+
+Edition.propTypes = {
+  name: PropTypes.string
+};
+
+export { Edition };

--- a/src/_includes/accs/accs-early-access.md
+++ b/src/_includes/accs/accs-early-access.md
@@ -1,0 +1,3 @@
+<InlineAlert variant="info" slots="text"/>
+
+This documentation describes a product in early-access development and does not reflect all functionality intended for general availability.

--- a/src/pages/cloud/guides/custom-attributes.md
+++ b/src/pages/cloud/guides/custom-attributes.md
@@ -10,6 +10,10 @@ noIndex: true
 
 # Custom attributes in Adobe Commerce as a Cloud Service
 
+import ACCSEarlyAccess from '/src/_includes/accs/accs-early-access.md'
+
+<ACCSEarlyAccess />
+
 Custom attributes can extend the core data model in Adobe Commerce. Since you cannot modify the Cloud Service data model directly, custom attributes allow you to add additional attributes to entities without requiring code or database schema changes.
 
 Consider a situation where you want to modify specify a `duns_number` or `industry_type` information for a company. Custom attributes make this possible.

--- a/src/pages/cloud/guides/index.md
+++ b/src/pages/cloud/guides/index.md
@@ -6,9 +6,14 @@ keywords:
   - REST
   - Services
 noIndex: true
+edition: saas
 ---
 
 # Adobe Commerce as a Cloud Service API Guide
+
+import ACCSEarlyAccess from '/src/_includes/accs/accs-early-access.md'
+
+<ACCSEarlyAccess />
 
 Adobe Commerce as a Cloud Service offers flexibility, scalability, and efficiency by enabling businesses to deliver and rapidly scale digital operations and accelerate innovation. Adobe's cloud-native infrastructure automatically adjusts resources to meet peak demands for traffic, orders, and catalog management.
 

--- a/src/pages/cloud/guides/rest/authentication/index.md
+++ b/src/pages/cloud/guides/rest/authentication/index.md
@@ -6,6 +6,10 @@ noIndex: true
 
 # REST authentication
 
+import ACCSEarlyAccess from '/src/_includes/accs/accs-early-access.md'
+
+<ACCSEarlyAccess />
+
 Adobe Commerce as a Cloud Service REST API authentication is handled through Adobe's Identity Management Service (IMS), providing secure access to Commerce functionality through standardized OAuth 2.0 protocols. This authentication system supports both interactive user-based workflows and automated server-to-server integrations, ensuring secure and appropriate access for different use cases.
 
 ## [User authentication with SUSI UI](./user.md)

--- a/src/pages/cloud/guides/rest/authentication/server-to-server.md
+++ b/src/pages/cloud/guides/rest/authentication/server-to-server.md
@@ -9,6 +9,10 @@ noIndex: true
 
 # Server-to-server authentication
 
+import ACCSEarlyAccess from '/src/_includes/accs/accs-early-access.md'
+
+<ACCSEarlyAccess />
+
 Server-to-Server Authentication provides a secure way for automated systems to interact with the Adobe Commerce as a Cloud Service REST API without user intervention. This authentication method is essential for background processes, scheduled tasks, and system integrations that need to operate independently of user sessions. Unlike user authentication, server-to-server authentication uses technical account credentials to obtain access tokens directly, making it ideal for headless commerce implementations and automated workflows.
 
 ## Prerequisites

--- a/src/pages/cloud/guides/rest/authentication/user.md
+++ b/src/pages/cloud/guides/rest/authentication/user.md
@@ -9,6 +9,10 @@ noIndex: true
 
 # User authentication
 
+import ACCSEarlyAccess from '/src/_includes/accs/accs-early-access.md'
+
+<ACCSEarlyAccess />
+
 User Authentication with Adobe's Secure User Sign-In (SUSI) interface enables Commerce administrators to authenticate through Adobe's Identity Management Service (IMS). This authentication flow is specifically designed for scenarios where API operations need to be executed with user-specific permissions. When using this method, all API calls are performed within the context of the authenticated admin user's permissions, as defined in the Adobe Admin Console.
 
 Adobe provides three types of OAuth credentials for User Authentication with a different application architectures:

--- a/src/pages/cloud/guides/rest/index.md
+++ b/src/pages/cloud/guides/rest/index.md
@@ -5,9 +5,14 @@ keywords:
   - REST
   - Services
 noIndex: true
+edition: saas
 ---
 
 # Rest overview
+
+import ACCSEarlyAccess from '/src/_includes/accs/accs-early-access.md'
+
+<ACCSEarlyAccess />
 
 The Adobe Commerce as a Cloud Service REST API serves as a critical tool for extending and integrating commerce functionalities, but the endpoints available differ significantly from the REST APIs for Adobe Commerce on Cloud and on-premises deployments.
 

--- a/src/pages/cloud/guides/rest/integration/index.md
+++ b/src/pages/cloud/guides/rest/integration/index.md
@@ -9,6 +9,10 @@ noIndex: true
 
 # Server-to-server integration
 
+import ACCSEarlyAccess from '/src/_includes/accs/accs-early-access.md'
+
+<ACCSEarlyAccess />
+
 This guide provides practical steps for implementing Server-to-Server integration with Adobe Commerce Cloud Services REST APIs using OAuth server-to-server authentication. This type of integration enables automated system-to-system communication without user intervention, which is ideal for to following use cases:
 
 - Background processes and automated tasks

--- a/src/pages/cloud/guides/rest/webhooks.md
+++ b/src/pages/cloud/guides/rest/webhooks.md
@@ -9,6 +9,10 @@ noIndex: true
 
 # Webhooks in Adobe Commerce as a Cloud Service
 
+import ACCSEarlyAccess from '/src/_includes/accs/accs-early-access.md'
+
+<ACCSEarlyAccess />
+
 Webhooks allow developers to trigger calls to external systems synchronously when an Adobe Commerce event occurs.
 
 Adobe Commerce as a Cloud Service provides REST endpoints that allow you to subscribe and unsubscribe webhooks.

--- a/src/pages/graphql/catalog-service/categories.md
+++ b/src/pages/graphql/catalog-service/categories.md
@@ -1,6 +1,6 @@
 ---
 title: categories query | GraphQL Developer Guide
-edition: ee
+edition: paas
 description: Describes how to construct and use the Catalog Service categories query.
 keywords:
   - GraphQL

--- a/src/pages/graphql/catalog-service/index.md
+++ b/src/pages/graphql/catalog-service/index.md
@@ -1,6 +1,6 @@
 ---
 title: Catalog Service for Adobe Commerce
-edition: ee
+edition: paas
 description: Learn how Catalog Service implements GraphQL.
 keywords:
   - GraphQL

--- a/src/pages/graphql/catalog-service/product-variants.md
+++ b/src/pages/graphql/catalog-service/product-variants.md
@@ -1,6 +1,6 @@
 ---
 title: variants query
-edition: ee
+edition: paas
 description: "Describes how to construct and use the Catalog Service `variants` query to retrieve details about the variants available for a product."
 keywords:
   - GraphQL

--- a/src/pages/graphql/catalog-service/products.md
+++ b/src/pages/graphql/catalog-service/products.md
@@ -1,6 +1,6 @@
 ---
 title: products query
-edition: ee
+edition: paas
 description: Describes how to construct and use the Catalog Service products query.
 keywords:
   - GraphQL

--- a/src/pages/graphql/catalog-service/refine-product.md
+++ b/src/pages/graphql/catalog-service/refine-product.md
@@ -1,6 +1,6 @@
 ---
 title: refineProduct query | GraphQL Developer Guide
-edition: ee
+edition: paas
 description: Describes how to construct and use the Catalog Service refineProduct query.
 keywords:
   - GraphQL

--- a/src/pages/graphql/index.md
+++ b/src/pages/graphql/index.md
@@ -1,6 +1,6 @@
 ---
 title: Storefront Services GraphQL Overview
-edition: ee
+edition: paas
 description: Learn about the GraphQL capabilities of Live Search, Catalog Service, and Product Recommendations
 ---
 

--- a/src/pages/graphql/live-search/attribute-metadata.md
+++ b/src/pages/graphql/live-search/attribute-metadata.md
@@ -1,6 +1,6 @@
 ---
 title: attributeMetadata query
-edition: ee
+edition: paas
 description: Describes how to construct and use the Live Search attributeMetadata query.
 keywords:
   - GraphQL

--- a/src/pages/graphql/live-search/index.md
+++ b/src/pages/graphql/live-search/index.md
@@ -1,6 +1,6 @@
 ---
 title: Live Search
-edition: ee
+edition: paas
 description: Learn how Live Search implements GraphQL.
 keywords:
   - GraphQL

--- a/src/pages/graphql/live-search/product-search.md
+++ b/src/pages/graphql/live-search/product-search.md
@@ -1,6 +1,6 @@
 ---
 title: productSearch query
-edition: ee
+edition: paas
 description: Describes how to construct and use the productSearch query in both Live Search and Catalog Service.
 keywords:
   - GraphQL
@@ -132,7 +132,13 @@ The `filter` attribute is the part of the query that uses product attributes as 
 
 #### Filtering by attributes
 
-An attribute filter consists of a product `attribute`, a comparison operator, and the value that is being searched for. Together, they help narrow down the search results, based on shopper input. For example, if you want to set up a filter for jackets based on size, you could set the product attribute to `size`. To filter on medium-sized jackets only, set the `eq` field to `M`. To filter on both medium- and large-sized jackets, set the `in` field to `["M", "L"]`. If an attribute is numeric, you can filter on it as a price range, such as between $50 and $100. To filter on a price range, set the `attribute` to `price`, and assign the `range` field with `from` and `to` values as `50` and `100`, respectively.
+An attribute filter consists of a product `attribute`, a comparison operator, and the value that is being searched for. Together, they help narrow the search results, based on shopper input. For example:
+
+- To set up a filter for jackets based on size, set the product attribute to `size`.
+- To filter on medium-sized jackets only, set the `eq` field to `M`.
+- To filter on both medium- and large-sized jackets, set the `in` field to `["M", "L"]`.
+
+If an attribute is numeric, you can filter on it as a price range, such as between $50 and $100. For example, to filter on a price range, set the `attribute` to `price`, and assign the `range` field with `from` and `to` values as `50` and `100`, respectively. Products that are equal to the upper range are not included in the results. This aligns with how price ranges are defined for facets.
 
 You can define multiple filters in the same call. The following example filters on the price and size:
 

--- a/src/pages/graphql/recommendations/index.md
+++ b/src/pages/graphql/recommendations/index.md
@@ -1,7 +1,7 @@
 ---
 title: Product Recommendations
 description: Learn how Product Recommendations implements GraphQL.
-edition: ee
+edition: paas
 keywords:
   - GraphQL
   - Services

--- a/src/pages/graphql/recommendations/recommendations.md
+++ b/src/pages/graphql/recommendations/recommendations.md
@@ -1,6 +1,6 @@
 ---
 title: recommendations query | GraphQL Developer Guide
-edition: ee
+edition: paas
 description: Describes how to construct and use the Product Recommendations recommendations query.
 keywords:
   - GraphQL

--- a/src/pages/live-search/index.md
+++ b/src/pages/live-search/index.md
@@ -1,7 +1,7 @@
 ---
 title: Live Search Events | Commerce Services
 description: Lists events in the Adobe Commerce Event SDK that are applicable to Live Search. 
-edition: ee
+edition: paas
 keywords:
   - Search
   - Services

--- a/src/pages/product-recommendations/index.md
+++ b/src/pages/product-recommendations/index.md
@@ -1,7 +1,7 @@
 ---
 title: Product Recommendations SDK
 description: Learn how to use the Product Recommendations SDK with Adobe Commerce to fetch recommendations programmatically in the browser.
-edition: ee
+edition: paas
 keywords:
   - Recommendations
   - Services

--- a/src/pages/reference/cloud/graphql.md
+++ b/src/pages/reference/cloud/graphql.md
@@ -1,6 +1,6 @@
 ---
 title: Cloud Service GraphQL API Reference
-edition: ee
+edition: paas
 description: Learn about the Adobe Commerce as a Cloud Service GraphQL APIs.
 keywords:
   - GraphQL

--- a/src/pages/reference/cloud/rest.md
+++ b/src/pages/reference/cloud/rest.md
@@ -1,7 +1,7 @@
 ---
 title: Cloud Service REST API Reference
 description: Learn about Adobe Commerce as a Cloud Service REST API.
-edition: ee
+edition: paas
 keywords:
   - REST
   - Services
@@ -9,6 +9,10 @@ noIndex: true
 ---
 
 # REST API reference for Adobe Commerce as a Cloud Service
+
+import ACCSEarlyAccess from '/src/_includes/accs/accs-early-access.md'
+
+<ACCSEarlyAccess />
 
 The Adobe Commerce as a Cloud Service REST API contains the following endpoints. More detailed endpoint information will be available in the future. For more immediate information, you can cross-reference the endpoints listed here with the existing [REST API reference](https://developer.adobe.com/commerce/webapi/rest/quick-reference/) for Adobe Commerce on Cloud and on-premises deployments.
 

--- a/src/pages/shared-services/storefront-events/collector/index.md
+++ b/src/pages/shared-services/storefront-events/collector/index.md
@@ -1,7 +1,7 @@
 ---
 title: Adobe Commerce Event Collector | Commerce Services
 description: Learn how to listen for (and handle) Adobe Commerce storefront events emitted by the events SDK.
-edition: ee
+edition: paas
 keywords:
   - Events
   - Services

--- a/src/pages/shared-services/storefront-events/sdk/context.md
+++ b/src/pages/shared-services/storefront-events/sdk/context.md
@@ -1,7 +1,7 @@
 ---
 title: Context for storefront events | Commerce Services 
 description: Learn how to programmatically get and set context for Adobe Commerce storefront events.
-edition: ee
+edition: paas
 keywords:
   - Events
   - Services

--- a/src/pages/shared-services/storefront-events/sdk/index.md
+++ b/src/pages/shared-services/storefront-events/sdk/index.md
@@ -1,7 +1,7 @@
 ---
 title: Adobe Commerce Events SDK | Commerce Services
 description: Learn how to programmatically publish and subscribe to Adobe Commerce storefront events.
-edition: ee
+edition: paas
 keywords:
   - Events
   - Services

--- a/src/pages/shared-services/storefront-events/sdk/publish.md
+++ b/src/pages/shared-services/storefront-events/sdk/publish.md
@@ -1,7 +1,7 @@
 ---
 title: Publish storefront events | Commerce Services
 description: Learn how to programmatically publish Adobe Commerce storefront events.
-edition: ee
+edition: paas
 keywords:
   - Events
   - Services

--- a/src/pages/shared-services/storefront-events/sdk/subscribe.md
+++ b/src/pages/shared-services/storefront-events/sdk/subscribe.md
@@ -1,7 +1,7 @@
 ---
 title: Subscribe to storefront events | Commerce Services
 description: Learn how to programmatically subscribe to Adobe Commerce storefront events.
-edition: ee
+edition: paas
 keywords:
   - Events
   - Services

--- a/src/pages/shared-services/storefront-events/sdk/unsubscribe.md
+++ b/src/pages/shared-services/storefront-events/sdk/unsubscribe.md
@@ -1,7 +1,7 @@
 ---
 title: Unsubscribe from storefront events | Commerce Services
 description: Learn how to programmatically unsubscribe from Adobe Commerce storefront events.
-edition: ee
+edition: paas
 keywords:
   - Events
   - Services


### PR DESCRIPTION
## Purpose of this pull request

This pull request (PR) demonstrates how we can align the [Editions](https://github.com/adobe/aio-theme/blob/main/packages/gatsby-theme-aio/src/components/Edition/index.js) component with "badges" in ExL.

This is necessary to align with the strategy that we're using on ExL to differentiate between PaaS and SaaS solutions with the launch of the new **Adobe Commerce as a Cloud Service** and **Adobe Commerce Optimizer** products (GA in June). 

See CCSAAS-861 for details.

Related to #226, but is a simplified implementation since we don't need multiple page-level badges right now. Label text, link, and tooltip are hardcoded, which is not ideal but is sufficient for our purposes. We'll need to re-implement on EDS later anyway, so best not to over invest in a complex implementation for Gatsby.

## TODOs

- [x] Test badge style when listed under headings (style looks good for h2 and h3s)
- [x] Squash commits