### PR TITLE
DCAT-2205: Adding documentation for price-book delete that all assigned prices will also get deleted

### DIFF
--- a/src/openapi/data-ingestion-schema-v1.yaml
+++ b/src/openapi/data-ingestion-schema-v1.yaml
@@ -1175,7 +1175,7 @@ paths:
       summary: Delete price books.
       description: |
         Delete existing price books.
-        When deleting a price book, all associated prices assigned to the `priceBookId` will also get deleted.
+        When you delete a price book, all associated prices assigned to the `priceBookId` are also deleted. If a product does not have any other price books assigned, the prices default to the pricing schedule defined in the default, `main` price book.
         Note that you cannot delete the default price book with id `main`.
       operationId: deletePriceBooks
       parameters:

--- a/src/openapi/data-ingestion-schema-v1.yaml
+++ b/src/openapi/data-ingestion-schema-v1.yaml
@@ -1175,6 +1175,7 @@ paths:
       summary: Delete price books.
       description: |
         Delete existing price books.
+        When deleting a price book, all associated prices assigned to the `priceBookId` will also get deleted.
         Note that you cannot delete the default price book with id `main`.
       operationId: deletePriceBooks
       parameters:


### PR DESCRIPTION
## Purpose of this pull request

* Added documentation for price-book delete that all assigned prices will also get deleted

## Affected pages

* https://developer-stage.adobe.com/commerce/services/composable-catalog/data-ingestion/api-reference/#operation/createProducts
* https://jira.corp.adobe.com/browse/DCAT-2205