### PR TITLE
Modify edition label for PaaS

### DIFF
--- a/src/@adobe/gatsby-theme-aio/components/Edition/index.js
+++ b/src/@adobe/gatsby-theme-aio/components/Edition/index.js
@@ -26,7 +26,7 @@ const Edition = ({ ...props }) => {
     case 'paas':
       editionText = 'PaaS';
       editionColor = 'spectrum-Badge--informative';
-      editionTooltip = 'Applies to Adobe Commerce on Cloud (Adobe-managed PaaS infrastructure) and on-premises projects.';
+      editionTooltip = 'Applies to Adobe Commerce on Cloud (Adobe-managed PaaS infrastructure) and on-premises projects only.';
       break;
     case 'saas':
       editionText = 'SaaS';

--- a/src/@adobe/gatsby-theme-aio/components/Edition/index.js
+++ b/src/@adobe/gatsby-theme-aio/components/Edition/index.js
@@ -24,12 +24,12 @@ const EDITIONS_LINK = 'https://experienceleague.adobe.com/en/docs/commerce/user-
 const Edition = ({ ...props }) => {
   switch (props.name) {
     case 'paas':
-      editionText = 'PaaS only';
+      editionText = 'PaaS';
       editionColor = 'spectrum-Badge--informative';
-      editionTooltip = 'Applies to Adobe Commerce on Cloud projects (Adobe-managed PaaS infrastructure).';
+      editionTooltip = 'Applies to Adobe Commerce on Cloud (Adobe-managed PaaS infrastructure) and on-premises projects.';
       break;
     case 'saas':
-      editionText = 'SaaS only';
+      editionText = 'SaaS';
       editionColor = 'spectrum-Badge--positive';
       editionTooltip = 'Applies to Adobe Commerce as a Cloud Service and Adobe Commerce Optimizer projects (Adobe-managed SaaS infrastructure).';
       break;

--- a/src/@adobe/gatsby-theme-aio/components/Edition/index.js
+++ b/src/@adobe/gatsby-theme-aio/components/Edition/index.js
@@ -24,12 +24,12 @@ const EDITIONS_LINK = 'https://experienceleague.adobe.com/en/docs/commerce/user-
 const Edition = ({ ...props }) => {
   switch (props.name) {
     case 'paas':
-      editionText = 'PaaS';
+      editionText = 'PaaS only';
       editionColor = 'spectrum-Badge--informative';
       editionTooltip = 'Applies to Adobe Commerce on Cloud (Adobe-managed PaaS infrastructure) and on-premises projects only.';
       break;
     case 'saas':
-      editionText = 'SaaS';
+      editionText = 'SaaS only';
       editionColor = 'spectrum-Badge--positive';
       editionTooltip = 'Applies to Adobe Commerce as a Cloud Service and Adobe Commerce Optimizer projects (Adobe-managed SaaS infrastructure).';
       break;

--- a/src/pages/graphql/catalog-service/categories.md
+++ b/src/pages/graphql/catalog-service/categories.md
@@ -1,6 +1,5 @@
 ---
 title: categories query | GraphQL Developer Guide
-edition: paas
 description: Describes how to construct and use the Catalog Service categories query.
 keywords:
   - GraphQL

--- a/src/pages/graphql/catalog-service/index.md
+++ b/src/pages/graphql/catalog-service/index.md
@@ -1,6 +1,5 @@
 ---
 title: Catalog Service for Adobe Commerce
-edition: paas
 description: Learn how Catalog Service implements GraphQL.
 keywords:
   - GraphQL

--- a/src/pages/graphql/catalog-service/product-variants.md
+++ b/src/pages/graphql/catalog-service/product-variants.md
@@ -1,6 +1,5 @@
 ---
 title: variants query
-edition: paas
 description: "Describes how to construct and use the Catalog Service `variants` query to retrieve details about the variants available for a product."
 keywords:
   - GraphQL

--- a/src/pages/graphql/catalog-service/products.md
+++ b/src/pages/graphql/catalog-service/products.md
@@ -1,6 +1,5 @@
 ---
 title: products query
-edition: paas
 description: Describes how to construct and use the Catalog Service products query.
 keywords:
   - GraphQL

--- a/src/pages/graphql/catalog-service/refine-product.md
+++ b/src/pages/graphql/catalog-service/refine-product.md
@@ -1,6 +1,5 @@
 ---
 title: refineProduct query | GraphQL Developer Guide
-edition: paas
 description: Describes how to construct and use the Catalog Service refineProduct query.
 keywords:
   - GraphQL

--- a/src/pages/graphql/index.md
+++ b/src/pages/graphql/index.md
@@ -1,6 +1,5 @@
 ---
 title: Storefront Services GraphQL Overview
-edition: paas
 description: Learn about the GraphQL capabilities of Live Search, Catalog Service, and Product Recommendations
 ---
 

--- a/src/pages/graphql/live-search/attribute-metadata.md
+++ b/src/pages/graphql/live-search/attribute-metadata.md
@@ -1,6 +1,5 @@
 ---
 title: attributeMetadata query
-edition: paas
 description: Describes how to construct and use the Live Search attributeMetadata query.
 keywords:
   - GraphQL

--- a/src/pages/graphql/live-search/index.md
+++ b/src/pages/graphql/live-search/index.md
@@ -1,6 +1,5 @@
 ---
 title: Live Search
-edition: paas
 description: Learn how Live Search implements GraphQL.
 keywords:
   - GraphQL

--- a/src/pages/graphql/live-search/product-search.md
+++ b/src/pages/graphql/live-search/product-search.md
@@ -1,6 +1,5 @@
 ---
 title: productSearch query
-edition: paas
 description: Describes how to construct and use the productSearch query in both Live Search and Catalog Service.
 keywords:
   - GraphQL

--- a/src/pages/graphql/recommendations/index.md
+++ b/src/pages/graphql/recommendations/index.md
@@ -1,7 +1,6 @@
 ---
 title: Product Recommendations
 description: Learn how Product Recommendations implements GraphQL.
-edition: paas
 keywords:
   - GraphQL
   - Services

--- a/src/pages/graphql/recommendations/recommendations.md
+++ b/src/pages/graphql/recommendations/recommendations.md
@@ -1,6 +1,5 @@
 ---
 title: recommendations query | GraphQL Developer Guide
-edition: paas
 description: Describes how to construct and use the Product Recommendations recommendations query.
 keywords:
   - GraphQL

--- a/src/pages/live-search/index.md
+++ b/src/pages/live-search/index.md
@@ -1,7 +1,6 @@
 ---
 title: Live Search Events | Commerce Services
 description: Lists events in the Adobe Commerce Event SDK that are applicable to Live Search. 
-edition: paas
 keywords:
   - Search
   - Services

--- a/src/pages/product-recommendations/index.md
+++ b/src/pages/product-recommendations/index.md
@@ -1,7 +1,6 @@
 ---
 title: Product Recommendations SDK
 description: Learn how to use the Product Recommendations SDK with Adobe Commerce to fetch recommendations programmatically in the browser.
-edition: paas
 keywords:
   - Recommendations
   - Services

--- a/src/pages/shared-services/storefront-events/collector/index.md
+++ b/src/pages/shared-services/storefront-events/collector/index.md
@@ -1,7 +1,6 @@
 ---
 title: Adobe Commerce Event Collector | Commerce Services
 description: Learn how to listen for (and handle) Adobe Commerce storefront events emitted by the events SDK.
-edition: paas
 keywords:
   - Events
   - Services

--- a/src/pages/shared-services/storefront-events/sdk/context.md
+++ b/src/pages/shared-services/storefront-events/sdk/context.md
@@ -1,7 +1,6 @@
 ---
 title: Context for storefront events | Commerce Services 
 description: Learn how to programmatically get and set context for Adobe Commerce storefront events.
-edition: paas
 keywords:
   - Events
   - Services

--- a/src/pages/shared-services/storefront-events/sdk/index.md
+++ b/src/pages/shared-services/storefront-events/sdk/index.md
@@ -1,7 +1,6 @@
 ---
 title: Adobe Commerce Events SDK | Commerce Services
 description: Learn how to programmatically publish and subscribe to Adobe Commerce storefront events.
-edition: paas
 keywords:
   - Events
   - Services

--- a/src/pages/shared-services/storefront-events/sdk/publish.md
+++ b/src/pages/shared-services/storefront-events/sdk/publish.md
@@ -1,7 +1,6 @@
 ---
 title: Publish storefront events | Commerce Services
 description: Learn how to programmatically publish Adobe Commerce storefront events.
-edition: paas
 keywords:
   - Events
   - Services

--- a/src/pages/shared-services/storefront-events/sdk/subscribe.md
+++ b/src/pages/shared-services/storefront-events/sdk/subscribe.md
@@ -1,7 +1,6 @@
 ---
 title: Subscribe to storefront events | Commerce Services
 description: Learn how to programmatically subscribe to Adobe Commerce storefront events.
-edition: paas
 keywords:
   - Events
   - Services

--- a/src/pages/shared-services/storefront-events/sdk/unsubscribe.md
+++ b/src/pages/shared-services/storefront-events/sdk/unsubscribe.md
@@ -1,7 +1,6 @@
 ---
 title: Unsubscribe from storefront events | Commerce Services
 description: Learn how to programmatically unsubscribe from Adobe Commerce storefront events.
-edition: paas
 keywords:
   - Events
   - Services


### PR DESCRIPTION
## Purpose of this pull request

This pull request (PR) aligns the PaaS edition tooltip with recent changes.

It also removes the `paas` edition from content that was formerly marked with the `ee` (Adobe Commerce only) edition. 