### PR TITLE
Revert changes to Metadata visibleIn enum options

### DIFF
--- a/src/openapi/data-ingestion-schema-v1.yaml
+++ b/src/openapi/data-ingestion-schema-v1.yaml
@@ -113,8 +113,10 @@ paths:
                       "dataType": "TEXT",
                       "visibleIn":
                         [
-                          "CATALOG",
-                          "SEARCH"
+                          "PRODUCT_DETAIL",
+                          "PRODUCT_LISTING",
+                          "SEARCH_RESULTS",
+                          "PRODUCT_COMPARE"
                         ],
                       "filterable": true,
                       "sortable": false,
@@ -129,8 +131,10 @@ paths:
                       "dataType": "TEXT",
                       "visibleIn":
                         [
-                          "CATALOG",
-                          "SEARCH"
+                          "PRODUCT_DETAIL",
+                          "PRODUCT_LISTING",
+                          "SEARCH_RESULTS",
+                          "PRODUCT_COMPARE"
                         ],
                       "filterable": false,
                       "sortable": true,
@@ -143,7 +147,7 @@ paths:
                       "scope": { "locale": "en" },
                       "label": "Product Description",
                       "dataType": "TEXT",
-                      "visibleIn": ["CATALOG"],
+                      "visibleIn": ["PRODUCT_DETAIL"],
                       "filterable": false,
                       "sortable": false,
                       "searchable": false,
@@ -155,7 +159,7 @@ paths:
                       "scope": { "locale": "en" },
                       "label": "Product Short Description",
                       "dataType": "TEXT",
-                      "visibleIn": ["CATALOG"],
+                      "visibleIn": ["PRODUCT_DETAIL"],
                       "filterable": false,
                       "sortable": false,
                       "searchable": true,
@@ -169,8 +173,10 @@ paths:
                       "dataType": "DECIMAL",
                       "visibleIn":
                         [
-                          "CATALOG",
-                          "SEARCH"
+                          "PRODUCT_DETAIL",
+                          "PRODUCT_LISTING",
+                          "SEARCH_RESULTS",
+                          "PRODUCT_COMPARE"
                         ],
                       "filterable": true,
                       "sortable": true,
@@ -247,14 +253,17 @@ paths:
                   Note that fields with the `array` type will replace existing data.
                   The example below updates the following attributes:
                   * `label` - Change the product attribute label.
-                  * `visibleIn` - Add `CATALOG` role to the product attribute.
+                  * `visibleIn` - Add `PRODUCT_LISTING` role to the product attribute.
                 value:
                   [
                     {
                       "code": "name",
                       "scope": { "locale": "en" },
                       "label": "Updated - Product Name",
-                      "visibleIn": ["CATALOG"]
+                      "visibleIn": [
+                        "PRODUCT_DETAIL",
+                        "PRODUCT_LISTING"
+                      ]
                     }
                   ]
       responses:
@@ -1570,12 +1579,16 @@ components:
           type: array
           description: |
             Determines how the attribute is used on the storefront.
-            * `CATALOG`: Product attribute is visible in product listing, detail, and compare pages.
-            * `SEARCH`: Product attribute is visible on Search Results Page.
+            * `PRODUCT_DETAIL`: Product attribute is visible on the Product Detail Page.
+            * `PRODUCT_LISTING`: Product attribute is visible on Product Listing Page.
+            * `SEARCH_RESULTS`: Product attribute is visible on Search Results Page.
+            * `PRODUCT_COMPARE`: Product attribute is visible on Product Compare Page.
           items:
             enum:
-              - CATALOG
-              - SEARCH
+              - PRODUCT_DETAIL
+              - PRODUCT_LISTING
+              - SEARCH_RESULTS
+              - PRODUCT_COMPARE
         label:
           type: string
           description: Label for the attribute that is displayed in user interfaces.
@@ -1634,12 +1647,16 @@ components:
           type: array
           description: |
             Determines how the attribute is used on the storefront.
-            * `SEARCH`: Product attribute is visible on Search Results Page.
-            * `CATALOG`: Product is visible in Product Listing, Detail, and Compare pages.
+            * `PRODUCT_DETAIL`: Product attribute is visible on the Product Detail Page.
+            * `PRODUCT_LISTING`: Product attribute is visible on Product Listing Page.
+            * `SEARCH_RESULTS`: Product attribute is visible on Search Results Page.
+            * `PRODUCT_COMPARE`: Product attribute is visible on Product Compare Page.
           items:
             enum:
-              - CATALOG
-              - SEARCH
+              - PRODUCT_DETAIL
+              - PRODUCT_LISTING
+              - SEARCH_RESULTS
+              - PRODUCT_COMPARE
         label:
           type: string
           description: Label for the attribute that is displayed in user interfaces.


### PR DESCRIPTION
## Purpose of this pull request

Reverts the changes to the `visibleIn` enum options of the Metadata endpoint to use:

```
enum:
    - PRODUCT_DETAIL
    - PRODUCT_LISTING
    - SEARCH_RESULTS
    - PRODUCT_COMPARE
```

Effectively reverts commit [e577d44](https://github.com/AdobeDocs/commerce-services/commit/e577d4458c520131ea49bd89135d47152ff4f4ae)
