### PR TITLE
COMOPT-383: Use ComOpt UI for channels and policies

### DIFF
--- a/src/pages/composable-catalog/ccdm-use-case.md
+++ b/src/pages/composable-catalog/ccdm-use-case.md
@@ -668,6 +668,12 @@ curl --request POST \
 
 ## Step 2. Define the channel and policies
 
+<InlineAlert variant="info" slots="text"/>
+
+Channels and policies must be created from the [Adobe Commerce Optimizer user interface](https://experienceleague.adobe.com/en/docs/commerce/optimizer/catalog/channels). The below API documentation fo Channels and Policies
+are provided only to help users get a deeper understanding of the underlying data structure that supports Merchandising Services powered by
+Channels and Policies.
+
 In this step, create a channel for `Zenith Automotive` using the [Create channel](https://developer-stage.adobe.com/commerce/services/graphql-api/admin-api/index.html#mutation-createChannel) GraphQL mutation from the Channels and Policies API.
 
 Assign two policies to the channel: a `Location Policy` with "USA" and "UK" as locations, and a `Brand Policy` with "Aurora" and "Bolt".

--- a/src/pages/composable-catalog/ccdm-use-case.md
+++ b/src/pages/composable-catalog/ccdm-use-case.md
@@ -670,7 +670,7 @@ curl --request POST \
 
 <InlineAlert variant="info" slots="text"/>
 
-Channels and policies must be created from the [Adobe Commerce Optimizer user interface](https://experienceleague.adobe.com/en/docs/commerce/optimizer/catalog/channels). The below API documentation fo Channels and Policies
+Channels and policies must be created from the [Adobe Commerce Optimizer user interface](https://experienceleague.adobe.com/en/docs/commerce/optimizer/catalog/channels). The below API documentation for Channels and Policies
 are provided only to help users get a deeper understanding of the underlying data structure that supports Merchandising Services powered by
 Channels and Policies.
 

--- a/src/pages/graphql/index.md
+++ b/src/pages/graphql/index.md
@@ -15,4 +15,4 @@ The endpoints for all Storefront Service queries are:
 
 You must also specify multiple HTTP headers, including an API key, with each call. Refer to the documentation for each query for details about the required headers.
 
-You can optionally use [API Mesh for Adobe Developer App Builder](https://developer.adobe.com/graphql-mesh-gateway/gateway/) to integrate the core Commerce schema, the Storefront Services schema, and third-party APIs. API Mesh requires an [Adobe I/O Runtime](https://developer.adobe.com/runtime/docs/guides/) account.
+You can optionally use [API Mesh for Adobe Developer App Builder](https://developer.adobe.com/graphql-mesh-gateway/gateway/) to integrate the core Commerce schema, the Storefront Services schema, and third-party APIs. API Mesh requires an [Adobe I/O Runtime](https://developer.adobe.com/app-builder/docs/guides/runtime_guides/) account.


### PR DESCRIPTION
## Purpose of this pull request

Updates the Merchandising Services tutorial to add a note about using Channels and Policies UI instead of the APIs.

## Affected pages

[Define the channel and policies](https://developer-stage.adobe.com/commerce/services/composable-catalog/ccdm-use-case/#step-2-define-the-channel-and-policies)

<!--
If you are fixing a GitHub issue, using the GitHub keyword format (https://help.github.com/en/articles/closing-issues-using-keywords#closing-an-issue-in-a-different-repository) closes the issue when this pull request is merged. Example: `Fixes #1234`.
`main` is the default branch. Merged pull requests to `main` go live on the site automatically. Any requested changes to content on the `main` branch must be related to the released codebase. Any content related to future releases goes in the `develop` branch.
See Contribution guidelines (https://github.com/AdobeDocs/commerce-services/blob/main/.github/CONTRIBUTING.md) for more information.
-->
