### PR TITLE
DCAT-2432: Catalog Data Ingestion API Improvements

### DIFF
--- a/src/openapi/data-ingestion-schema-v1.yaml
+++ b/src/openapi/data-ingestion-schema-v1.yaml
@@ -1809,10 +1809,12 @@ components:
           example: kangaroo-hoodie.html
         description:
           type: string
+          nullable: true
           description: The main description for the product
           example: A kangaroo hoodie for all seasons
         shortDescription:
           type: string
+          nullable: true
           description: A short description of the product
           example: A hoodie for all seasons with a kangaroo pocket
         status:
@@ -1836,10 +1838,7 @@ components:
               - CATALOG
               - SEARCH
         metaTags:
-          type: object
-          description: Meta attributes that are specified in <meta> tags.
-          items:
-            $ref: "#/components/schemas/ProductMetaAttribute"
+          $ref: "#/components/schemas/ProductMetaAttribute"
         attributes:
           type: array
           description: A list of product attributes.
@@ -1870,6 +1869,11 @@ components:
           description: Composite products, such as bundle products, must include a list of individual products that are part of the bundle, organized into groups (for example, "shirts", "pants", "accessories").
           items:
             $ref: "#/components/schemas/ProductBundle"
+        externalIds:
+          type: array
+          description: A list of external IDs for the product.
+          items:
+            $ref: "#/components/schemas/ProductExternalId"
     FeedProductUpdate:
       title: Catalog Product payload
       type: object
@@ -1893,10 +1897,12 @@ components:
           example: kangaroo-hoodie.html
         description:
           type: string
+          nullable: true
           description: The main description for the product
           example: A kangaroo hoodie for all seasons
         shortDescription:
           type: string
+          nullable: true
           description: A short description of the product
           example: A hoodie for all seasons with a kangaroo pocket
         status:
@@ -1920,10 +1926,7 @@ components:
               - CATALOG
               - SEARCH
         metaTags:
-          type: object
-          description: Meta attributes that are specified in <meta> tags.
-          items:
-            $ref: "#/components/schemas/ProductMetaAttribute"
+          $ref: "#/components/schemas/ProductMetaAttribute"
         attributes:
           type: array
           description: A list of product attributes.
@@ -1956,6 +1959,11 @@ components:
           description: Composite products, such as bundle products, must include a list of individual products that are part of the bundle, organized into groups (for example, "shirts", "pants", "accessories").
           items:
             $ref: "#/components/schemas/ProductBundle"
+        externalIds:
+          type: array
+          description: A list of external IDs for the product.
+          items:
+            $ref: "#/components/schemas/ProductExternalId"
     FeedProductDelete:
       title: Catalog Product delete payload
       type: object
@@ -2055,6 +2063,9 @@ components:
     DiscountsFinalPrice:
       title: Final Price
       type: object
+      required:
+        - code
+        - price
       properties:
         code:
           type: string
@@ -2064,6 +2075,9 @@ components:
     DiscountsPercentage:
       title: Discount
       type: object
+      required:
+        - code
+        - percentage
       properties:
         code:
           type: string
@@ -2083,6 +2097,7 @@ components:
           example: English
     ProductMetaAttribute:
       title: Meta Attributes
+      description: Meta attributes that are specified in <meta> tags.
       type: object
       properties:
         title:
@@ -2180,7 +2195,7 @@ components:
           items:
             type: string
     ProductConfiguration:
-      title: ProductConfiguration
+      title: Configurations
       type: object
       required:
         - attributeCode
@@ -2199,6 +2214,7 @@ components:
         defaultVariantReferenceId:
           type: string
           description: Specifies the pre-selected value variant reference id of the current option.
+          nullable: true
         type:
           type: string
           enum:
@@ -2235,7 +2251,7 @@ components:
           type: string
           description: Image URL of the option value. Can be used for option with a SWATCH type.
     ProductBundle:
-      title: ProductBundle
+      title: Bundles
       type: object
       required:
         - group
@@ -2267,6 +2283,19 @@ components:
             Each item in the list represents a product that can be selected as part of the bundle.
           items:
             $ref: "#/components/schemas/ProductBundleItem"
+    ProductExternalId:
+      title: External Ids
+      type: object
+      required:
+        - id
+        - origin
+      properties:
+        id:
+          type: string
+          description: External ID of the product.
+        origin:
+          type: string
+          description: External ID origin. Specifies the system that generated the external ID, such as Adobe Commerce, Google Product Ratings, etc.
     ProductBundleItem:
       title: ProductBundleItem
       type: object


### PR DESCRIPTION
## Purpose of this pull request
- Marked required fields in request payloads
- Fixed Product `metaTags` field not visible
- Added Product `externalIds` field

## Affected pages
https://developer-stage.adobe.com/commerce/services/composable-catalog/data-ingestion/api-reference/