### PR TITLE
ACP2E-4008: [Documentation] Add link to the headless implementation guide into "Product Recommendations SDK" document.

### DIFF
--- a/src/pages/product-recommendations/index.md
+++ b/src/pages/product-recommendations/index.md
@@ -10,6 +10,8 @@ keywords:
 
 If you need to programmatically access product recommendations for your storefront, use the [Product Recommendations JavaScript SDK](https://www.npmjs.com/package/@magento/recommendations-js-sdk). The SDK is a web services API wrapper that allows you to fetch recommendations programmatically in the browser. With the SDK, you do not need to manage the full lifecycle or understand the complexity of the web services API.
 
+For Commerce headless implementations use this [Headless](https://experienceleague.adobe.com/en/docs/commerce/product-recommendations/getting-started/headless) guide.
+
 ## Installing
 
 This SDK can be pulled down from a CDN or installed as a module from NPM.


### PR DESCRIPTION
## Purpose of this pull request

This pull request (PR) is to Add the link to headless implementation guide into "Product Recommendations SDK" document. Merchants sometimes cannot find this guide document and create support requests to provide it.
"Headless" document contains link to the "Product Recommendations SDK" document.
But "Product Recommendations SDK" document does not have link to the "Headless" document.

## Affected pages

- https://developer.adobe.com/commerce/services/product-recommendations/