### PR TITLE
Replace developer-staging links

### DIFF
--- a/.github/workflows/stage.yml
+++ b/.github/workflows/stage.yml
@@ -99,7 +99,7 @@
             ALGOLIA_INDEXATION_MODE: skip
             GATSBY_ALGOLIA_INDEX_NAME: ${{ secrets.ALGOLIA_INDEX_NAME || github.event.repository.name }}
             GATSBY_FEDS_PRIVACY_ID: ${{ secrets.AIO_FEDS_PRIVACY_ID }}
-            GATSBY_SITE_DOMAIN_URL: https://developer-stage.adobe.com
+            GATSBY_SITE_DOMAIN_URL: https://developer.adobe.com
             GATSBY_REDOCLY_KEY: ${{ secrets.REDOCLY_LICENSE_KEY }}
         - name: Deploy
           uses: AdobeDocs/static-website-deploy@master

--- a/README.md
+++ b/README.md
@@ -127,11 +127,11 @@ For local builds, ensure that your environment has the following installed:
 
 1. Create and submit a PR against the `ccdm-early-access` branch, and request review from the Commerce Documentation team.
 
-1. After updates are approved, a documentation team member merges the PR and publishes the updates to [developer-stage site](https://developer-stage.adobe.com/commerce/services/merchandising-services/) for Early Access customers.
+1. After updates are approved, a documentation team member merges the PR and publishes the updates to [developer site](https://developer.adobe.com/commerce/services/merchandising-services/) for Early Access customers.
 
    View the published API references:
 
-   - [Storefront API Reference](https://developer-stage.adobe.com/commerce/services/optimizer/reference/graphql/merchandising-api/)
+   - [Storefront API Reference](https://developer.adobe.com/commerce/services/optimizer/reference/graphql/merchandising-api/)
 
 ### Resources
 

--- a/spectaql/config-admin.yml
+++ b/spectaql/config-admin.yml
@@ -423,7 +423,7 @@ info:
   description: |
      Use the Channels and Policies API to set up distribution channels, locales, and policies to filter products into custom catalogs
      with customer-specific pricing and regional settings for language, currency, and units of measure.
-     For more information about the API, see the <a href="https://developer-stage.adobe.com/commerce/services/optimizer/admin/" target="_blank">developer documentation</a>.
+     For more information about the API, see the <a href="https://developer.adobe.com/commerce/services/optimizer/admin/" target="_blank">developer documentation</a>.
   version: 1.0.0
   title: Channels and Policies API
   # This is non-standard and optional. If omitted, will use "title". Also, only relevant
@@ -442,7 +442,7 @@ info:
   # x-introItems:
     # Can be a Title (for the Nav panel) + URL to simply add a link to somewhere
     # - title: Channels and Policies Guide
-    # url: https://developer-stage.adobe.com/commerce/services/optimizer/admin/
+    # url: https://developer.adobe.com/commerce/services/optimizer/admin/
     # Can be a Title (for the Nav panel) + description (for the Content panel)
     # - title: Important thing 1
     #   description: Some important stuff we wanted you to know. Supports `markdown`

--- a/spectaql/config-storefront.yml
+++ b/spectaql/config-storefront.yml
@@ -423,7 +423,7 @@ info:
 
   description: |
      Use the Merchandising GraphQL API to access rich view-model (read-only) catalog data to build product-related storefront experiences.
-     For more information about the API, see the <a href="https://developer-stage.adobe.com/commerce/services/optimizer/reference/graphql/merchandising-api/" target="_blank">developer documentation</a>.
+     For more information about the API, see the <a href="https://developer.adobe.com/commerce/services/optimizer/reference/graphql/merchandising-api/" target="_blank">developer documentation</a>.
   title: Merchandising GraphQL API
   # This is non-standard and optional. If omitted, will use "title". Also, only relevant
   # when building non-embedded.
@@ -441,7 +441,7 @@ info:
   # x-introItems:
     # Can be a Title (for the Nav panel) + URL to simply add a link to somewhere
     # - title: MerchandisingAPI Guide
-    # url: https://developer-stage.adobe.com/commerce/services/optimizer/merchandising-services/
+    # url: https://developer.adobe.com/commerce/services/optimizer/merchandising-services/
     # Can be a Title (for the Nav panel) + description (for the Content panel)
     # - title: Important thing 1
     #   description: Some important stuff we wanted you to know. Supports `markdown`

--- a/src/openapi/README.md
+++ b/src/openapi/README.md
@@ -28,6 +28,6 @@ The Data Ingestion API Reference is embedded in the [Data Ingestion API referenc
 
 1. Open a PR against the `ccdm-early-access` branch and request review from the Commerce Documentation team.
 
-1. After updates are approved, a documentation team member merges the PR and publishes the updates to [developer-stage site](https://developer-stage.adobe.com/commerce/services/optimizer/) for Early Access customers.
+1. After updates are approved, a documentation team member merges the PR and publishes the updates to [developer site](https://developer.adobe.com/commerce/services/optimizer/) for Early Access customers.
 
-   You can review the currently published version in the [Data Ingestion API reference topic](https://developer-stage.adobe.com/commerce/services/optimizer/reference/rest/data-ingestion-api/).
+   You can review the currently published version in the [Data Ingestion API reference topic](https://developer.adobe.com/commerce/services/optimizer/reference/rest/data-ingestion-api/).

--- a/src/pages/optimizer/ccdm-use-case.md
+++ b/src/pages/optimizer/ccdm-use-case.md
@@ -53,7 +53,7 @@ Add two simple products, "Aurora Prism battery" and "Bolt Atlas battery" and the
 
 ### Add product attribute metadata
 
-Create the metadata to define the search characteristics and filters for displaying product attributes on the storefront by submitting a [Create product attribute metadata](https://developer-stage.adobe.com/commerce/services/optimizer/reference/rest/data-ingestion-api/#operation/ProductMetadataPut) POST request.
+Create the metadata to define the search characteristics and filters for displaying product attributes on the storefront by submitting a [Create product attribute metadata](https://developer.adobe.com/commerce/services/optimizer/reference/rest/data-ingestion-api/#operation/ProductMetadataPut) POST request.
 
 You must specify the product attribute metadata for each locale you want to support.
 
@@ -69,7 +69,7 @@ For the Zenith Automotive catalog, each product has the following attributes.
 - `is_vehicle` is a boolean attribute that indicates whether the product is a vehicle or a battery.
 - `part_category` is a string attribute that indicates the category of the product.
 
-Create the metadata to define the search characteristics and filters for displaying product attributes on the storefront by submitting a [Create product attribute metadata](https://developer-stage.adobe.com/commerce/services/optimizer/reference/rest/data-ingestion-api/#operation/ProductMetadataPut) POST request.
+Create the metadata to define the search characteristics and filters for displaying product attributes on the storefront by submitting a [Create product attribute metadata](https://developer.adobe.com/commerce/services/optimizer/reference/rest/data-ingestion-api/#operation/ProductMetadataPut) POST request.
 
 #### Request to add metadata for the `en-US` catalog source
 
@@ -454,7 +454,7 @@ curl --request POST \
 
 ### Add products
 
-Add products by submitting a [createProducts](https://developer-stage.adobe.com/commerce/services/optimizer/reference/rest/data-ingestion-api/#operation/ProductsPost) POST request using the Data Ingestion API.
+Add products by submitting a [createProducts](https://developer.adobe.com/commerce/services/optimizer/reference/rest/data-ingestion-api/#operation/ProductsPost) POST request using the Data Ingestion API.
 
 #### Create Aurora product
 
@@ -538,7 +538,7 @@ curl --request POST \
 
 #### Create Bolt product
 
-Add the product *Bolt Atlas Battery* with two attribute codes, `Brand` set to *Bolt*, and `Country` set to *UK* by sending the following payload in the [createProducts](https://developer-stage.adobe.com/commerce/services/optimizer/reference/rest/data-ingestion-api/#operation/ProductsPost) request.
+Add the product *Bolt Atlas Battery* with two attribute codes, `Brand` set to *Bolt*, and `Country` set to *UK* by sending the following payload in the [createProducts](https://developer.adobe.com/commerce/services/optimizer/reference/rest/data-ingestion-api/#operation/ProductsPost) request.
 
 **Create product request**
 
@@ -635,7 +635,7 @@ In this step, create the following policies and catalog view for Zenith Automoti
 
 ## Step 3. Retrieve SKUs
 
-Use the Merchandising GraphQL API [productSearch](https://developer-stage.adobe.com/commerce/services/graphql-api/storefront-api/index.html#query-productSearch) query to retrieve the SKUs you created.
+Use the Merchandising GraphQL API [productSearch](https://developer.adobe.com/commerce/services/graphql-api/storefront-api/index.html#query-productSearch) query to retrieve the SKUs you created.
 
 Send GraphQL requests for Merchandising APIs to the following base URL:
 
@@ -645,7 +645,7 @@ Send GraphQL requests for Merchandising APIs to the following base URL:
 
 Retrieve the SKU you created for `Aurora` where location is `USA`. Use the search phrase `Zenith Automotive Vehicles and Parts`, and specify a page size to limit results.
 
-The brand and location (`AC-Policy-Brand` and `AC-Policy-Country`) are passed in using [Merchandising API headers](https://developer-stage.adobe.com/commerce/services/using-the-api/#header).
+The brand and location (`AC-Policy-Brand` and `AC-Policy-Country`) are passed in using [Merchandising API headers](https://developer.adobe.com/commerce/services/using-the-api/#header).
 
 Use the following headers in the request:
 
@@ -814,7 +814,7 @@ The response returns the product details for a single SKU, `Aurora Prism battery
 
 Retrieve the SKU you created for `Bolt` where location is `UK`. Use the search phrase `Zenith Automotive Vehicles and Parts`, and specify a page size to limit results.
 
-The brand and location (`AC-Policy-Brand` and `AC-Policy-Country`) are passed in using the [Merchandising API headers](https://developer-stage.adobe.com/commerce/services/optimizer/using-the-api/#header).
+The brand and location (`AC-Policy-Brand` and `AC-Policy-Country`) are passed in using the [Merchandising API headers](https://developer.adobe.com/commerce/services/optimizer/using-the-api.md/#header).
 
 Use the following headers in the request:
 

--- a/src/pages/optimizer/data-ingestion/index.md
+++ b/src/pages/optimizer/data-ingestion/index.md
@@ -30,7 +30,7 @@ Metadata is required to index product data for discovery. Consequently, it must 
 
 You can also define custom metadata for additional product attributes. For example, you can define a `brand` attribute to allow product discovery and filtering by brand name.
 
-For details, see <a href="https://developer-stage.adobe.com/commerce/services/optimizer/reference/rest/data-ingestion-api/#tag/Metadata" target="_blank" rel="noopener noreferrer">Metadata API</a> in the *Data Ingestion API Reference*.
+For details, see <a href="https:developer.adobe.com/commerce/services/optimizer/reference/rest/data-ingestion-api/#tag/Metadata" target="_blank" rel="noopener noreferrer">Metadata API</a> in the *Data Ingestion API Reference*.
 
 ## Products
 
@@ -47,7 +47,7 @@ Each product type has its own set of attributes and configurations to help you m
 
 For example, if you're selling a t-shirt, the product variants might include different sizes (small, medium, large) and colors (red, blue, green). Each combination of size and color represents a unique product variant.
 
-For details, see <a href="https://developer-stage.adobe.com/commerce/services/optimizer/reference/rest/data-ingestion-api/#tag/Products" target="_blank" rel="noopener noreferrer">Products API</a> in the *Data Ingestion API reference*.
+For details, see <a href="https://developer.adobe.com/commerce/services/optimizer/reference/rest/data-ingestion-api/#tag/Products" target="_blank" rel="noopener noreferrer">Products API</a> in the *Data Ingestion API reference*.
 
 ## Price books and prices
 
@@ -57,7 +57,7 @@ In Merchandising Services, a product SKU and its price are decoupled. This decou
 
 **Prices** are the monetary values assigned to products within a price book. To create prices for each product SKU, specify the associated price books and define the pricing schedule for each price book.
 
-For details, see <a href="https://developer-stage.adobe.com/commerce/services/optimizer/reference/rest/data-ingestion-api/#tag/Metadata/#tag/Price-Books" target="_blank" rel="noopener noreferrer">Price Books</a> and <a href="https://developer-stage.adobe.com/commerce/services/optimizer/reference/rest/data-ingestion-api/#operation/createPrices" target="_blank" rel="noopener noreferrer">Prices</a> in the *Data Ingestion API Reference*.
+For details, see <a href="https://developer.adobe.com/commerce/services/optimizer/reference/rest/data-ingestion-api/#tag/Metadata/#tag/Price-Books" target="_blank" rel="noopener noreferrer">Price Books</a> and <a href="https://developer.adobe.com/commerce/services/optimizer/reference/rest/data-ingestion-api/#operation/createPrices" target="_blank" rel="noopener noreferrer">Prices</a> in the *Data Ingestion API Reference*.
 
 ## Load sample data using the Adobe Commerce Optimizer SDK
 

--- a/src/pages/optimizer/data-ingestion/using-the-api.md
+++ b/src/pages/optimizer/data-ingestion/using-the-api.md
@@ -204,7 +204,7 @@ After you successfully make your first request, you can continue to use the Data
 - Create price books to manage pricing for different customer segments, regions, or sales channels.
 - Create prices to set the monetary values for your products within the price books.
 
-You can also explore the [API reference](https://developer-stage.adobe.com/commerce/services/optimizer/reference/rest/data-ingestion-api/) for detailed information about each endpoint and its parameters.
+You can also explore the [API reference](https://developer.adobe.com/commerce/services/optimizer/reference/rest/data-ingestion-api/) for detailed information about each endpoint and its parameters.
 
 ## Create integrations with SDK
 

--- a/src/pages/optimizer/merchandising-services/index.md
+++ b/src/pages/optimizer/merchandising-services/index.md
@@ -97,7 +97,7 @@ See the [Get Started with the Merchandising API](using-the-api.md) section for i
 
 - **[Data Ingestion API](../data-ingestion/index.md)**: Ingest and manage product and pricing data
 - **<a href="https://experienceleague.adobe.com/docs/commerce/optimizer/setup/catalog-view.html" target="_blank" rel="noopener noreferrer">Catalog Management</a>**: Set up catalog views and policies in Adobe Commerce Optimizer
-- **<a href="https://developer-stage.adobe.com/commerce/services/optimizer/reference/graphql/merchandising-api/" target="_blank" rel="noopener noreferrer">Merchandising API Reference</a>**: Merchandising API Reference
+- **<a href="https://developer.adobe.com/commerce/services/optimizer/reference/graphql/merchandising-api/" target="_blank" rel="noopener noreferrer">Merchandising API Reference</a>**: Merchandising API Reference
 - **[GraphQL Queries](use-cases.md#available-queries)**: Available queries
 
 For additional support and community resources, visit the [Adobe Commerce Developer Portal](https://developer.adobe.com/commerce/).

--- a/src/pages/optimizer/merchandising-services/use-cases.md
+++ b/src/pages/optimizer/merchandising-services/use-cases.md
@@ -109,4 +109,4 @@ query ProductDetails($skus: [String!]!) {
 }
 ```
 
-For detailed examples of each query, see the <a href="https://developer-stage.adobe.com/commerce/services/optimizer/reference/graphql/merchandising-api/)" target="_blank" rel="noopener noreferrer">Merchandising API Reference</a>.
+For detailed examples of each query, see the <a href="https://developer.adobe.com/commerce/services/optimizer/reference/graphql/merchandising-api/)" target="_blank" rel="noopener noreferrer">Merchandising API Reference</a>.

--- a/src/pages/optimizer/merchandising-services/using-the-api.md
+++ b/src/pages/optimizer/merchandising-services/using-the-api.md
@@ -125,7 +125,7 @@ To get started with the Merchandising API, follow these steps to make your first
      }'
    ```
 
-   For sample requests and examples using the API, see the <a href="https://developer-stage.adobe.com/commerce/services/optimizer/reference/graphql/merchandising-api.md/" target="_blank" rel="noopener noreferrer">Merchandising API Reference</a>.
+   For sample requests and examples using the API, see the <a href="https://developer.adobe.com/commerce/services/optimizer/reference/graphql/merchandising-api.md/" target="_blank" rel="noopener noreferrer">Merchandising API Reference</a>.
 
 ## Test with the GraphQL Playground
 

--- a/static/graphql-api/admin-api/index.html
+++ b/static/graphql-api/admin-api/index.html
@@ -102,7 +102,7 @@
               <p>Use the Channels and Policies API to set up distribution channels, locales, and policies to filter
                 products into custom catalogs with customer-specific pricing and regional settings for language,
                 currency, and units of measure. For more information about the API, see the <a
-                   href="https://developer-stage.adobe.com/commerce/services/optimizer/admin/"
+                   href="https://developer.adobe.com/commerce/services/optimizer/admin/"
                    target="_blank">developer documentation</a>.</p>
             </div>
             <div class="doc-examples">

--- a/static/graphql-api/merchandising-api/index.html
+++ b/static/graphql-api/merchandising-api/index.html
@@ -142,7 +142,7 @@
             <div class="doc-copy">
               <p>Use the Merchandising GraphQL API to access rich view-model (read-only) catalog data to build
                 product-related storefront experiences. For more information about the API, see the <a
-                   href="https://developer-stage.adobe.com/commerce/services/optimizer/reference/rest/api-reference/"
+                   href="https://developer.adobe.com/commerce/services/optimizer/reference/rest/api-reference/"
                    target="_blank">developer documentation</a>.</p>
             </div>
             <div class="doc-examples">


### PR DESCRIPTION
## Purpose of this pull request

This pull request (PR)  updates inline documentation links to replace  `developer-staging.adobe.com` with `developer.adobe.com` links .

