### PR TITLE
Add link to Java SDK in SDK integration section

### DIFF
--- a/src/pages/optimizer/data-ingestion/using-the-api.md
+++ b/src/pages/optimizer/data-ingestion/using-the-api.md
@@ -207,7 +207,15 @@ You can also explore the [API reference](https://developer.adobe.com/commerce/se
 
 ## Create integrations with SDK
 
-The Adobe Commerce Optimizer (ACO) SDK simplifies integration with the Data Ingestion API by providing pre-built methods for catalog ingestion and IMS authentication. The SDK handles the complexity of API interactions, allowing you to focus on your business logic. To download the SDK and learn how to use it, see the [Adobe Commerce Optimizer GitHub repository](https://github.com/adobe-commerce/aco-ts-sdk).
+The Adobe Commerce Optimizer (ACO) SDK simplifies integration with the Data Ingestion API by providing pre-built methods for catalog ingestion and IMS authentication. The SDK handles the complexity of API interactions, allowing you to focus on your business logic.
+
+There are currently two SDKs available:
+
+[TypeScript SDK](https://github.com/adobe-commerce/aco-ts-sdk) – for JavaScript/TypeScript integrations
+
+[Java SDK](https://github.com/adobe-commerce/aco-java-sdk) – for Java-based integrations
+
+To download either SDK and learn how to use it, see the corresponding GitHub repository linked above.
 
 ## Limitations
 

--- a/src/pages/optimizer/data-ingestion/using-the-api.md
+++ b/src/pages/optimizer/data-ingestion/using-the-api.md
@@ -207,15 +207,14 @@ You can also explore the [API reference](https://developer.adobe.com/commerce/se
 
 ## Create integrations with SDK
 
-The Adobe Commerce Optimizer (ACO) SDK simplifies integration with the Data Ingestion API by providing pre-built methods for catalog ingestion and IMS authentication. The SDK handles the complexity of API interactions, allowing you to focus on your business logic.
+The Adobe Commerce Optimizer SDKs simplify integration with the Data Ingestion API by providing pre-built methods for catalog ingestion and IMS authentication. The SDKs handle the complexity of API interactions, allowing you to focus on your business logic.
 
-There are currently two SDKs available:
+Use the following GitHub repository links to download an available SDK and learn how to use it.
 
-[TypeScript SDK](https://github.com/adobe-commerce/aco-ts-sdk) – for JavaScript/TypeScript integrations
+- [TypeScript SDK](https://github.com/adobe-commerce/aco-ts-sdk) – for JavaScript/TypeScript integrations
 
-[Java SDK](https://github.com/adobe-commerce/aco-java-sdk) – for Java-based integrations
+- [Java SDK](https://github.com/adobe-commerce/aco-java-sdk) – for Java-based integrations
 
-To download either SDK and learn how to use it, see the corresponding GitHub repository linked above.
 
 ## Limitations
 

--- a/src/pages/optimizer/data-ingestion/using-the-api.md
+++ b/src/pages/optimizer/data-ingestion/using-the-api.md
@@ -215,7 +215,6 @@ Use the following GitHub repository links to download an available SDK and learn
 
 - [Java SDK](https://github.com/adobe-commerce/aco-java-sdk) – for Java-based integrations
 
-
 ## Limitations
 
 The Data Ingestion API has a rate limit of 300 requests per minute.


### PR DESCRIPTION
## Purpose of this pull request

Add a reference to the Java SDK in the "Create integrations with SDK" section, alongside the existing TypeScript SDK. This provides visibility into both available SDKs for integrating with the Adobe Commerce Optimizer Data Ingestion API.

## Affected pages

<!-- REQUIRED List the affected pages on developer.adobe.com (URLs). Not necessary for large numbers of files. -->

- https://developer.adobe.com/commerce/services/optimizer/data-ingestion/using-the-api/#create-integrations-with-sdk
