### PR TITLE
feat: change trigger to workflow dispatch for staging deployment

### DIFF
--- a/.github/workflows/stage.yml
+++ b/.github/workflows/stage.yml
@@ -1,13 +1,18 @@
 ---
   name: Staging deployment
   on:
-    # Trigger the workflow on each push to develop
-    push:
-      branches:
-        - develop
+    workflow_dispatch:
+      inputs:
+        clean:
+          description: 'Clean cache'
+          required: true
+          default: 'yes'
+        excludeSubfolder:
+          description: 'Exclude subfolder'
+          required: false
+          default: ''
   jobs:
     set-state:
-      if: ${{ github.ref == 'refs/heads/develop' }}
       runs-on: ubuntu-latest
       outputs:
         clean_cache: ${{ contains(github.event.inputs.clean, 'yes') }}


### PR DESCRIPTION
## Purpose of this pull request

This pull request (PR) reverts the staging deployment GitHub Actions workflow to trigger on workflow dispatch similar to other commerce devsite repos.

This is necessary to begin testing the REST API playground in #273 since the repo maintainer has requested to use `main` as the base branch for #273.