### PR TITLE
fix: set default content type

### DIFF
--- a/static/rest/data-ingestion-schema-v1.yaml
+++ b/static/rest/data-ingestion-schema-v1.yaml
@@ -1580,6 +1580,7 @@ components:
       schema:
         type: string
         enum: [application/json]
+        default: application/json
     ContentEncoding:
       name: Content-Encoding
       in: header


### PR DESCRIPTION
## Purpose of this pull request

This pull request (PR) sets the default Content-Type header paramater for the data ingestion API to `application/json` so that users don't have to select it every time they want to try the API.

## Staging

https://developer-stage.adobe.com/commerce/services/reference/rest/
