### PR TITLE
Comopt 998 filter api reference for catalog queries

### DIFF
--- a/spectaql/config-merchandising.yml
+++ b/spectaql/config-merchandising.yml
@@ -115,7 +115,7 @@ introspection:
 
   # URL of the GraphQL endpoint to hit if you want to generate the documentation based on live Introspection Query results
   # NOTE: If not using introspection.url OR servers[], you need to provide x-url below
-  url: https://na1-sandbox.api.commerce.adobe.com/tenant-id/graphql
+  url: https://na1-sandbox.api.commerce.adobe.com/Fwus6kdpvYCmeEdcCX7PZg/graphql # This value is the sandbox URL for the Instructor Instance in the Adobe Commerce Optimizer org.
   exclude:
     excludeMutations: true
   #
@@ -204,7 +204,7 @@ introspection:
   #
 
   # File that contains your metadata data in JS module export, or JSON format
-  metadataFile: spectaql/metadata-merchandising.json
+  metadataFile: spectaql/metadata-merchandising.json  # This file provides the configuration to filter the API reference to include only queries and types used to retrieve catalog data.
 
   # The path to a key from which to read the documentation-related metadata at each level of your metadata file.
   # Defaults to 'documentation', but in case you use a different name, or have a complex/nested metadata structure, you can
@@ -281,7 +281,7 @@ introspection:
 
   # Whether to document any Mutations at all, in the absence of a metadata directive
   # Default: true
-  mutationsDocumentedDefault: false
+  mutationsDocumentedDefault: false   # Merchandising API is read-only, so no mutations are documented.
   # Whether to document an individual Mutation, in the absence of a metadata directive
   # Default: true
   mutationDocumentedDefault: false

--- a/spectaql/config-merchandising.yml
+++ b/spectaql/config-merchandising.yml
@@ -116,6 +116,8 @@ introspection:
   # URL of the GraphQL endpoint to hit if you want to generate the documentation based on live Introspection Query results
   # NOTE: If not using introspection.url OR servers[], you need to provide x-url below
   url: https://na1-sandbox.api.commerce.adobe.com/tenant-id/graphql
+  exclude:
+    excludeMutations: true
   #
   #
   ##############################################
@@ -279,13 +281,13 @@ introspection:
 
   # Whether to document any Mutations at all, in the absence of a metadata directive
   # Default: true
-  mutationsDocumentedDefault: true
+  mutationsDocumentedDefault: false
   # Whether to document an individual Mutation, in the absence of a metadata directive
   # Default: true
-  mutationDocumentedDefault: true
+  mutationDocumentedDefault: false
   # Whether to document a Mutation Argument, in the absence of a metadata directive
   # Default: true
-  mutationArgDocumentedDefault: true
+  mutationArgDocumentedDefault: false
   # Hide any Mutations with undocumented return types so as not to reference something
   # that seemingly does not exist.
   # Default: true

--- a/spectaql/metadata-merchandising.json
+++ b/spectaql/metadata-merchandising.json
@@ -3321,14 +3321,19 @@
         "undocumented": true
       }
     },
+    "ProductSearchFilterInput": {
+      "documentation": {
+        "undocumented": false
+      }
+    },
     "ProductSearchSortInput": {
       "documentation": {
-        "undocumented": true
+        "undocumented": false
       }
     },
     "PurchaseHistory": {
       "documentation": {
-        "undocumented": true
+        "undocumented": false
       }
     },
     "PurchaseOrderApprovalRuleInput": {
@@ -3348,7 +3353,7 @@
     },
     "QueryContextInput": {
       "documentation": {
-        "undocumented": true
+        "undocumented": false
       }
     },
     "QuoteItemsSortInput": {
@@ -3643,7 +3648,7 @@
     },
     "ViewHistory": {
       "documentation": {
-        "undocumented": true
+        "undocumented": false
       }
     },
     "ViewHistoryInput": {
@@ -3860,7 +3865,7 @@
     },
     "PageType": {
       "documentation": {
-        "undocumented": true
+        "undocumented": false
       }
     },
     "PaymentLocation": {

--- a/spectaql/metadata-merchandising.json
+++ b/spectaql/metadata-merchandising.json
@@ -1,19 +1,4064 @@
 {
-    "INTERFACE": {
-        "CategoryViewInterface": {
-            "documentation": { "undocumented": true }
-        }
+  "OBJECT": {
+    "AddCustomAttributesToCartItemOutput": {
+      "documentation": {
+        "undocumented": true
+      }
     },
-    "OBJECT": {
-        "CategoryView": {
-            "documentation": { "undocumented": true }
+    "AddDownloadableProductsToCartOutput": {
+      "documentation": {
+        "undocumented": true
+      }
+    },
+    "AddGiftRegistryRegistrantsOutput": {
+      "documentation": {
+        "undocumented": true
+      }
+    },
+    "AddProductsToCartOutput": {
+      "documentation": {
+        "undocumented": true
+      }
+    },
+    "AddProductsToRequisitionListOutput": {
+      "documentation": {
+        "undocumented": true
+      }
+    },
+    "AddProductsToWishlistOutput": {
+      "documentation": {
+        "undocumented": true
+      }
+    },
+    "AddPurchaseOrderCommentOutput": {
+      "documentation": {
+        "undocumented": true
+      }
+    },
+    "AddRequisitionListItemToCartUserError": {
+      "documentation": {
+        "undocumented": true
+      }
+    },
+    "AddRequisitionListItemsToCartOutput": {
+      "documentation": {
+        "undocumented": true
+      }
+    },
+    "AddReturnCommentOutput": {
+      "documentation": {
+        "undocumented": true
+      }
+    },
+    "AddReturnTrackingOutput": {
+      "documentation": {
+        "undocumented": true
+      }
+    },
+    "AddWishlistItemsToCartOutput": {
+      "documentation": {
+        "undocumented": true
+      }
+    },
+    "AggregationOption": {
+      "documentation": {
+        "undocumented": true
+      }
+    },
+    "AggregationOptionInterface": {
+      "documentation": {
+        "undocumented": true
+      }
+    },
+    "ApplePayConfig": {
+      "documentation": {
+        "undocumented": true
+      }
+    },
+    "AppliedCoupon": {
+      "documentation": {
+        "undocumented": true
+      }
+    },
+    "AppliedGiftCard": {
+      "documentation": {
+        "undocumented": true
+      }
+    },
+    "AppliedStoreCredit": {
+      "documentation": {
+        "undocumented": true
+      }
+    },
+    "ApplyCouponToCartOutput": {
+      "documentation": {
+        "undocumented": true
+      }
+    },
+    "ApplyGiftCardToCartOutput": {
+      "documentation": {
+        "undocumented": true
+      }
+    },
+    "ApplyGiftCardToOrder": {
+      "documentation": {
+        "undocumented": true
+      }
+    },
+    "ApplyRewardPointsToCartOutput": {
+      "documentation": {
+        "undocumented": true
+      }
+    },
+    "ApplyStoreCreditToCartOutput": {
+      "documentation": {
+        "undocumented": true
+      }
+    },
+    "AssetImage": {
+      "documentation": {
+        "undocumented": true
+      }
+    },
+    "AssetVideo": {
+      "documentation": {
+        "undocumented": true
+      }
+    },
+    "AssignCompareListToCustomerOutput": {
+      "documentation": {
+        "undocumented": true
+      }
+    },
+    "Attribute": {
+      "documentation": {
+        "undocumented": true
+      }
+    },
+    "AttributeMetadata": {
+      "documentation": {
+        "undocumented": true
+      }
+    },
+    "AttributeMetadataError": {
+      "documentation": {
+        "undocumented": true
+      }
+    },
+    "AttributeOption": {
+      "documentation": {
+        "undocumented": true
+      }
+    },
+    "AttributeOptionMetadata": {
+      "documentation": {
+        "undocumented": true
+      }
+    },
+    "AttributeSelectedOption": {
+      "documentation": {
+        "undocumented": true
+      }
+    },
+    "AttributeSelectedOptionInterface": {
+      "documentation": {
+        "undocumented": true
+      }
+    },
+    "AttributeSelectedOptions": {
+      "documentation": {
+        "undocumented": true
+      }
+    },
+    "AttributeValue": {
+      "documentation": {
+        "undocumented": true
+      }
+    },
+    "AttributeValueInterface": {
+      "documentation": {
+        "undocumented": true
+      }
+    },
+    "AttributesFormOutput": {
+      "documentation": {
+        "undocumented": true
+      }
+    },
+    "AttributesMetadataOutput": {
+      "documentation": {
+        "undocumented": true
+      }
+    },
+    "AvailableCurrency": {
+      "documentation": {
+        "undocumented": true
+      }
+    },
+    "AvailablePaymentMethod": {
+      "documentation": {
+        "undocumented": true
+      }
+    },
+    "AvailableShippingMethod": {
+      "documentation": {
+        "undocumented": true
+      }
+    },
+    "BillingCartAddress": {
+      "documentation": {
+        "undocumented": true
+      }
+    },
+    "Breadcrumb": {
+      "documentation": {
+        "undocumented": true
+      }
+    },
+    "BundleCartItem": {
+      "documentation": {
+        "undocumented": true
+      }
+    },
+    "BundleCreditMemoItem": {
+      "documentation": {
+        "undocumented": true
+      }
+    },
+    "BundleInvoiceItem": {
+      "documentation": {
+        "undocumented": true
+      }
+    },
+    "BundleItem": {
+      "documentation": {
+        "undocumented": true
+      }
+    },
+    "BundleItemOption": {
+      "documentation": {
+        "undocumented": true
+      }
+    },
+    "BundleOrderItem": {
+      "documentation": {
+        "undocumented": true
+      }
+    },
+    "BundleProduct": {
+      "documentation": {
+        "undocumented": true
+      }
+    },
+    "BundleRequisitionListItem": {
+      "documentation": {
+        "undocumented": true
+      }
+    },
+    "BundleShipmentItem": {
+      "documentation": {
+        "undocumented": true
+      }
+    },
+    "BundleWishlistItem": {
+      "documentation": {
+        "undocumented": true
+      }
+    },
+    "ButtonStyles": {
+      "documentation": {
+        "undocumented": true
+      }
+    },
+    "CancelOrderError": {
+      "documentation": {
+        "undocumented": true
+      }
+    },
+    "CancelOrderOutput": {
+      "documentation": {
+        "undocumented": true
+      }
+    },
+    "CancellationReason": {
+      "documentation": {
+        "undocumented": true
+      }
+    },
+    "Card": {
+      "documentation": {
+        "undocumented": true
+      }
+    },
+    "CardBin": {
+      "documentation": {
+        "undocumented": true
+      }
+    },
+    "CardPaymentSourceOutput": {
+      "documentation": {
+        "undocumented": true
+      }
+    },
+    "Cart": {
+      "documentation": {
+        "undocumented": true
+      }
+    },
+    "CartAddressCountry": {
+      "documentation": {
+        "undocumented": true
+      }
+    },
+    "CartAddressInterface": {
+      "documentation": {
+        "undocumented": true
+      }
+    },
+    "CartAddressRegion": {
+      "documentation": {
+        "undocumented": true
+      }
+    },
+    "CartItemError": {
+      "documentation": {
+        "undocumented": true
+      }
+    },
+    "CartItemInterface": {
+      "documentation": {
+        "undocumented": true
+      }
+    },
+    "CartItemPrices": {
+      "documentation": {
+        "undocumented": true
+      }
+    },
+    "CartItemSelectedOptionValuePrice": {
+      "documentation": {
+        "undocumented": true
+      }
+    },
+    "CartItems": {
+      "documentation": {
+        "undocumented": true
+      }
+    },
+    "CartPrices": {
+      "documentation": {
+        "undocumented": true
+      }
+    },
+    "CartRuleStorefront": {
+      "documentation": {
+        "undocumented": true
+      }
+    },
+    "CartTaxItem": {
+      "documentation": {
+        "undocumented": true
+      }
+    },
+    "CartUserInputError": {
+      "documentation": {
+        "undocumented": true
+      }
+    },
+    "CatalogAttributeMetadata": {
+      "documentation": {
+        "undocumented": true
+      }
+    },
+    "CategoryBucketInterface": {
+      "documentation": {
+        "undocumented": true
+      }
+    },
+    "CategoryInterface": {
+      "documentation": {
+        "undocumented": true
+      }
+    },
+    "CategoryTree": {
+      "documentation": {
+        "undocumented": true
+      }
+    },
+    "CategoryViewInterface": {
+      "documentation": {
+        "undocumented": true
+      }
+    },
+    "CheckoutAgreement": {
+      "documentation": {
+        "undocumented": true
+      }
+    },
+    "CheckoutUserInputError": {
+      "documentation": {
+        "undocumented": true
+      }
+    },
+    "ClearCustomerCartOutput": {
+      "documentation": {
+        "undocumented": true
+      }
+    },
+    "CloseNegotiableQuoteOperationFailure": {
+      "documentation": {
+        "undocumented": true
+      }
+    },
+    "CloseNegotiableQuotesOutput": {
+      "documentation": {
+        "undocumented": true
+      }
+    },
+    "ColorSwatchData": {
+      "documentation": {
+        "undocumented": true
+      }
+    },
+    "Company": {
+      "documentation": {
+        "undocumented": true
+      }
+    },
+    "CompanyAclResource": {
+      "documentation": {
+        "undocumented": true
+      }
+    },
+    "CompanyAdmin": {
+      "documentation": {
+        "undocumented": true
+      }
+    },
+    "CompanyBasicInfo": {
+      "documentation": {
+        "undocumented": true
+      }
+    },
+    "CompanyCredit": {
+      "documentation": {
+        "undocumented": true
+      }
+    },
+    "CompanyCreditHistory": {
+      "documentation": {
+        "undocumented": true
+      }
+    },
+    "CompanyCreditOperation": {
+      "documentation": {
+        "undocumented": true
+      }
+    },
+    "CompanyCreditOperationUser": {
+      "documentation": {
+        "undocumented": true
+      }
+    },
+    "CompanyInvitationOutput": {
+      "documentation": {
+        "undocumented": true
+      }
+    },
+    "CompanyLegalAddress": {
+      "documentation": {
+        "undocumented": true
+      }
+    },
+    "CompanyRole": {
+      "documentation": {
+        "undocumented": true
+      }
+    },
+    "CompanyRoles": {
+      "documentation": {
+        "undocumented": true
+      }
+    },
+    "CompanySalesRepresentative": {
+      "documentation": {
+        "undocumented": true
+      }
+    },
+    "CompanyStructure": {
+      "documentation": {
+        "undocumented": true
+      }
+    },
+    "CompanyStructureItem": {
+      "documentation": {
+        "undocumented": true
+      }
+    },
+    "CompanyTeam": {
+      "documentation": {
+        "undocumented": true
+      }
+    },
+    "CompanyUsers": {
+      "documentation": {
+        "undocumented": true
+      }
+    },
+    "ComparableAttribute": {
+      "documentation": {
+        "undocumented": true
+      }
+    },
+    "ComparableItem": {
+      "documentation": {
+        "undocumented": true
+      }
+    },
+    "CompareList": {
+      "documentation": {
+        "undocumented": true
+      }
+    },
+    "ComplexTextValue": {
+      "documentation": {
+        "undocumented": true
+      }
+    },
+    "ConfigurableAttributeOption": {
+      "documentation": {
+        "undocumented": true
+      }
+    },
+    "ConfigurableCartItem": {
+      "documentation": {
+        "undocumented": true
+      }
+    },
+    "ConfigurableOptionAvailableForSelection": {
+      "documentation": {
+        "undocumented": true
+      }
+    },
+    "ConfigurableOrderItem": {
+      "documentation": {
+        "undocumented": true
+      }
+    },
+    "ConfigurableProduct": {
+      "documentation": {
+        "undocumented": true
+      }
+    },
+    "ConfigurableProductOption": {
+      "documentation": {
+        "undocumented": true
+      }
+    },
+    "ConfigurableProductOptionValue": {
+      "documentation": {
+        "undocumented": true
+      }
+    },
+    "ConfigurableProductOptions": {
+      "documentation": {
+        "undocumented": true
+      }
+    },
+    "ConfigurableProductOptionsSelection": {
+      "documentation": {
+        "undocumented": true
+      }
+    },
+    "ConfigurableProductOptionsValues": {
+      "documentation": {
+        "undocumented": true
+      }
+    },
+    "ConfigurableRequisitionListItem": {
+      "documentation": {
+        "undocumented": true
+      }
+    },
+    "ConfigurableVariant": {
+      "documentation": {
+        "undocumented": true
+      }
+    },
+    "ConfigurableWishlistItem": {
+      "documentation": {
+        "undocumented": true
+      }
+    },
+    "ContactUsOutput": {
+      "documentation": {
+        "undocumented": true
+      }
+    },
+    "CopyItemsFromRequisitionListsOutput": {
+      "documentation": {
+        "undocumented": true
+      }
+    },
+    "CopyProductsBetweenWishlistsOutput": {
+      "documentation": {
+        "undocumented": true
+      }
+    },
+    "Country": {
+      "documentation": {
+        "undocumented": true
+      }
+    },
+    "CreateCompanyOutput": {
+      "documentation": {
+        "undocumented": true
+      }
+    },
+    "CreateCompanyRoleOutput": {
+      "documentation": {
+        "undocumented": true
+      }
+    },
+    "CreateCompanyTeamOutput": {
+      "documentation": {
+        "undocumented": true
+      }
+    },
+    "CreateCompanyUserOutput": {
+      "documentation": {
+        "undocumented": true
+      }
+    },
+    "CreateGiftRegistryOutput": {
+      "documentation": {
+        "undocumented": true
+      }
+    },
+    "CreateGuestCartOutput": {
+      "documentation": {
+        "undocumented": true
+      }
+    },
+    "CreatePaymentOrderOutput": {
+      "documentation": {
+        "undocumented": true
+      }
+    },
+    "CreateRequisitionListOutput": {
+      "documentation": {
+        "undocumented": true
+      }
+    },
+    "CreateVaultCardPaymentTokenOutput": {
+      "documentation": {
+        "undocumented": true
+      }
+    },
+    "CreateVaultCardSetupTokenOutput": {
+      "documentation": {
+        "undocumented": true
+      }
+    },
+    "CreateWishlistOutput": {
+      "documentation": {
+        "undocumented": true
+      }
+    },
+    "CreditMemo": {
+      "documentation": {
+        "undocumented": true
+      }
+    },
+    "CreditMemoItem": {
+      "documentation": {
+        "undocumented": true
+      }
+    },
+    "CreditMemoItemInterface": {
+      "documentation": {
+        "undocumented": true
+      }
+    },
+    "CreditMemoOutput": {
+      "documentation": {
+        "undocumented": true
+      }
+    },
+    "CreditMemoTotal": {
+      "documentation": {
+        "undocumented": true
+      }
+    },
+    "Currency": {
+      "documentation": {
+        "undocumented": true
+      }
+    },
+    "CustomAttribute": {
+      "documentation": {
+        "undocumented": true
+      }
+    },
+    "CustomAttributeMetadataInterface": {
+      "documentation": {
+        "undocumented": true
+      }
+    },
+    "CustomAttributeOptionInterface": {
+      "documentation": {
+        "undocumented": true
+      }
+    },
+    "CustomConfigKeyValue": {
+      "documentation": {
+        "undocumented": true
+      }
+    },
+    "Customer": {
+      "documentation": {
+        "undocumented": true
+      }
+    },
+    "CustomerAddress": {
+      "documentation": {
+        "undocumented": true
+      }
+    },
+    "CustomerAddressAttribute": {
+      "documentation": {
+        "undocumented": true
+      }
+    },
+    "CustomerAddressRegion": {
+      "documentation": {
+        "undocumented": true
+      }
+    },
+    "CustomerAddresses": {
+      "documentation": {
+        "undocumented": true
+      }
+    },
+    "CustomerAttributeMetadata": {
+      "documentation": {
+        "undocumented": true
+      }
+    },
+    "CustomerDownloadableProduct": {
+      "documentation": {
+        "undocumented": true
+      }
+    },
+    "CustomerDownloadableProducts": {
+      "documentation": {
+        "undocumented": true
+      }
+    },
+    "CustomerGroupStorefront": {
+      "documentation": {
+        "undocumented": true
+      }
+    },
+    "CustomerOrder": {
+      "documentation": {
+        "undocumented": true
+      }
+    },
+    "CustomerOrders": {
+      "documentation": {
+        "undocumented": true
+      }
+    },
+    "CustomerOutput": {
+      "documentation": {
+        "undocumented": true
+      }
+    },
+    "CustomerPaymentTokens": {
+      "documentation": {
+        "undocumented": true
+      }
+    },
+    "CustomerSegmentStorefront": {
+      "documentation": {
+        "undocumented": true
+      }
+    },
+    "CustomerStoreCredit": {
+      "documentation": {
+        "undocumented": true
+      }
+    },
+    "CustomerStoreCreditHistory": {
+      "documentation": {
+        "undocumented": true
+      }
+    },
+    "CustomerStoreCreditHistoryItem": {
+      "documentation": {
+        "undocumented": true
+      }
+    },
+    "CustomerToken": {
+      "documentation": {
+        "undocumented": true
+      }
+    },
+    "CustomizableAreaOption": {
+      "documentation": {
+        "undocumented": true
+      }
+    },
+    "CustomizableAreaValue": {
+      "documentation": {
+        "undocumented": true
+      }
+    },
+    "CustomizableCheckboxOption": {
+      "documentation": {
+        "undocumented": true
+      }
+    },
+    "CustomizableCheckboxValue": {
+      "documentation": {
+        "undocumented": true
+      }
+    },
+    "CustomizableDateOption": {
+      "documentation": {
+        "undocumented": true
+      }
+    },
+    "CustomizableDateValue": {
+      "documentation": {
+        "undocumented": true
+      }
+    },
+    "CustomizableDropDownOption": {
+      "documentation": {
+        "undocumented": true
+      }
+    },
+    "CustomizableDropDownValue": {
+      "documentation": {
+        "undocumented": true
+      }
+    },
+    "CustomizableFieldOption": {
+      "documentation": {
+        "undocumented": true
+      }
+    },
+    "CustomizableFieldValue": {
+      "documentation": {
+        "undocumented": true
+      }
+    },
+    "CustomizableFileOption": {
+      "documentation": {
+        "undocumented": true
+      }
+    },
+    "CustomizableFileValue": {
+      "documentation": {
+        "undocumented": true
+      }
+    },
+    "CustomizableMultipleOption": {
+      "documentation": {
+        "undocumented": true
+      }
+    },
+    "CustomizableMultipleValue": {
+      "documentation": {
+        "undocumented": true
+      }
+    },
+    "CustomizableOptionInterface": {
+      "documentation": {
+        "undocumented": true
+      }
+    },
+    "CustomizableProductInterface": {
+      "documentation": {
+        "undocumented": true
+      }
+    },
+    "CustomizableRadioOption": {
+      "documentation": {
+        "undocumented": true
+      }
+    },
+    "CustomizableRadioValue": {
+      "documentation": {
+        "undocumented": true
+      }
+    },
+    "DeleteCompanyRoleOutput": {
+      "documentation": {
+        "undocumented": true
+      }
+    },
+    "DeleteCompanyTeamOutput": {
+      "documentation": {
+        "undocumented": true
+      }
+    },
+    "DeleteCompanyUserOutput": {
+      "documentation": {
+        "undocumented": true
+      }
+    },
+    "DeleteCompareListOutput": {
+      "documentation": {
+        "undocumented": true
+      }
+    },
+    "DeleteNegotiableQuoteOperationFailure": {
+      "documentation": {
+        "undocumented": true
+      }
+    },
+    "DeleteNegotiableQuoteTemplateOutput": {
+      "documentation": {
+        "undocumented": true
+      }
+    },
+    "DeleteNegotiableQuotesOutput": {
+      "documentation": {
+        "undocumented": true
+      }
+    },
+    "DeletePaymentTokenOutput": {
+      "documentation": {
+        "undocumented": true
+      }
+    },
+    "DeletePurchaseOrderApprovalRuleError": {
+      "documentation": {
+        "undocumented": true
+      }
+    },
+    "DeletePurchaseOrderApprovalRuleOutput": {
+      "documentation": {
+        "undocumented": true
+      }
+    },
+    "DeleteRequisitionListItemsOutput": {
+      "documentation": {
+        "undocumented": true
+      }
+    },
+    "DeleteRequisitionListOutput": {
+      "documentation": {
+        "undocumented": true
+      }
+    },
+    "DeleteWishlistOutput": {
+      "documentation": {
+        "undocumented": true
+      }
+    },
+    "Discount": {
+      "documentation": {
+        "undocumented": true
+      }
+    },
+    "DownloadableCartItem": {
+      "documentation": {
+        "undocumented": true
+      }
+    },
+    "DownloadableCreditMemoItem": {
+      "documentation": {
+        "undocumented": true
+      }
+    },
+    "DownloadableInvoiceItem": {
+      "documentation": {
+        "undocumented": true
+      }
+    },
+    "DownloadableItemsLinks": {
+      "documentation": {
+        "undocumented": true
+      }
+    },
+    "DownloadableOrderItem": {
+      "documentation": {
+        "undocumented": true
+      }
+    },
+    "DownloadableProduct": {
+      "documentation": {
+        "undocumented": true
+      }
+    },
+    "DownloadableProductLinks": {
+      "documentation": {
+        "undocumented": true
+      }
+    },
+    "DownloadableProductSamples": {
+      "documentation": {
+        "undocumented": true
+      }
+    },
+    "DownloadableRequisitionListItem": {
+      "documentation": {
+        "undocumented": true
+      }
+    },
+    "DownloadableWishlistItem": {
+      "documentation": {
+        "undocumented": true
+      }
+    },
+    "DuplicateNegotiableQuoteOutput": {
+      "documentation": {
+        "undocumented": true
+      }
+    },
+    "Error": {
+      "documentation": {
+        "undocumented": true
+      }
+    },
+    "ErrorInterface": {
+      "documentation": {
+        "undocumented": true
+      }
+    },
+    "EstimateTotalsOutput": {
+      "documentation": {
+        "undocumented": true
+      }
+    },
+    "ExchangeExternalCustomerTokenOutput": {
+      "documentation": {
+        "undocumented": true
+      }
+    },
+    "ExchangeRate": {
+      "documentation": {
+        "undocumented": true
+      }
+    },
+    "FixedProductTax": {
+      "documentation": {
+        "undocumented": true
+      }
+    },
+    "GenerateCustomerTokenAsAdminOutput": {
+      "documentation": {
+        "undocumented": true
+      }
+    },
+    "GenerateNegotiableQuoteFromTemplateOutput": {
+      "documentation": {
+        "undocumented": true
+      }
+    },
+    "GetPaymentSDKOutput": {
+      "documentation": {
+        "undocumented": true
+      }
+    },
+    "GiftCardAccount": {
+      "documentation": {
+        "undocumented": true
+      }
+    },
+    "GiftCardAmounts": {
+      "documentation": {
+        "undocumented": true
+      }
+    },
+    "GiftCardCartItem": {
+      "documentation": {
+        "undocumented": true
+      }
+    },
+    "GiftCardCreditMemoItem": {
+      "documentation": {
+        "undocumented": true
+      }
+    },
+    "GiftCardInvoiceItem": {
+      "documentation": {
+        "undocumented": true
+      }
+    },
+    "GiftCardItem": {
+      "documentation": {
+        "undocumented": true
+      }
+    },
+    "GiftCardOptions": {
+      "documentation": {
+        "undocumented": true
+      }
+    },
+    "GiftCardOrderItem": {
+      "documentation": {
+        "undocumented": true
+      }
+    },
+    "GiftCardProduct": {
+      "documentation": {
+        "undocumented": true
+      }
+    },
+    "GiftCardRequisitionListItem": {
+      "documentation": {
+        "undocumented": true
+      }
+    },
+    "GiftCardShipmentItem": {
+      "documentation": {
+        "undocumented": true
+      }
+    },
+    "GiftCardWishlistItem": {
+      "documentation": {
+        "undocumented": true
+      }
+    },
+    "GiftMessage": {
+      "documentation": {
+        "undocumented": true
+      }
+    },
+    "GiftOptionsPrices": {
+      "documentation": {
+        "undocumented": true
+      }
+    },
+    "GiftRegistry": {
+      "documentation": {
+        "undocumented": true
+      }
+    },
+    "GiftRegistryDynamicAttribute": {
+      "documentation": {
+        "undocumented": true
+      }
+    },
+    "GiftRegistryDynamicAttributeInterface": {
+      "documentation": {
+        "undocumented": true
+      }
+    },
+    "GiftRegistryDynamicAttributeMetadata": {
+      "documentation": {
+        "undocumented": true
+      }
+    },
+    "GiftRegistryDynamicAttributeMetadataInterface": {
+      "documentation": {
+        "undocumented": true
+      }
+    },
+    "GiftRegistryItem": {
+      "documentation": {
+        "undocumented": true
+      }
+    },
+    "GiftRegistryItemInterface": {
+      "documentation": {
+        "undocumented": true
+      }
+    },
+    "GiftRegistryItemUserErrorInterface": {
+      "documentation": {
+        "undocumented": true
+      }
+    },
+    "GiftRegistryItemUserErrors": {
+      "documentation": {
+        "undocumented": true
+      }
+    },
+    "GiftRegistryItemsUserError": {
+      "documentation": {
+        "undocumented": true
+      }
+    },
+    "GiftRegistryOutput": {
+      "documentation": {
+        "undocumented": true
+      }
+    },
+    "GiftRegistryOutputInterface": {
+      "documentation": {
+        "undocumented": true
+      }
+    },
+    "GiftRegistryRegistrant": {
+      "documentation": {
+        "undocumented": true
+      }
+    },
+    "GiftRegistryRegistrantDynamicAttribute": {
+      "documentation": {
+        "undocumented": true
+      }
+    },
+    "GiftRegistrySearchResult": {
+      "documentation": {
+        "undocumented": true
+      }
+    },
+    "GiftRegistryType": {
+      "documentation": {
+        "undocumented": true
+      }
+    },
+    "GiftWrapping": {
+      "documentation": {
+        "undocumented": true
+      }
+    },
+    "GiftWrappingImage": {
+      "documentation": {
+        "undocumented": true
+      }
+    },
+    "GooglePayButtonStyles": {
+      "documentation": {
+        "undocumented": true
+      }
+    },
+    "GooglePayConfig": {
+      "documentation": {
+        "undocumented": true
+      }
+    },
+    "GroupedProduct": {
+      "documentation": {
+        "undocumented": true
+      }
+    },
+    "GroupedProductItem": {
+      "documentation": {
+        "undocumented": true
+      }
+    },
+    "GroupedProductWishlistItem": {
+      "documentation": {
+        "undocumented": true
+      }
+    },
+    "HostedFieldsConfig": {
+      "documentation": {
+        "undocumented": true
+      }
+    },
+    "ImageSwatchData": {
+      "documentation": {
+        "undocumented": true
+      }
+    },
+    "InsufficientStockError": {
+      "documentation": {
+        "undocumented": true
+      }
+    },
+    "InternalError": {
+      "documentation": {
+        "undocumented": true
+      }
+    },
+    "Invoice": {
+      "documentation": {
+        "undocumented": true
+      }
+    },
+    "InvoiceItem": {
+      "documentation": {
+        "undocumented": true
+      }
+    },
+    "InvoiceItemInterface": {
+      "documentation": {
+        "undocumented": true
+      }
+    },
+    "InvoiceOutput": {
+      "documentation": {
+        "undocumented": true
+      }
+    },
+    "InvoiceTotal": {
+      "documentation": {
+        "undocumented": true
+      }
+    },
+    "IsCompanyAdminEmailAvailableOutput": {
+      "documentation": {
+        "undocumented": true
+      }
+    },
+    "IsCompanyEmailAvailableOutput": {
+      "documentation": {
+        "undocumented": true
+      }
+    },
+    "IsCompanyRoleNameAvailableOutput": {
+      "documentation": {
+        "undocumented": true
+      }
+    },
+    "IsCompanyUserEmailAvailableOutput": {
+      "documentation": {
+        "undocumented": true
+      }
+    },
+    "IsEmailAvailableOutput": {
+      "documentation": {
+        "undocumented": true
+      }
+    },
+    "ItemNote": {
+      "documentation": {
+        "undocumented": true
+      }
+    },
+    "ItemSelectedBundleOption": {
+      "documentation": {
+        "undocumented": true
+      }
+    },
+    "ItemSelectedBundleOptionValue": {
+      "documentation": {
+        "undocumented": true
+      }
+    },
+    "KeyValue": {
+      "documentation": {
+        "undocumented": true
+      }
+    },
+    "MediaGalleryEntry": {
+      "documentation": {
+        "undocumented": true
+      }
+    },
+    "MediaGalleryInterface": {
+      "documentation": {
+        "undocumented": true
+      }
+    },
+    "MessageStyleLogo": {
+      "documentation": {
+        "undocumented": true
+      }
+    },
+    "MessageStyles": {
+      "documentation": {
+        "undocumented": true
+      }
+    },
+    "Money": {
+      "documentation": {
+        "undocumented": true
+      }
+    },
+    "MoveCartItemsToGiftRegistryOutput": {
+      "documentation": {
+        "undocumented": true
+      }
+    },
+    "MoveItemsBetweenRequisitionListsOutput": {
+      "documentation": {
+        "undocumented": true
+      }
+    },
+    "MoveLineItemToRequisitionListOutput": {
+      "documentation": {
+        "undocumented": true
+      }
+    },
+    "MoveProductsBetweenWishlistsOutput": {
+      "documentation": {
+        "undocumented": true
+      }
+    },
+    "Mutation": {
+      "documentation": {
+        "undocumented": true
+      }
+    },
+    "NegotiableQuote": {
+      "documentation": {
+        "undocumented": true
+      }
+    },
+    "NegotiableQuoteAddressCountry": {
+      "documentation": {
+        "undocumented": true
+      }
+    },
+    "NegotiableQuoteAddressInterface": {
+      "documentation": {
+        "undocumented": true
+      }
+    },
+    "NegotiableQuoteAddressRegion": {
+      "documentation": {
+        "undocumented": true
+      }
+    },
+    "NegotiableQuoteBillingAddress": {
+      "documentation": {
+        "undocumented": true
+      }
+    },
+    "NegotiableQuoteComment": {
+      "documentation": {
+        "undocumented": true
+      }
+    },
+    "NegotiableQuoteCustomLogChange": {
+      "documentation": {
+        "undocumented": true
+      }
+    },
+    "NegotiableQuoteHistoryChanges": {
+      "documentation": {
+        "undocumented": true
+      }
+    },
+    "NegotiableQuoteHistoryCommentChange": {
+      "documentation": {
+        "undocumented": true
+      }
+    },
+    "NegotiableQuoteHistoryEntry": {
+      "documentation": {
+        "undocumented": true
+      }
+    },
+    "NegotiableQuoteHistoryExpirationChange": {
+      "documentation": {
+        "undocumented": true
+      }
+    },
+    "NegotiableQuoteHistoryProductsRemovedChange": {
+      "documentation": {
+        "undocumented": true
+      }
+    },
+    "NegotiableQuoteHistoryStatusChange": {
+      "documentation": {
+        "undocumented": true
+      }
+    },
+    "NegotiableQuoteHistoryStatusesChange": {
+      "documentation": {
+        "undocumented": true
+      }
+    },
+    "NegotiableQuoteHistoryTotalChange": {
+      "documentation": {
+        "undocumented": true
+      }
+    },
+    "NegotiableQuoteInvalidStateError": {
+      "documentation": {
+        "undocumented": true
+      }
+    },
+    "NegotiableQuoteReferenceDocumentLink": {
+      "documentation": {
+        "undocumented": true
+      }
+    },
+    "NegotiableQuoteShippingAddress": {
+      "documentation": {
+        "undocumented": true
+      }
+    },
+    "NegotiableQuoteTemplate": {
+      "documentation": {
+        "undocumented": true
+      }
+    },
+    "NegotiableQuoteTemplateGridItem": {
+      "documentation": {
+        "undocumented": true
+      }
+    },
+    "NegotiableQuoteTemplatesOutput": {
+      "documentation": {
+        "undocumented": true
+      }
+    },
+    "NegotiableQuoteUidNonFatalResultInterface": {
+      "documentation": {
+        "undocumented": true
+      }
+    },
+    "NegotiableQuoteUidOperationSuccess": {
+      "documentation": {
+        "undocumented": true
+      }
+    },
+    "NegotiableQuoteUser": {
+      "documentation": {
+        "undocumented": true
+      }
+    },
+    "NegotiableQuotesOutput": {
+      "documentation": {
+        "undocumented": true
+      }
+    },
+    "NoSuchEntityUidError": {
+      "documentation": {
+        "undocumented": true
+      }
+    },
+    "OopePaymentMethodConfig": {
+      "documentation": {
+        "undocumented": true
+      }
+    },
+    "Order": {
+      "documentation": {
+        "undocumented": true
+      }
+    },
+    "OrderAddress": {
+      "documentation": {
+        "undocumented": true
+      }
+    },
+    "OrderCustomerInfo": {
+      "documentation": {
+        "undocumented": true
+      }
+    },
+    "OrderItem": {
+      "documentation": {
+        "undocumented": true
+      }
+    },
+    "OrderItemInterface": {
+      "documentation": {
+        "undocumented": true
+      }
+    },
+    "OrderItemOption": {
+      "documentation": {
+        "undocumented": true
+      }
+    },
+    "OrderItemPrices": {
+      "documentation": {
+        "undocumented": true
+      }
+    },
+    "OrderPaymentMethod": {
+      "documentation": {
+        "undocumented": true
+      }
+    },
+    "OrderShipment": {
+      "documentation": {
+        "undocumented": true
+      }
+    },
+    "OrderTotal": {
+      "documentation": {
+        "undocumented": true
+      }
+    },
+    "PaymentCommonConfig": {
+      "documentation": {
+        "undocumented": true
+      }
+    },
+    "PaymentConfigItem": {
+      "documentation": {
+        "undocumented": true
+      }
+    },
+    "PaymentConfigOutput": {
+      "documentation": {
+        "undocumented": true
+      }
+    },
+    "PaymentOrderOutput": {
+      "documentation": {
+        "undocumented": true
+      }
+    },
+    "PaymentSDKParamsItem": {
+      "documentation": {
+        "undocumented": true
+      }
+    },
+    "PaymentSourceDetails": {
+      "documentation": {
+        "undocumented": true
+      }
+    },
+    "PaymentSourceOutput": {
+      "documentation": {
+        "undocumented": true
+      }
+    },
+    "PaymentToken": {
+      "documentation": {
+        "undocumented": true
+      }
+    },
+    "PhysicalProductInterface": {
+      "documentation": {
+        "undocumented": true
+      }
+    },
+    "PickupLocation": {
+      "documentation": {
+        "undocumented": true
+      }
+    },
+    "PickupLocations": {
+      "documentation": {
+        "undocumented": true
+      }
+    },
+    "PlaceNegotiableQuoteOrderOutput": {
+      "documentation": {
+        "undocumented": true
+      }
+    },
+    "PlaceOrderError": {
+      "documentation": {
+        "undocumented": true
+      }
+    },
+    "PlaceOrderForPurchaseOrderOutput": {
+      "documentation": {
+        "undocumented": true
+      }
+    },
+    "PlaceOrderOutput": {
+      "documentation": {
+        "undocumented": true
+      }
+    },
+    "PlacePurchaseOrderOutput": {
+      "documentation": {
+        "undocumented": true
+      }
+    },
+    "PriceDetails": {
+      "documentation": {
+        "undocumented": true
+      }
+    },
+    "PriceRange": {
+      "documentation": {
+        "undocumented": true
+      }
+    },
+    "ProductAttribute": {
+      "documentation": {
+        "undocumented": true
+      }
+    },
+    "ProductCustomAttributes": {
+      "documentation": {
+        "undocumented": true
+      }
+    },
+    "ProductDiscount": {
+      "documentation": {
+        "undocumented": true
+      }
+    },
+    "ProductImage": {
+      "documentation": {
+        "undocumented": true
+      }
+    },
+    "ProductInterface": {
+      "documentation": {
+        "undocumented": true
+      }
+    },
+    "ProductLinks": {
+      "documentation": {
+        "undocumented": true
+      }
+    },
+    "ProductLinksInterface": {
+      "documentation": {
+        "undocumented": true
+      }
+    },
+    "ProductMediaGalleryEntriesAssetImage": {
+      "documentation": {
+        "undocumented": true
+      }
+    },
+    "ProductMediaGalleryEntriesAssetVideo": {
+      "documentation": {
+        "undocumented": true
+      }
+    },
+    "ProductMediaGalleryEntriesContent": {
+      "documentation": {
+        "undocumented": true
+      }
+    },
+    "ProductMediaGalleryEntriesVideoContent": {
+      "documentation": {
+        "undocumented": true
+      }
+    },
+    "ProductPrice": {
+      "documentation": {
+        "undocumented": true
+      }
+    },
+    "ProductVideo": {
+      "documentation": {
+        "undocumented": true
+      }
+    },
+    "ProductViewInputOption": {
+      "documentation": {
+        "undocumented": true
+      }
+    },
+    "ProductViewInputOptionImageSize": {
+      "documentation": {
+        "undocumented": true
+      }
+    },
+    "ProductViewInputOptionRange": {
+      "documentation": {
+        "undocumented": true
+      }
+    },
+    "PurchaseOrder": {
+      "documentation": {
+        "undocumented": true
+      }
+    },
+    "PurchaseOrderActionError": {
+      "documentation": {
+        "undocumented": true
+      }
+    },
+    "PurchaseOrderApprovalFlowEvent": {
+      "documentation": {
+        "undocumented": true
+      }
+    },
+    "PurchaseOrderApprovalRule": {
+      "documentation": {
+        "undocumented": true
+      }
+    },
+    "PurchaseOrderApprovalRuleConditionAmount": {
+      "documentation": {
+        "undocumented": true
+      }
+    },
+    "PurchaseOrderApprovalRuleConditionInterface": {
+      "documentation": {
+        "undocumented": true
+      }
+    },
+    "PurchaseOrderApprovalRuleConditionQuantity": {
+      "documentation": {
+        "undocumented": true
+      }
+    },
+    "PurchaseOrderApprovalRuleMetadata": {
+      "documentation": {
+        "undocumented": true
+      }
+    },
+    "PurchaseOrderApprovalRules": {
+      "documentation": {
+        "undocumented": true
+      }
+    },
+    "PurchaseOrderComment": {
+      "documentation": {
+        "undocumented": true
+      }
+    },
+    "PurchaseOrderHistoryItem": {
+      "documentation": {
+        "undocumented": true
+      }
+    },
+    "PurchaseOrderRuleApprovalFlow": {
+      "documentation": {
+        "undocumented": true
+      }
+    },
+    "PurchaseOrders": {
+      "documentation": {
+        "undocumented": true
+      }
+    },
+    "PurchaseOrdersActionOutput": {
+      "documentation": {
+        "undocumented": true
+      }
+    },
+    "QuoteTemplateNotificationMessage": {
+      "documentation": {
+        "undocumented": true
+      }
+    },
+    "ReCaptchaConfigOutput": {
+      "documentation": {
+        "undocumented": true
+      }
+    },
+    "ReCaptchaConfiguration": {
+      "documentation": {
+        "undocumented": true
+      }
+    },
+    "ReCaptchaConfigurationV3": {
+      "documentation": {
+        "undocumented": true
+      }
+    },
+    "Region": {
+      "documentation": {
+        "undocumented": true
+      }
+    },
+    "RemoveCouponFromCartOutput": {
+      "documentation": {
+        "undocumented": true
+      }
+    },
+    "RemoveGiftCardFromCartOutput": {
+      "documentation": {
+        "undocumented": true
+      }
+    },
+    "RemoveGiftRegistryItemsOutput": {
+      "documentation": {
+        "undocumented": true
+      }
+    },
+    "RemoveGiftRegistryOutput": {
+      "documentation": {
+        "undocumented": true
+      }
+    },
+    "RemoveGiftRegistryRegistrantsOutput": {
+      "documentation": {
+        "undocumented": true
+      }
+    },
+    "RemoveItemFromCartOutput": {
+      "documentation": {
+        "undocumented": true
+      }
+    },
+    "RemoveNegotiableQuoteItemsOutput": {
+      "documentation": {
+        "undocumented": true
+      }
+    },
+    "RemoveProductsFromWishlistOutput": {
+      "documentation": {
+        "undocumented": true
+      }
+    },
+    "RemoveReturnTrackingOutput": {
+      "documentation": {
+        "undocumented": true
+      }
+    },
+    "RemoveRewardPointsFromCartOutput": {
+      "documentation": {
+        "undocumented": true
+      }
+    },
+    "RemoveStoreCreditFromCartOutput": {
+      "documentation": {
+        "undocumented": true
+      }
+    },
+    "RenameNegotiableQuoteOutput": {
+      "documentation": {
+        "undocumented": true
+      }
+    },
+    "ReorderItemsOutput": {
+      "documentation": {
+        "undocumented": true
+      }
+    },
+    "RequestNegotiableQuoteOutput": {
+      "documentation": {
+        "undocumented": true
+      }
+    },
+    "RequestReturnOutput": {
+      "documentation": {
+        "undocumented": true
+      }
+    },
+    "RequisitionList": {
+      "documentation": {
+        "undocumented": true
+      }
+    },
+    "RequisitionListItemInterface": {
+      "documentation": {
+        "undocumented": true
+      }
+    },
+    "RequisitionLists": {
+      "documentation": {
+        "undocumented": true
+      }
+    },
+    "RequistionListItems": {
+      "documentation": {
+        "undocumented": true
+      }
+    },
+    "Return": {
+      "documentation": {
+        "undocumented": true
+      }
+    },
+    "ReturnComment": {
+      "documentation": {
+        "undocumented": true
+      }
+    },
+    "ReturnCustomAttribute": {
+      "documentation": {
+        "undocumented": true
+      }
+    },
+    "ReturnCustomer": {
+      "documentation": {
+        "undocumented": true
+      }
+    },
+    "ReturnItem": {
+      "documentation": {
+        "undocumented": true
+      }
+    },
+    "ReturnItemAttributeMetadata": {
+      "documentation": {
+        "undocumented": true
+      }
+    },
+    "ReturnShipping": {
+      "documentation": {
+        "undocumented": true
+      }
+    },
+    "ReturnShippingAddress": {
+      "documentation": {
+        "undocumented": true
+      }
+    },
+    "ReturnShippingCarrier": {
+      "documentation": {
+        "undocumented": true
+      }
+    },
+    "ReturnShippingTracking": {
+      "documentation": {
+        "undocumented": true
+      }
+    },
+    "ReturnShippingTrackingStatus": {
+      "documentation": {
+        "undocumented": true
+      }
+    },
+    "Returns": {
+      "documentation": {
+        "undocumented": true
+      }
+    },
+    "RevokeCustomerTokenOutput": {
+      "documentation": {
+        "undocumented": true
+      }
+    },
+    "RewardPoints": {
+      "documentation": {
+        "undocumented": true
+      }
+    },
+    "RewardPointsAmount": {
+      "documentation": {
+        "undocumented": true
+      }
+    },
+    "RewardPointsBalanceHistoryItem": {
+      "documentation": {
+        "undocumented": true
+      }
+    },
+    "RewardPointsExchangeRates": {
+      "documentation": {
+        "undocumented": true
+      }
+    },
+    "RewardPointsRate": {
+      "documentation": {
+        "undocumented": true
+      }
+    },
+    "RewardPointsSubscriptionStatus": {
+      "documentation": {
+        "undocumented": true
+      }
+    },
+    "SDKParams": {
+      "documentation": {
+        "undocumented": true
+      }
+    },
+    "SalesCommentItem": {
+      "documentation": {
+        "undocumented": true
+      }
+    },
+    "SalesItemInterface": {
+      "documentation": {
+        "undocumented": true
+      }
+    },
+    "SearchSuggestion": {
+      "documentation": {
+        "undocumented": true
+      }
+    },
+    "SelectedBundleOption": {
+      "documentation": {
+        "undocumented": true
+      }
+    },
+    "SelectedBundleOptionValue": {
+      "documentation": {
+        "undocumented": true
+      }
+    },
+    "SelectedConfigurableOption": {
+      "documentation": {
+        "undocumented": true
+      }
+    },
+    "SelectedCustomizableOption": {
+      "documentation": {
+        "undocumented": true
+      }
+    },
+    "SelectedCustomizableOptionValue": {
+      "documentation": {
+        "undocumented": true
+      }
+    },
+    "SelectedPaymentMethod": {
+      "documentation": {
+        "undocumented": true
+      }
+    },
+    "SelectedShippingMethod": {
+      "documentation": {
+        "undocumented": true
+      }
+    },
+    "SendNegotiableQuoteForReviewOutput": {
+      "documentation": {
+        "undocumented": true
+      }
+    },
+    "SetBillingAddressOnCartOutput": {
+      "documentation": {
+        "undocumented": true
+      }
+    },
+    "SetCustomAttributesOnCompanyOutput": {
+      "documentation": {
+        "undocumented": true
+      }
+    },
+    "SetCustomAttributesOnNegotiableQuoteOutput": {
+      "documentation": {
+        "undocumented": true
+      }
+    },
+    "SetGiftOptionsOnCartOutput": {
+      "documentation": {
+        "undocumented": true
+      }
+    },
+    "SetGuestEmailOnCartOutput": {
+      "documentation": {
+        "undocumented": true
+      }
+    },
+    "SetLineItemNoteOutput": {
+      "documentation": {
+        "undocumented": true
+      }
+    },
+    "SetNegotiableQuoteBillingAddressOutput": {
+      "documentation": {
+        "undocumented": true
+      }
+    },
+    "SetNegotiableQuotePaymentMethodOutput": {
+      "documentation": {
+        "undocumented": true
+      }
+    },
+    "SetNegotiableQuoteShippingAddressOutput": {
+      "documentation": {
+        "undocumented": true
+      }
+    },
+    "SetNegotiableQuoteShippingMethodsOutput": {
+      "documentation": {
+        "undocumented": true
+      }
+    },
+    "SetPaymentMethodOnCartOutput": {
+      "documentation": {
+        "undocumented": true
+      }
+    },
+    "SetShippingAddressesOnCartOutput": {
+      "documentation": {
+        "undocumented": true
+      }
+    },
+    "SetShippingMethodsOnCartOutput": {
+      "documentation": {
+        "undocumented": true
+      }
+    },
+    "ShareGiftRegistryOutput": {
+      "documentation": {
+        "undocumented": true
+      }
+    },
+    "ShipmentItem": {
+      "documentation": {
+        "undocumented": true
+      }
+    },
+    "ShipmentItemInterface": {
+      "documentation": {
+        "undocumented": true
+      }
+    },
+    "ShipmentTracking": {
+      "documentation": {
+        "undocumented": true
+      }
+    },
+    "ShippingAdditionalData": {
+      "documentation": {
+        "undocumented": true
+      }
+    },
+    "ShippingCartAddress": {
+      "documentation": {
+        "undocumented": true
+      }
+    },
+    "ShippingDiscount": {
+      "documentation": {
+        "undocumented": true
+      }
+    },
+    "ShippingHandling": {
+      "documentation": {
+        "undocumented": true
+      }
+    },
+    "SimpleCartItem": {
+      "documentation": {
+        "undocumented": true
+      }
+    },
+    "SimpleProduct": {
+      "documentation": {
+        "undocumented": true
+      }
+    },
+    "SimpleRequisitionListItem": {
+      "documentation": {
+        "undocumented": true
+      }
+    },
+    "SimpleWishlistItem": {
+      "documentation": {
+        "undocumented": true
+      }
+    },
+    "SmartButtonsConfig": {
+      "documentation": {
+        "undocumented": true
+      }
+    },
+    "SortField": {
+      "documentation": {
+        "undocumented": true
+      }
+    },
+    "SortFields": {
+      "documentation": {
+        "undocumented": true
+      }
+    },
+    "StoreConfig": {
+      "documentation": {
+        "undocumented": true
+      }
+    },
+    "StorefrontProperties": {
+      "documentation": {
+        "undocumented": true
+      }
+    },
+    "SubscribeEmailToNewsletterOutput": {
+      "documentation": {
+        "undocumented": true
+      }
+    },
+    "SwatchData": {
+      "documentation": {
+        "undocumented": true
+      }
+    },
+    "SwatchDataInterface": {
+      "documentation": {
+        "undocumented": true
+      }
+    },
+    "TaxItem": {
+      "documentation": {
+        "undocumented": true
+      }
+    },
+    "TextSwatchData": {
+      "documentation": {
+        "undocumented": true
+      }
+    },
+    "TierPrice": {
+      "documentation": {
+        "undocumented": true
+      }
+    },
+    "UpdateCartItemsOutput": {
+      "documentation": {
+        "undocumented": true
+      }
+    },
+    "UpdateCompanyOutput": {
+      "documentation": {
+        "undocumented": true
+      }
+    },
+    "UpdateCompanyRoleOutput": {
+      "documentation": {
+        "undocumented": true
+      }
+    },
+    "UpdateCompanyStructureOutput": {
+      "documentation": {
+        "undocumented": true
+      }
+    },
+    "UpdateCompanyTeamOutput": {
+      "documentation": {
+        "undocumented": true
+      }
+    },
+    "UpdateCompanyUserOutput": {
+      "documentation": {
+        "undocumented": true
+      }
+    },
+    "UpdateGiftRegistryItemsOutput": {
+      "documentation": {
+        "undocumented": true
+      }
+    },
+    "UpdateGiftRegistryOutput": {
+      "documentation": {
+        "undocumented": true
+      }
+    },
+    "UpdateGiftRegistryRegistrantsOutput": {
+      "documentation": {
+        "undocumented": true
+      }
+    },
+    "UpdateNegotiableQuoteItemsQuantityOutput": {
+      "documentation": {
+        "undocumented": true
+      }
+    },
+    "UpdateNegotiableQuoteTemplateItemsQuantityOutput": {
+      "documentation": {
+        "undocumented": true
+      }
+    },
+    "UpdateProductsInWishlistOutput": {
+      "documentation": {
+        "undocumented": true
+      }
+    },
+    "UpdateRequisitionListItemsOutput": {
+      "documentation": {
+        "undocumented": true
+      }
+    },
+    "UpdateRequisitionListOutput": {
+      "documentation": {
+        "undocumented": true
+      }
+    },
+    "UpdateWishlistOutput": {
+      "documentation": {
+        "undocumented": true
+      }
+    },
+    "UserCompaniesOutput": {
+      "documentation": {
+        "undocumented": true
+      }
+    },
+    "ValidatePurchaseOrderError": {
+      "documentation": {
+        "undocumented": true
+      }
+    },
+    "ValidatePurchaseOrdersOutput": {
+      "documentation": {
+        "undocumented": true
+      }
+    },
+    "ValidationRule": {
+      "documentation": {
+        "undocumented": true
+      }
+    },
+    "VaultConfigOutput": {
+      "documentation": {
+        "undocumented": true
+      }
+    },
+    "VaultCreditCardConfig": {
+      "documentation": {
+        "undocumented": true
+      }
+    },
+    "VirtualCartItem": {
+      "documentation": {
+        "undocumented": true
+      }
+    },
+    "VirtualProduct": {
+      "documentation": {
+        "undocumented": true
+      }
+    },
+    "VirtualRequisitionListItem": {
+      "documentation": {
+        "undocumented": true
+      }
+    },
+    "VirtualWishlistItem": {
+      "documentation": {
+        "undocumented": true
+      }
+    },
+    "WishListUserInputError": {
+      "documentation": {
+        "undocumented": true
+      }
+    },
+    "Wishlist": {
+      "documentation": {
+        "undocumented": true
+      }
+    },
+    "WishlistCartUserInputError": {
+      "documentation": {
+        "undocumented": true
+      }
+    },
+    "WishlistItemInterface": {
+      "documentation": {
+        "undocumented": true
+      }
+    },
+    "WishlistItems": {
+      "documentation": {
+        "undocumented": true
+      }
+    },
+    "Query": {
+      "fields": {
+        "attributesForm": {
+          "documentation": {
+            "undocumented": true
+          }
         },
-        "Query": {
-            "fields": {
-                "categories": {
-                    "documentation": { "undocumented": true }
-                }
-            }
+        "attributesList": {
+          "documentation": {
+            "undocumented": true
+          }
+        },
+        "attributesSearch": {
+          "documentation": {
+            "undocumented": true
+          }
+        },
+        "availableStores": {
+          "documentation": {
+            "undocumented": true
+          }
+        },
+        "cart": {
+          "documentation": {
+            "undocumented": true
+          }
+        },
+        "categories": {
+          "documentation": {
+            "undocumented": true
+          }
+        },
+        "checkoutAgreements": {
+          "documentation": {
+            "undocumented": true
+          }
+        },
+        "categoryView": {
+          "documentation": {
+            "undocumented": true
+          }
+        },
+        "company": {
+          "documentation": {
+            "undocumented": true
+          }
+        },
+        "compareList": {
+          "documentation": {
+            "undocumented": true
+          }
+        },
+        "countries": {
+          "documentation": {
+            "undocumented": true
+          }
+        },
+        "country": {
+          "documentation": {
+            "undocumented": true
+          }
+        },
+        "currency": {
+          "documentation": {
+            "undocumented": true
+          }
+        },
+        "customerDownloadableProducts": {
+          "documentation": {
+            "undocumented": true
+          }
+        },
+        "customerGroup": {
+          "documentation": {
+            "undocumented": true
+          }
+        },
+        "customer": {
+          "documentation": {
+            "undocumented": true
+          }
+        },
+        "customerCart": {
+          "documentation": {
+            "undocumented": true
+          }
+        },
+        "customerDownloads": {
+          "documentation": {
+            "undocumented": true
+          }
+        },
+        "customerGroups": {
+          "documentation": {
+            "undocumented": true
+          }
+        },
+        "customerPaymentTokens": {
+          "documentation": {
+            "undocumented": true
+          }
+        },
+        "customerSegments": {
+          "documentation": {
+            "undocumented": true
+          }
+        },
+        "getPaymentConfig": {
+          "documentation": {
+            "undocumented": true
+          }
+        },
+        "getPaymentOrder": {
+          "documentation": {
+            "undocumented": true
+          }
+        },
+        "getPaymentSDK": {
+          "documentation": {
+            "undocumented": true
+          }
+        },
+        "getVaultConfig": {
+          "documentation": {
+            "undocumented": true
+          }
+        },
+        "giftCardAccount": {
+          "documentation": {
+            "undocumented": true
+          }
+        },
+        "giftRegistry": {
+          "documentation": {
+            "undocumented": true
+          }
+        },
+        "giftRegistryEmailSearch": {
+          "documentation": {
+            "undocumented": true
+          }
+        },
+        "giftRegistryIdSearch": {
+          "documentation": {
+            "undocumented": true
+          }
+        },
+        "giftRegistryTypeSearch": {
+          "documentation": {
+            "undocumented": true
+          }
+        },
+        "giftRegistryTypes": {
+          "documentation": {
+            "undocumented": true
+          }
+        },
+        "guestOrder": {
+          "documentation": {
+            "undocumented": true
+          }
+        },
+        "guestOrderByToken": {
+          "documentation": {
+            "undocumented": true
+          }
+        },
+        "guestOrderByTokenSearch": {
+          "documentation": {
+            "undocumented": true
+          }
+        },
+        "isCompanyAdminEmailAvailable": {
+          "documentation": {
+            "undocumented": true
+          }
+        },
+        "isCompanyEmailAvailable": {
+          "documentation": {
+            "undocumented": true
+          }
+        },
+        "isCompanyRoleNameAvailable": {
+          "documentation": {
+            "undocumented": true
+          }
+        },
+        "isCompanyUserEmailAvailable": {
+          "documentation": {
+            "undocumented": true
+          }
+        },
+        "isEmailAvailable": {
+          "documentation": {
+            "undocumented": true
+          }
+        },
+        "negotiableQuote": {
+          "documentation": {
+            "undocumented": true
+          }
+        },
+        "negotiableQuoteTemplate": {
+          "documentation": {
+            "undocumented": true
+          }
+        },
+        "negotiableQuoteTemplates": {
+          "documentation": {
+            "undocumented": true
+          }
+        },
+        "negotiableQuotes": {
+          "documentation": {
+            "undocumented": true
+          }
+        },
+        "pickupLocations": {
+          "documentation": {
+            "undocumented": true
+          }
+        },
+        "recaptchaFormConfig": {
+          "documentation": {
+            "undocumented": true
+          }
+        },
+        "recaptchaV3Config": {
+          "documentation": {
+            "undocumented": true
+          }
+        },
+        "storeConfig": {
+          "documentation": {
+            "undocumented": true
+          }
         }
+      }
     }
+  },
+  "INPUT_OBJECT": {
+    "AcceptNegotiableQuoteTemplateInput": {
+      "documentation": {
+        "undocumented": true
+      }
+    },
+    "AddDownloadableProductsToCartInput": {
+      "documentation": {
+        "undocumented": true
+      }
+    },
+    "AddGiftRegistryItemInput": {
+      "documentation": {
+        "undocumented": true
+      }
+    },
+    "AddGiftRegistryRegistrantInput": {
+      "documentation": {
+        "undocumented": true
+      }
+    },
+    "AddProductsToCompareListInput": {
+      "documentation": {
+        "undocumented": true
+      }
+    },
+    "AddPurchaseOrderCommentInput": {
+      "documentation": {
+        "undocumented": true
+      }
+    },
+    "AddPurchaseOrderItemsToCartInput": {
+      "documentation": {
+        "undocumented": true
+      }
+    },
+    "AddReturnCommentInput": {
+      "documentation": {
+        "undocumented": true
+      }
+    },
+    "AddReturnTrackingInput": {
+      "documentation": {
+        "undocumented": true
+      }
+    },
+    "ApplePayMethodInput": {
+      "documentation": {
+        "undocumented": true
+      }
+    },
+    "ApplyCouponToCartInput": {
+      "documentation": {
+        "undocumented": true
+      }
+    },
+    "ApplyCouponsToCartInput": {
+      "documentation": {
+        "undocumented": true
+      }
+    },
+    "ApplyGiftCardToCartInput": {
+      "documentation": {
+        "undocumented": true
+      }
+    },
+    "ApplyStoreCreditToCartInput": {
+      "documentation": {
+        "undocumented": true
+      }
+    },
+    "AreaInput": {
+      "documentation": {
+        "undocumented": true
+      }
+    },
+    "AttributeFilterInput": {
+      "documentation": {
+        "undocumented": true
+      }
+    },
+    "AttributeInput": {
+      "documentation": {
+        "undocumented": true
+      }
+    },
+    "AttributeInputSelectedOption": {
+      "documentation": {
+        "undocumented": true
+      }
+    },
+    "AttributeValueInput": {
+      "documentation": {
+        "undocumented": true
+      }
+    },
+    "BillingAddressInput": {
+      "documentation": {
+        "undocumented": true
+      }
+    },
+    "BillingAddressPaymentSourceInput": {
+      "documentation": {
+        "undocumented": true
+      }
+    },
+    "BundleOptionInput": {
+      "documentation": {
+        "undocumented": true
+      }
+    },
+    "CancelNegotiableQuoteTemplateInput": {
+      "documentation": {
+        "undocumented": true
+      }
+    },
+    "CancelOrderInput": {
+      "documentation": {
+        "undocumented": true
+      }
+    },
+    "CardPaymentSourceInput": {
+      "documentation": {
+        "undocumented": true
+      }
+    },
+    "CartAddressInput": {
+      "documentation": {
+        "undocumented": true
+      }
+    },
+    "CartCustomAttributesInput": {
+      "documentation": {
+        "undocumented": true
+      }
+    },
+    "CartItemCustomAttributesInput": {
+      "documentation": {
+        "undocumented": true
+      }
+    },
+    "CartItemInput": {
+      "documentation": {
+        "undocumented": true
+      }
+    },
+    "CartItemUpdateInput": {
+      "documentation": {
+        "undocumented": true
+      }
+    },
+    "CloseNegotiableQuotesInput": {
+      "documentation": {
+        "undocumented": true
+      }
+    },
+    "CompaniesSortInput": {
+      "documentation": {
+        "undocumented": true
+      }
+    },
+    "CompanyAdminInput": {
+      "documentation": {
+        "undocumented": true
+      }
+    },
+    "CompanyCreateInput": {
+      "documentation": {
+        "undocumented": true
+      }
+    },
+    "CompanyCreditHistoryFilterInput": {
+      "documentation": {
+        "undocumented": true
+      }
+    },
+    "CompanyInvitationInput": {
+      "documentation": {
+        "undocumented": true
+      }
+    },
+    "CompanyInvitationUserInput": {
+      "documentation": {
+        "undocumented": true
+      }
+    },
+    "CompanyLegalAddressCreateInput": {
+      "documentation": {
+        "undocumented": true
+      }
+    },
+    "CompanyLegalAddressUpdateInput": {
+      "documentation": {
+        "undocumented": true
+      }
+    },
+    "CompanyRoleCreateInput": {
+      "documentation": {
+        "undocumented": true
+      }
+    },
+    "CompanyRoleUpdateInput": {
+      "documentation": {
+        "undocumented": true
+      }
+    },
+    "CompanyStructureUpdateInput": {
+      "documentation": {
+        "undocumented": true
+      }
+    },
+    "CompanyTeamCreateInput": {
+      "documentation": {
+        "undocumented": true
+      }
+    },
+    "CompanyTeamUpdateInput": {
+      "documentation": {
+        "undocumented": true
+      }
+    },
+    "CompanyUpdateInput": {
+      "documentation": {
+        "undocumented": true
+      }
+    },
+    "CompanyUserCreateInput": {
+      "documentation": {
+        "undocumented": true
+      }
+    },
+    "CompanyUserUpdateInput": {
+      "documentation": {
+        "undocumented": true
+      }
+    },
+    "CompanyUsersFilterInput": {
+      "documentation": {
+        "undocumented": true
+      }
+    },
+    "ConfirmCancelOrderInput": {
+      "documentation": {
+        "undocumented": true
+      }
+    },
+    "ConfirmEmailInput": {
+      "documentation": {
+        "undocumented": true
+      }
+    },
+    "ConfirmReturnInput": {
+      "documentation": {
+        "undocumented": true
+      }
+    },
+    "ContactUsInput": {
+      "documentation": {
+        "undocumented": true
+      }
+    },
+    "CopyItemsBetweenRequisitionListsInput": {
+      "documentation": {
+        "undocumented": true
+      }
+    },
+    "CreateCompareListInput": {
+      "documentation": {
+        "undocumented": true
+      }
+    },
+    "CreateGiftRegistryInput": {
+      "documentation": {
+        "undocumented": true
+      }
+    },
+    "CreateGuestCartInput": {
+      "documentation": {
+        "undocumented": true
+      }
+    },
+    "CreatePaymentOrderInput": {
+      "documentation": {
+        "undocumented": true
+      }
+    },
+    "CreatePurchaseOrderApprovalRuleConditionAmountInput": {
+      "documentation": {
+        "undocumented": true
+      }
+    },
+    "CreatePurchaseOrderApprovalRuleConditionInput": {
+      "documentation": {
+        "undocumented": true
+      }
+    },
+    "CreateRequisitionListInput": {
+      "documentation": {
+        "undocumented": true
+      }
+    },
+    "CreateVaultCardPaymentTokenInput": {
+      "documentation": {
+        "undocumented": true
+      }
+    },
+    "CreateVaultCardSetupTokenInput": {
+      "documentation": {
+        "undocumented": true
+      }
+    },
+    "CreateWishlistInput": {
+      "documentation": {
+        "undocumented": true
+      }
+    },
+    "CreditMemoCustomAttributesInput": {
+      "documentation": {
+        "undocumented": true
+      }
+    },
+    "CreditMemoItemCustomAttributesInput": {
+      "documentation": {
+        "undocumented": true
+      }
+    },
+    "CustomAttributeInput": {
+      "documentation": {
+        "undocumented": true
+      }
+    },
+    "CustomerAddressAttributeInput": {
+      "documentation": {
+        "undocumented": true
+      }
+    },
+    "CustomerAddressInput": {
+      "documentation": {
+        "undocumented": true
+      }
+    },
+    "CustomerAddressRegionInput": {
+      "documentation": {
+        "undocumented": true
+      }
+    },
+    "CustomerCreateInput": {
+      "documentation": {
+        "undocumented": true
+      }
+    },
+    "CustomerInput": {
+      "documentation": {
+        "undocumented": true
+      }
+    },
+    "CustomerOrderSortInput": {
+      "documentation": {
+        "undocumented": true
+      }
+    },
+    "CustomerOrdersFilterInput": {
+      "documentation": {
+        "undocumented": true
+      }
+    },
+    "CustomerUpdateInput": {
+      "documentation": {
+        "undocumented": true
+      }
+    },
+    "CustomizableOptionInput": {
+      "documentation": {
+        "undocumented": true
+      }
+    },
+    "DeleteNegotiableQuoteTemplateInput": {
+      "documentation": {
+        "undocumented": true
+      }
+    },
+    "DeleteNegotiableQuotesInput": {
+      "documentation": {
+        "undocumented": true
+      }
+    },
+    "DeletePurchaseOrderApprovalRuleInput": {
+      "documentation": {
+        "undocumented": true
+      }
+    },
+    "DownloadableProductCartItemInput": {
+      "documentation": {
+        "undocumented": true
+      }
+    },
+    "DownloadableProductLinksInput": {
+      "documentation": {
+        "undocumented": true
+      }
+    },
+    "DuplicateNegotiableQuoteInput": {
+      "documentation": {
+        "undocumented": true
+      }
+    },
+    "EnteredCustomAttributeInput": {
+      "documentation": {
+        "undocumented": true
+      }
+    },
+    "EnteredOptionInput": {
+      "documentation": {
+        "undocumented": true
+      }
+    },
+    "EstimateAddressInput": {
+      "documentation": {
+        "undocumented": true
+      }
+    },
+    "EstimateTotalsInput": {
+      "documentation": {
+        "undocumented": true
+      }
+    },
+    "ExchangeExternalCustomerTokenInput": {
+      "documentation": {
+        "undocumented": true
+      }
+    },
+    "FilterEqualTypeInput": {
+      "documentation": {
+        "undocumented": true
+      }
+    },
+    "FilterMatchTypeInput": {
+      "documentation": {
+        "undocumented": true
+      }
+    },
+    "FilterRangeTypeInput": {
+      "documentation": {
+        "undocumented": true
+      }
+    },
+    "FilterStringTypeInput": {
+      "documentation": {
+        "undocumented": true
+      }
+    },
+    "FilterTypeInput": {
+      "documentation": {
+        "undocumented": true
+      }
+    },
+    "GenerateCustomerTokenAsAdminInput": {
+      "documentation": {
+        "undocumented": true
+      }
+    },
+    "GenerateNegotiableQuoteFromTemplateInput": {
+      "documentation": {
+        "undocumented": true
+      }
+    },
+    "GiftCardAccountInput": {
+      "documentation": {
+        "undocumented": true
+      }
+    },
+    "GiftMessageInput": {
+      "documentation": {
+        "undocumented": true
+      }
+    },
+    "GiftRegistryDynamicAttributeInput": {
+      "documentation": {
+        "undocumented": true
+      }
+    },
+    "GiftRegistryShippingAddressInput": {
+      "documentation": {
+        "undocumented": true
+      }
+    },
+    "GooglePayMethodInput": {
+      "documentation": {
+        "undocumented": true
+      }
+    },
+    "GuestOrderCancelInput": {
+      "documentation": {
+        "undocumented": true
+      }
+    },
+    "GuestOrderInformationInput": {
+      "documentation": {
+        "undocumented": true
+      }
+    },
+    "HostedFieldsInput": {
+      "documentation": {
+        "undocumented": true
+      }
+    },
+    "InvoiceCustomAttributesInput": {
+      "documentation": {
+        "undocumented": true
+      }
+    },
+    "InvoiceItemCustomAttributesInput": {
+      "documentation": {
+        "undocumented": true
+      }
+    },
+    "LineItemNoteInput": {
+      "documentation": {
+        "undocumented": true
+      }
+    },
+    "MoveItemsBetweenRequisitionListsInput": {
+      "documentation": {
+        "undocumented": true
+      }
+    },
+    "MoveLineItemToRequisitionListInput": {
+      "documentation": {
+        "undocumented": true
+      }
+    },
+    "NegotiableQuoteAddressInput": {
+      "documentation": {
+        "undocumented": true
+      }
+    },
+    "NegotiableQuoteBillingAddressInput": {
+      "documentation": {
+        "undocumented": true
+      }
+    },
+    "NegotiableQuoteCommentInput": {
+      "documentation": {
+        "undocumented": true
+      }
+    },
+    "NegotiableQuoteFilterInput": {
+      "documentation": {
+        "undocumented": true
+      }
+    },
+    "NegotiableQuoteItemQuantityInput": {
+      "documentation": {
+        "undocumented": true
+      }
+    },
+    "NegotiableQuotePaymentMethodInput": {
+      "documentation": {
+        "undocumented": true
+      }
+    },
+    "NegotiableQuoteShippingAddressInput": {
+      "documentation": {
+        "undocumented": true
+      }
+    },
+    "NegotiableQuoteSortInput": {
+      "documentation": {
+        "undocumented": true
+      }
+    },
+    "NegotiableQuoteTemplateFilterInput": {
+      "documentation": {
+        "undocumented": true
+      }
+    },
+    "NegotiableQuoteTemplateItemQuantityInput": {
+      "documentation": {
+        "undocumented": true
+      }
+    },
+    "NegotiableQuoteTemplateReferenceDocumentLinkInput": {
+      "documentation": {
+        "undocumented": true
+      }
+    },
+    "NegotiableQuoteTemplateShippingAddressInput": {
+      "documentation": {
+        "undocumented": true
+      }
+    },
+    "NegotiableQuoteTemplateSortInput": {
+      "documentation": {
+        "undocumented": true
+      }
+    },
+    "OpenNegotiableQuoteTemplateInput": {
+      "documentation": {
+        "undocumented": true
+      }
+    },
+    "OrderInformationInput": {
+      "documentation": {
+        "undocumented": true
+      }
+    },
+    "OrderTokenInput": {
+      "documentation": {
+        "undocumented": true
+      }
+    },
+    "PaymentAttributeInput": {
+      "documentation": {
+        "undocumented": true
+      }
+    },
+    "PaymentMethodInput": {
+      "documentation": {
+        "undocumented": true
+      }
+    },
+    "PaymentSourceInput": {
+      "documentation": {
+        "undocumented": true
+      }
+    },
+    "PickupLocationFilterInput": {
+      "documentation": {
+        "undocumented": true
+      }
+    },
+    "PickupLocationSortInput": {
+      "documentation": {
+        "undocumented": true
+      }
+    },
+    "PlaceNegotiableQuoteOrderInput": {
+      "documentation": {
+        "undocumented": true
+      }
+    },
+    "PlaceOrderForPurchaseOrderInput": {
+      "documentation": {
+        "undocumented": true
+      }
+    },
+    "PlaceOrderInput": {
+      "documentation": {
+        "undocumented": true
+      }
+    },
+    "PlacePurchaseOrderInput": {
+      "documentation": {
+        "undocumented": true
+      }
+    },
+    "ProductInfoInput": {
+      "documentation": {
+        "undocumented": true
+      }
+    },
+    "ProductSearchSortInput": {
+      "documentation": {
+        "undocumented": true
+      }
+    },
+    "PurchaseHistory": {
+      "documentation": {
+        "undocumented": true
+      }
+    },
+    "PurchaseOrderApprovalRuleInput": {
+      "documentation": {
+        "undocumented": true
+      }
+    },
+    "PurchaseOrdersActionInput": {
+      "documentation": {
+        "undocumented": true
+      }
+    },
+    "PurchaseOrdersFilterInput": {
+      "documentation": {
+        "undocumented": true
+      }
+    },
+    "QueryContextInput": {
+      "documentation": {
+        "undocumented": true
+      }
+    },
+    "QuoteItemsSortInput": {
+      "documentation": {
+        "undocumented": true
+      }
+    },
+    "QuoteTemplateLineItemNoteInput": {
+      "documentation": {
+        "undocumented": true
+      }
+    },
+    "RemoveCouponFromCartInput": {
+      "documentation": {
+        "undocumented": true
+      }
+    },
+    "RemoveCouponsFromCartInput": {
+      "documentation": {
+        "undocumented": true
+      }
+    },
+    "RemoveGiftCardFromCartInput": {
+      "documentation": {
+        "undocumented": true
+      }
+    },
+    "RemoveItemFromCartInput": {
+      "documentation": {
+        "undocumented": true
+      }
+    },
+    "RemoveNegotiableQuoteItemsInput": {
+      "documentation": {
+        "undocumented": true
+      }
+    },
+    "RemoveNegotiableQuoteTemplateItemsInput": {
+      "documentation": {
+        "undocumented": true
+      }
+    },
+    "RemoveProductsFromCompareListInput": {
+      "documentation": {
+        "undocumented": true
+      }
+    },
+    "RemoveReturnTrackingInput": {
+      "documentation": {
+        "undocumented": true
+      }
+    },
+    "RemoveStoreCreditFromCartInput": {
+      "documentation": {
+        "undocumented": true
+      }
+    },
+    "RenameNegotiableQuoteInput": {
+      "documentation": {
+        "undocumented": true
+      }
+    },
+    "RequestGuestReturnInput": {
+      "documentation": {
+        "undocumented": true
+      }
+    },
+    "RequestNegotiableQuoteInput": {
+      "documentation": {
+        "undocumented": true
+      }
+    },
+    "RequestNegotiableQuoteTemplateInput": {
+      "documentation": {
+        "undocumented": true
+      }
+    },
+    "RequestReturnInput": {
+      "documentation": {
+        "undocumented": true
+      }
+    },
+    "RequestReturnItemInput": {
+      "documentation": {
+        "undocumented": true
+      }
+    },
+    "RequisitionListFilterInput": {
+      "documentation": {
+        "undocumented": true
+      }
+    },
+    "RequisitionListItemsInput": {
+      "documentation": {
+        "undocumented": true
+      }
+    },
+    "SearchClauseInput": {
+      "documentation": {
+        "undocumented": true
+      }
+    },
+    "SearchRangeInput": {
+      "documentation": {
+        "undocumented": true
+      }
+    },
+    "SelectedCustomAttributeInput": {
+      "documentation": {
+        "undocumented": true
+      }
+    },
+    "SendNegotiableQuoteForReviewInput": {
+      "documentation": {
+        "undocumented": true
+      }
+    },
+    "SetBillingAddressOnCartInput": {
+      "documentation": {
+        "undocumented": true
+      }
+    },
+    "SetCustomAttributesOnCompanyInput": {
+      "documentation": {
+        "undocumented": true
+      }
+    },
+    "SetCustomAttributesOnNegotiableQuoteInput": {
+      "documentation": {
+        "undocumented": true
+      }
+    },
+    "SetGiftOptionsOnCartInput": {
+      "documentation": {
+        "undocumented": true
+      }
+    },
+    "SetGuestEmailOnCartInput": {
+      "documentation": {
+        "undocumented": true
+      }
+    },
+    "SetNegotiableQuoteBillingAddressInput": {
+      "documentation": {
+        "undocumented": true
+      }
+    },
+    "SetNegotiableQuotePaymentMethodInput": {
+      "documentation": {
+        "undocumented": true
+      }
+    },
+    "SetNegotiableQuoteShippingAddressInput": {
+      "documentation": {
+        "undocumented": true
+      }
+    },
+    "SetNegotiableQuoteShippingMethodsInput": {
+      "documentation": {
+        "undocumented": true
+      }
+    },
+    "SetNegotiableQuoteTemplateShippingAddressInput": {
+      "documentation": {
+        "undocumented": true
+      }
+    },
+    "SetPaymentMethodAndPlaceOrderInput": {
+      "documentation": {
+        "undocumented": true
+      }
+    },
+    "SetPaymentMethodOnCartInput": {
+      "documentation": {
+        "undocumented": true
+      }
+    },
+    "SetShippingAddressesOnCartInput": {
+      "documentation": {
+        "undocumented": true
+      }
+    },
+    "SetShippingMethodsOnCartInput": {
+      "documentation": {
+        "undocumented": true
+      }
+    },
+    "ShareGiftRegistryInviteeInput": {
+      "documentation": {
+        "undocumented": true
+      }
+    },
+    "ShareGiftRegistrySenderInput": {
+      "documentation": {
+        "undocumented": true
+      }
+    },
+    "ShippingAddressInput": {
+      "documentation": {
+        "undocumented": true
+      }
+    },
+    "ShippingMethodInput": {
+      "documentation": {
+        "undocumented": true
+      }
+    },
+    "SmartButtonMethodInput": {
+      "documentation": {
+        "undocumented": true
+      }
+    },
+    "SubmitNegotiableQuoteTemplateForReviewInput": {
+      "documentation": {
+        "undocumented": true
+      }
+    },
+    "Subtree": {
+      "documentation": {
+        "undocumented": true
+      }
+    },
+    "SyncPaymentOrderInput": {
+      "documentation": {
+        "undocumented": true
+      }
+    },
+    "UpdateCartItemsInput": {
+      "documentation": {
+        "undocumented": true
+      }
+    },
+    "UpdateGiftRegistryInput": {
+      "documentation": {
+        "undocumented": true
+      }
+    },
+    "UpdateGiftRegistryItemInput": {
+      "documentation": {
+        "undocumented": true
+      }
+    },
+    "UpdateGiftRegistryRegistrantInput": {
+      "documentation": {
+        "undocumented": true
+      }
+    },
+    "UpdateNegotiableQuoteQuantitiesInput": {
+      "documentation": {
+        "undocumented": true
+      }
+    },
+    "UpdateNegotiableQuoteTemplateQuantitiesInput": {
+      "documentation": {
+        "undocumented": true
+      }
+    },
+    "UpdatePurchaseOrderApprovalRuleInput": {
+      "documentation": {
+        "undocumented": true
+      }
+    },
+    "UpdateRequisitionListInput": {
+      "documentation": {
+        "undocumented": true
+      }
+    },
+    "UpdateRequisitionListItemsInput": {
+      "documentation": {
+        "undocumented": true
+      }
+    },
+    "UserCompaniesInput": {
+      "documentation": {
+        "undocumented": true
+      }
+    },
+    "ValidatePurchaseOrdersInput": {
+      "documentation": {
+        "undocumented": true
+      }
+    },
+    "VaultMethodInput": {
+      "documentation": {
+        "undocumented": true
+      }
+    },
+    "VaultSetupTokenInput": {
+      "documentation": {
+        "undocumented": true
+      }
+    },
+    "ViewHistory": {
+      "documentation": {
+        "undocumented": true
+      }
+    },
+    "ViewHistoryInput": {
+      "documentation": {
+        "undocumented": true
+      }
+    },
+    "WishlistItemCopyInput": {
+      "documentation": {
+        "undocumented": true
+      }
+    },
+    "WishlistItemInput": {
+      "documentation": {
+        "undocumented": true
+      }
+    },
+    "WishlistItemMoveInput": {
+      "documentation": {
+        "undocumented": true
+      }
+    },
+    "WishlistItemUpdateInput": {
+      "documentation": {
+        "undocumented": true
+      }
+    }
+  },
+  "ENUM": {
+    "AddRequisitionListItemToCartUserErrorType": {
+      "documentation": {
+        "undocumented": true
+      }
+    },
+    "ApplyCouponsStrategy": {
+      "documentation": {
+        "undocumented": true
+      }
+    },
+    "AttributeEntityTypeEnum": {
+      "documentation": {
+        "undocumented": true
+      }
+    },
+    "AttributeFrontendInputEnum": {
+      "documentation": {
+        "undocumented": true
+      }
+    },
+    "AttributeMetadataErrorType": {
+      "documentation": {
+        "undocumented": true
+      }
+    },
+    "BatchMutationStatus": {
+      "documentation": {
+        "undocumented": true
+      }
+    },
+    "CancelOrderErrorCode": {
+      "documentation": {
+        "undocumented": true
+      }
+    },
+    "CartDiscountType": {
+      "documentation": {
+        "undocumented": true
+      }
+    },
+    "CartItemErrorType": {
+      "documentation": {
+        "undocumented": true
+      }
+    },
+    "CartUserInputErrorType": {
+      "documentation": {
+        "undocumented": true
+      }
+    },
+    "CatalogAttributeApplyToEnum": {
+      "documentation": {
+        "undocumented": true
+      }
+    },
+    "CheckoutAgreementMode": {
+      "documentation": {
+        "undocumented": true
+      }
+    },
+    "CheckoutUserInputErrorCodes": {
+      "documentation": {
+        "undocumented": true
+      }
+    },
+    "CompaniesSortFieldEnum": {
+      "documentation": {
+        "undocumented": true
+      }
+    },
+    "CompanyCreditOperationType": {
+      "documentation": {
+        "undocumented": true
+      }
+    },
+    "CompanyCreditOperationUserType": {
+      "documentation": {
+        "undocumented": true
+      }
+    },
+    "CompanyUserStatusEnum": {
+      "documentation": {
+        "undocumented": true
+      }
+    },
+    "ConfirmationStatusEnum": {
+      "documentation": {
+        "undocumented": true
+      }
+    },
+    "CountryCodeEnum": {
+      "documentation": {
+        "undocumented": true
+      }
+    },
+    "CurrencyEnum": {
+      "documentation": {
+        "undocumented": true
+      }
+    },
+    "CustomerOrderSortableField": {
+      "documentation": {
+        "undocumented": true
+      }
+    },
+    "CustomizableDateTypeEnum": {
+      "documentation": {
+        "undocumented": true
+      }
+    },
+    "DeletePurchaseOrderApprovalRuleErrorType": {
+      "documentation": {
+        "undocumented": true
+      }
+    },
+    "FilterMatchTypeEnum": {
+      "documentation": {
+        "undocumented": true
+      }
+    },
+    "FixedProductTaxDisplaySettings": {
+      "documentation": {
+        "undocumented": true
+      }
+    },
+    "GiftCardTypeEnum": {
+      "documentation": {
+        "undocumented": true
+      }
+    },
+    "GiftRegistryDynamicAttributeGroup": {
+      "documentation": {
+        "undocumented": true
+      }
+    },
+    "GiftRegistryItemsUserErrorType": {
+      "documentation": {
+        "undocumented": true
+      }
+    },
+    "GiftRegistryPrivacySettings": {
+      "documentation": {
+        "undocumented": true
+      }
+    },
+    "GiftRegistryStatus": {
+      "documentation": {
+        "undocumented": true
+      }
+    },
+    "InputFilterEnum": {
+      "documentation": {
+        "undocumented": true
+      }
+    },
+    "NegotiableQuoteCommentCreatorType": {
+      "documentation": {
+        "undocumented": true
+      }
+    },
+    "NegotiableQuoteHistoryEntryChangeType": {
+      "documentation": {
+        "undocumented": true
+      }
+    },
+    "NegotiableQuoteSortableField": {
+      "documentation": {
+        "undocumented": true
+      }
+    },
+    "NegotiableQuoteStatus": {
+      "documentation": {
+        "undocumented": true
+      }
+    },
+    "NegotiableQuoteTemplateSortableField": {
+      "documentation": {
+        "undocumented": true
+      }
+    },
+    "OrderActionType": {
+      "documentation": {
+        "undocumented": true
+      }
+    },
+    "PageType": {
+      "documentation": {
+        "undocumented": true
+      }
+    },
+    "PaymentLocation": {
+      "documentation": {
+        "undocumented": true
+      }
+    },
+    "PaymentTokenTypeEnum": {
+      "documentation": {
+        "undocumented": true
+      }
+    },
+    "PlaceOrderErrorCodes": {
+      "documentation": {
+        "undocumented": true
+      }
+    },
+    "PriceTypeEnum": {
+      "documentation": {
+        "undocumented": true
+      }
+    },
+    "PriceViewEnum": {
+      "documentation": {
+        "undocumented": true
+      }
+    },
+    "ProductImageThumbnail": {
+      "documentation": {
+        "undocumented": true
+      }
+    },
+    "ProductStockStatus": {
+      "documentation": {
+        "undocumented": true
+      }
+    },
+    "PurchaseOrderAction": {
+      "documentation": {
+        "undocumented": true
+      }
+    },
+    "PurchaseOrderApprovalFlowItemStatus": {
+      "documentation": {
+        "undocumented": true
+      }
+    },
+    "PurchaseOrderApprovalRuleConditionOperator": {
+      "documentation": {
+        "undocumented": true
+      }
+    },
+    "PurchaseOrderApprovalRuleStatus": {
+      "documentation": {
+        "undocumented": true
+      }
+    },
+    "PurchaseOrderApprovalRuleType": {
+      "documentation": {
+        "undocumented": true
+      }
+    },
+    "PurchaseOrderErrorType": {
+      "documentation": {
+        "undocumented": true
+      }
+    },
+    "PurchaseOrderStatus": {
+      "documentation": {
+        "undocumented": true
+      }
+    },
+    "ReCaptchaFormEnum": {
+      "documentation": {
+        "undocumented": true
+      }
+    },
+    "ReCaptchaTypeEmum": {
+      "documentation": {
+        "undocumented": true
+      }
+    },
+    "ReturnItemStatus": {
+      "documentation": {
+        "undocumented": true
+      }
+    },
+    "ReturnShippingTrackingStatusType": {
+      "documentation": {
+        "undocumented": true
+      }
+    },
+    "ReturnStatus": {
+      "documentation": {
+        "undocumented": true
+      }
+    },
+    "RewardPointsSubscriptionStatusesEnum": {
+      "documentation": {
+        "undocumented": true
+      }
+    },
+    "ScopeTypeEnum": {
+      "documentation": {
+        "undocumented": true
+      }
+    },
+    "ShipBundleItemsEnum": {
+      "documentation": {
+        "undocumented": true
+      }
+    },
+    "SortEnum": {
+      "documentation": {
+        "undocumented": true
+      }
+    },
+    "SortQuoteItemsEnum": {
+      "documentation": {
+        "undocumented": true
+      }
+    },
+    "SubscriptionStatusesEnum": {
+      "documentation": {
+        "undocumented": true
+      }
+    },
+    "SwatchInputTypeEnum": {
+      "documentation": {
+        "undocumented": true
+      }
+    },
+    "TaxWrappingEnum": {
+      "documentation": {
+        "undocumented": true
+      }
+    },
+    "ThreeDSMode": {
+      "documentation": {
+        "undocumented": true
+      }
+    },
+    "UseInLayeredNavigationOptions": {
+      "documentation": {
+        "undocumented": true
+      }
+    },
+    "ValidatePurchaseOrderErrorType": {
+      "documentation": {
+        "undocumented": true
+      }
+    },
+    "ValidationRuleEnum": {
+      "documentation": {
+        "undocumented": true
+      }
+    },
+    "WishListUserInputErrorType": {
+      "documentation": {
+        "undocumented": true
+      }
+    },
+    "WishlistCartUserInputErrorType": {
+      "documentation": {
+        "undocumented": true
+      }
+    },
+    "WishlistVisibilityEnum": {
+      "documentation": {
+        "undocumented": true
+      }
+    }
+  },
+  "UNION": {
+    "CloseNegotiableQuoteError": {
+      "documentation": {
+        "undocumented": true
+      }
+    },
+    "CloseNegotiableQuoteOperationResult": {
+      "documentation": {
+        "undocumented": true
+      }
+    },
+    "CompanyStructureEntity": {
+      "documentation": {
+        "undocumented": true
+      }
+    },
+    "DeleteNegotiableQuoteError": {
+      "documentation": {
+        "undocumented": true
+      }
+    },
+    "DeleteNegotiableQuoteOperationResult": {
+      "documentation": {
+        "undocumented": true
+      }
+    }
+  }
 }

--- a/static/graphql-api/admin-api/index.html
+++ b/static/graphql-api/admin-api/index.html
@@ -31,6 +31,7 @@
                 <li><a href="#query-policies">policies</a></li>
                 <li><a href="#query-policy">policy</a></li>
                 <li><a href="#query-priceBooks">priceBooks</a></li>
+                <li><a href="#query-priceBooksByIds">priceBooksByIds</a></li>
                 <li><a href="#query-scopes">scopes</a></li>
               </ul>
             </li>
@@ -355,10 +356,10 @@ Authorization: Bearer &lt;YOUR_TOKEN_HERE&gt;</code></pre>
       <span class="hljs-attr">"allowedPriceBookIds"</span><span class="hljs-punctuation">:</span> <span class="hljs-punctuation">[</span><span class="hljs-string">"abc123"</span><span class="hljs-punctuation">]</span><span class="hljs-punctuation">,</span>
       <span class="hljs-attr">"channelId"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"abc123"</span><span class="hljs-punctuation">,</span>
       <span class="hljs-attr">"createdAt"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"xyz789"</span><span class="hljs-punctuation">,</span>
-      <span class="hljs-attr">"defaultPriceBookId"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"xyz789"</span><span class="hljs-punctuation">,</span>
+      <span class="hljs-attr">"defaultPriceBookId"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"abc123"</span><span class="hljs-punctuation">,</span>
       <span class="hljs-attr">"name"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"xyz789"</span><span class="hljs-punctuation">,</span>
       <span class="hljs-attr">"policies"</span><span class="hljs-punctuation">:</span> <span class="hljs-punctuation">[</span><span class="hljs-string">PolicyResponse</span><span class="hljs-punctuation">]</span><span class="hljs-punctuation">,</span>
-      <span class="hljs-attr">"policyIds"</span><span class="hljs-punctuation">:</span> <span class="hljs-punctuation">[</span><span class="hljs-string">"xyz789"</span><span class="hljs-punctuation">]</span><span class="hljs-punctuation">,</span>
+      <span class="hljs-attr">"policyIds"</span><span class="hljs-punctuation">:</span> <span class="hljs-punctuation">[</span><span class="hljs-string">"abc123"</span><span class="hljs-punctuation">]</span><span class="hljs-punctuation">,</span>
       <span class="hljs-attr">"scopes"</span><span class="hljs-punctuation">:</span> <span class="hljs-punctuation">[</span><span class="hljs-string">ChannelScopeResponse</span><span class="hljs-punctuation">]</span><span class="hljs-punctuation">,</span>
       <span class="hljs-attr">"updatedAt"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"abc123"</span>
     <span class="hljs-punctuation">}</span>
@@ -599,12 +600,12 @@ Authorization: Bearer &lt;YOUR_TOKEN_HERE&gt;</code></pre>
         <span class="hljs-attr">"allowedPriceBookIds"</span><span class="hljs-punctuation">:</span> <span class="hljs-punctuation">[</span><span class="hljs-string">"xyz789"</span><span class="hljs-punctuation">]</span><span class="hljs-punctuation">,</span>
         <span class="hljs-attr">"channelId"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"xyz789"</span><span class="hljs-punctuation">,</span>
         <span class="hljs-attr">"createdAt"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"xyz789"</span><span class="hljs-punctuation">,</span>
-        <span class="hljs-attr">"defaultPriceBookId"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"abc123"</span><span class="hljs-punctuation">,</span>
-        <span class="hljs-attr">"name"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"abc123"</span><span class="hljs-punctuation">,</span>
+        <span class="hljs-attr">"defaultPriceBookId"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"xyz789"</span><span class="hljs-punctuation">,</span>
+        <span class="hljs-attr">"name"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"xyz789"</span><span class="hljs-punctuation">,</span>
         <span class="hljs-attr">"policies"</span><span class="hljs-punctuation">:</span> <span class="hljs-punctuation">[</span><span class="hljs-string">PolicyResponse</span><span class="hljs-punctuation">]</span><span class="hljs-punctuation">,</span>
         <span class="hljs-attr">"policyIds"</span><span class="hljs-punctuation">:</span> <span class="hljs-punctuation">[</span><span class="hljs-string">"xyz789"</span><span class="hljs-punctuation">]</span><span class="hljs-punctuation">,</span>
         <span class="hljs-attr">"scopes"</span><span class="hljs-punctuation">:</span> <span class="hljs-punctuation">[</span><span class="hljs-string">ChannelScopeResponse</span><span class="hljs-punctuation">]</span><span class="hljs-punctuation">,</span>
-        <span class="hljs-attr">"updatedAt"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"xyz789"</span>
+        <span class="hljs-attr">"updatedAt"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"abc123"</span>
       <span class="hljs-punctuation">}</span>
     <span class="hljs-punctuation">]</span>
   <span class="hljs-punctuation">}</span>
@@ -750,8 +751,8 @@ Authorization: Bearer &lt;YOUR_TOKEN_HERE&gt;</code></pre>
         <span class="hljs-attr">"createdAt"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"abc123"</span><span class="hljs-punctuation">,</span>
         <span class="hljs-attr">"mandatory"</span><span class="hljs-punctuation">:</span> <span class="hljs-literal"><span class="hljs-keyword">true</span></span><span class="hljs-punctuation">,</span>
         <span class="hljs-attr">"name"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"xyz789"</span><span class="hljs-punctuation">,</span>
-        <span class="hljs-attr">"policyId"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"abc123"</span><span class="hljs-punctuation">,</span>
-        <span class="hljs-attr">"updatedAt"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"xyz789"</span>
+        <span class="hljs-attr">"policyId"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"xyz789"</span><span class="hljs-punctuation">,</span>
+        <span class="hljs-attr">"updatedAt"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"abc123"</span>
       <span class="hljs-punctuation">}</span>
     <span class="hljs-punctuation">]</span>
   <span class="hljs-punctuation">}</span>
@@ -955,10 +956,10 @@ Authorization: Bearer &lt;YOUR_TOKEN_HERE&gt;</code></pre>
     <span class="hljs-attr">"policy"</span><span class="hljs-punctuation">:</span> <span class="hljs-punctuation">{</span>
       <span class="hljs-attr">"actions"</span><span class="hljs-punctuation">:</span> <span class="hljs-punctuation">[</span><span class="hljs-string">ActionResponse</span><span class="hljs-punctuation">]</span><span class="hljs-punctuation">,</span>
       <span class="hljs-attr">"createdAt"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"abc123"</span><span class="hljs-punctuation">,</span>
-      <span class="hljs-attr">"mandatory"</span><span class="hljs-punctuation">:</span> <span class="hljs-literal"><span class="hljs-keyword">false</span></span><span class="hljs-punctuation">,</span>
+      <span class="hljs-attr">"mandatory"</span><span class="hljs-punctuation">:</span> <span class="hljs-literal"><span class="hljs-keyword">true</span></span><span class="hljs-punctuation">,</span>
       <span class="hljs-attr">"name"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"xyz789"</span><span class="hljs-punctuation">,</span>
       <span class="hljs-attr">"policyId"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"abc123"</span><span class="hljs-punctuation">,</span>
-      <span class="hljs-attr">"updatedAt"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"xyz789"</span>
+      <span class="hljs-attr">"updatedAt"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"abc123"</span>
     <span class="hljs-punctuation">}</span>
   <span class="hljs-punctuation">}</span>
 <span class="hljs-punctuation">}</span>
@@ -1065,7 +1066,7 @@ Authorization: Bearer &lt;YOUR_TOKEN_HERE&gt;</code></pre>
                   <head></head>
                   <body><pre><code class="hljs language-json"><span class="hljs-punctuation">{</span>
   <span class="hljs-attr">"scrollId"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"abc123"</span><span class="hljs-punctuation">,</span>
-  <span class="hljs-attr">"searchTerm"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"abc123"</span><span class="hljs-punctuation">,</span>
+  <span class="hljs-attr">"searchTerm"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"xyz789"</span><span class="hljs-punctuation">,</span>
   <span class="hljs-attr">"size"</span><span class="hljs-punctuation">:</span> <span class="hljs-number">123</span>
 <span class="hljs-punctuation">}</span>
 </code></pre>
@@ -1081,6 +1082,100 @@ Authorization: Bearer &lt;YOUR_TOKEN_HERE&gt;</code></pre>
     <span class="hljs-attr">"priceBooks"</span><span class="hljs-punctuation">:</span> <span class="hljs-punctuation">{</span>
       <span class="hljs-attr">"items"</span><span class="hljs-punctuation">:</span> <span class="hljs-punctuation">[</span><span class="hljs-string">PriceBook</span><span class="hljs-punctuation">]</span><span class="hljs-punctuation">,</span>
       <span class="hljs-attr">"scrollId"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"xyz789"</span>
+    <span class="hljs-punctuation">}</span>
+  <span class="hljs-punctuation">}</span>
+<span class="hljs-punctuation">}</span>
+</code></pre>
+                  </body>
+                </html>
+              </div>
+            </div>
+            <a href="#top">back to top</a>
+          </div>
+        </section>
+        <section id="query-priceBooksByIds" class="operation operation-query" data-traverse-target="query-priceBooksByIds">
+          <div class="operation-group-name">
+            <a href="#group-Operations-Queries">Queries</a>
+          </div>
+          <h2 class="operation-heading ">
+            <code>priceBooksByIds</code>
+          </h2>
+          <div class="doc-row">
+            <div class="doc-copy">
+              <div class="operation-description doc-copy-section">
+                <h5>Description</h5>
+                <p>The list of price books including the hierarchy of their parent child relationships retrieved by a list of price book ids.</p>
+                <p>Parameters:</p>
+                <ul>
+                  <li>ids: The list of price book ids to retrieve (required)</li>
+                </ul>
+              </div>
+            </div>
+          </div>
+          <div class="doc-row">
+            <div class="doc-copy">
+              <div class="operation-response doc-copy-section">
+                <h5>Response</h5>
+                <p> Returns a <a href="#definition-PriceBooksResponse"><code>PriceBooksResponse!</code></a>
+                </p>
+              </div>
+              <div class="operation-arguments doc-copy-section">
+                <h5>Arguments</h5>
+                <table>
+                  <thead>
+                    <tr>
+                      <th>Name</th>
+                      <th>Description</th>
+                    </tr>
+                  </thead>
+                  <tbody>
+                    <tr>
+                      <td>
+                        <span class="property-name"><code>ids</code></span> - <span class="property-type"><a href="#definition-String"><code>[String!]!</code></a></span>
+                      </td>
+                      <td>
+                      </td>
+                    </tr>
+                  </tbody>
+                </table>
+              </div>
+            </div>
+            <div class="doc-examples">
+              <h4 class="example-heading">Example</h4>
+              <div class="example-section example-section-is-code operation-query-example">
+                <h5>Query</h5>
+                <html>
+                  <head></head>
+                  <body><pre><code class="hljs language-gql"><span class="hljs-symbol"><span class="hljs-keyword">query</span> priceBooksByIds<span class="hljs-tag">(<span class="hljs-code">$ids</span>: <span class="hljs-type">[String!</span>]!)</span> <span class="hljs-tag">{
+  <span class="hljs-symbol">priceBooksByIds<span class="hljs-tag">(ids: <span class="hljs-code">$ids</span>)</span> <span class="hljs-tag">{
+    <span class="hljs-symbol">items <span class="hljs-tag">{
+      <span class="hljs-type">...PriceBookFragment</span>
+    }</span></span>
+    <span class="hljs-symbol">scrollId</span>
+  }</span></span>
+}</span></span>
+</code></pre>
+                  </body>
+                </html>
+              </div>
+              <div class="example-section example-section-is-code operation-variables-example">
+                <h5>Variables</h5>
+                <html>
+                  <head></head>
+                  <body><pre><code class="hljs language-json"><span class="hljs-punctuation">{</span><span class="hljs-attr">"ids"</span><span class="hljs-punctuation">:</span> <span class="hljs-punctuation">[</span><span class="hljs-string">"abc123"</span><span class="hljs-punctuation">]</span><span class="hljs-punctuation">}</span>
+</code></pre>
+                  </body>
+                </html>
+              </div>
+              <div class="example-section example-section-is-code operation-response-example">
+                <h5>Response</h5>
+                <html>
+                  <head></head>
+                  <body><pre><code class="hljs language-json"><span class="hljs-punctuation">{</span>
+  <span class="hljs-attr">"data"</span><span class="hljs-punctuation">:</span> <span class="hljs-punctuation">{</span>
+    <span class="hljs-attr">"priceBooksByIds"</span><span class="hljs-punctuation">:</span> <span class="hljs-punctuation">{</span>
+      <span class="hljs-attr">"items"</span><span class="hljs-punctuation">:</span> <span class="hljs-punctuation">[</span><span class="hljs-string">PriceBook</span><span class="hljs-punctuation">]</span><span class="hljs-punctuation">,</span>
+      <span class="hljs-attr">"scrollId"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"abc123"</span>
     <span class="hljs-punctuation">}</span>
   <span class="hljs-punctuation">}</span>
 <span class="hljs-punctuation">}</span>
@@ -1134,7 +1229,7 @@ Authorization: Bearer &lt;YOUR_TOKEN_HERE&gt;</code></pre>
                 <h5>Response</h5>
                 <html>
                   <head></head>
-                  <body><pre><code class="hljs language-json"><span class="hljs-punctuation">{</span><span class="hljs-attr">"data"</span><span class="hljs-punctuation">:</span> <span class="hljs-punctuation">{</span><span class="hljs-attr">"scopes"</span><span class="hljs-punctuation">:</span> <span class="hljs-punctuation">[</span><span class="hljs-punctuation">{</span><span class="hljs-attr">"locale"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"xyz789"</span><span class="hljs-punctuation">}</span><span class="hljs-punctuation">]</span><span class="hljs-punctuation">}</span><span class="hljs-punctuation">}</span>
+                  <body><pre><code class="hljs language-json"><span class="hljs-punctuation">{</span><span class="hljs-attr">"data"</span><span class="hljs-punctuation">:</span> <span class="hljs-punctuation">{</span><span class="hljs-attr">"scopes"</span><span class="hljs-punctuation">:</span> <span class="hljs-punctuation">[</span><span class="hljs-punctuation">{</span><span class="hljs-attr">"locale"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"abc123"</span><span class="hljs-punctuation">}</span><span class="hljs-punctuation">]</span><span class="hljs-punctuation">}</span><span class="hljs-punctuation">}</span>
 </code></pre>
                   </body>
                 </html>
@@ -1841,13 +1936,13 @@ Authorization: Bearer &lt;YOUR_TOKEN_HERE&gt;</code></pre>
                   <body><pre><code class="hljs language-json"><span class="hljs-punctuation">{</span>
   <span class="hljs-attr">"data"</span><span class="hljs-punctuation">:</span> <span class="hljs-punctuation">{</span>
     <span class="hljs-attr">"createChannel"</span><span class="hljs-punctuation">:</span> <span class="hljs-punctuation">{</span>
-      <span class="hljs-attr">"allowedPriceBookIds"</span><span class="hljs-punctuation">:</span> <span class="hljs-punctuation">[</span><span class="hljs-string">"abc123"</span><span class="hljs-punctuation">]</span><span class="hljs-punctuation">,</span>
+      <span class="hljs-attr">"allowedPriceBookIds"</span><span class="hljs-punctuation">:</span> <span class="hljs-punctuation">[</span><span class="hljs-string">"xyz789"</span><span class="hljs-punctuation">]</span><span class="hljs-punctuation">,</span>
       <span class="hljs-attr">"channelId"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"xyz789"</span><span class="hljs-punctuation">,</span>
       <span class="hljs-attr">"createdAt"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"xyz789"</span><span class="hljs-punctuation">,</span>
       <span class="hljs-attr">"defaultPriceBookId"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"xyz789"</span><span class="hljs-punctuation">,</span>
       <span class="hljs-attr">"name"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"xyz789"</span><span class="hljs-punctuation">,</span>
       <span class="hljs-attr">"policies"</span><span class="hljs-punctuation">:</span> <span class="hljs-punctuation">[</span><span class="hljs-string">PolicyResponse</span><span class="hljs-punctuation">]</span><span class="hljs-punctuation">,</span>
-      <span class="hljs-attr">"policyIds"</span><span class="hljs-punctuation">:</span> <span class="hljs-punctuation">[</span><span class="hljs-string">"xyz789"</span><span class="hljs-punctuation">]</span><span class="hljs-punctuation">,</span>
+      <span class="hljs-attr">"policyIds"</span><span class="hljs-punctuation">:</span> <span class="hljs-punctuation">[</span><span class="hljs-string">"abc123"</span><span class="hljs-punctuation">]</span><span class="hljs-punctuation">,</span>
       <span class="hljs-attr">"scopes"</span><span class="hljs-punctuation">:</span> <span class="hljs-punctuation">[</span><span class="hljs-string">ChannelScopeResponse</span><span class="hljs-punctuation">]</span><span class="hljs-punctuation">,</span>
       <span class="hljs-attr">"updatedAt"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"xyz789"</span>
     <span class="hljs-punctuation">}</span>
@@ -2056,8 +2151,8 @@ Authorization: Bearer &lt;YOUR_TOKEN_HERE&gt;</code></pre>
       <span class="hljs-attr">"actions"</span><span class="hljs-punctuation">:</span> <span class="hljs-punctuation">[</span><span class="hljs-string">ActionResponse</span><span class="hljs-punctuation">]</span><span class="hljs-punctuation">,</span>
       <span class="hljs-attr">"createdAt"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"abc123"</span><span class="hljs-punctuation">,</span>
       <span class="hljs-attr">"mandatory"</span><span class="hljs-punctuation">:</span> <span class="hljs-literal"><span class="hljs-keyword">true</span></span><span class="hljs-punctuation">,</span>
-      <span class="hljs-attr">"name"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"abc123"</span><span class="hljs-punctuation">,</span>
-      <span class="hljs-attr">"policyId"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"xyz789"</span><span class="hljs-punctuation">,</span>
+      <span class="hljs-attr">"name"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"xyz789"</span><span class="hljs-punctuation">,</span>
+      <span class="hljs-attr">"policyId"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"abc123"</span><span class="hljs-punctuation">,</span>
       <span class="hljs-attr">"updatedAt"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"xyz789"</span>
     <span class="hljs-punctuation">}</span>
   <span class="hljs-punctuation">}</span>
@@ -2181,7 +2276,7 @@ Authorization: Bearer &lt;YOUR_TOKEN_HERE&gt;</code></pre>
                 <h5>Variables</h5>
                 <html>
                   <head></head>
-                  <body><pre><code class="hljs language-json"><span class="hljs-punctuation">{</span><span class="hljs-attr">"channelId"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"abc123"</span><span class="hljs-punctuation">}</span>
+                  <body><pre><code class="hljs language-json"><span class="hljs-punctuation">{</span><span class="hljs-attr">"channelId"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"xyz789"</span><span class="hljs-punctuation">}</span>
 </code></pre>
                   </body>
                 </html>
@@ -2190,7 +2285,7 @@ Authorization: Bearer &lt;YOUR_TOKEN_HERE&gt;</code></pre>
                 <h5>Response</h5>
                 <html>
                   <head></head>
-                  <body><pre><code class="hljs language-json"><span class="hljs-punctuation">{</span><span class="hljs-attr">"data"</span><span class="hljs-punctuation">:</span> <span class="hljs-punctuation">{</span><span class="hljs-attr">"deleteChannel"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"xyz789"</span><span class="hljs-punctuation">}</span><span class="hljs-punctuation">}</span>
+                  <body><pre><code class="hljs language-json"><span class="hljs-punctuation">{</span><span class="hljs-attr">"data"</span><span class="hljs-punctuation">:</span> <span class="hljs-punctuation">{</span><span class="hljs-attr">"deleteChannel"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"abc123"</span><span class="hljs-punctuation">}</span><span class="hljs-punctuation">}</span>
 </code></pre>
                   </body>
                 </html>
@@ -2473,12 +2568,12 @@ is <span class="hljs-keyword">an</span> all-<span class="hljs-keyword">or</span>
       <span class="hljs-attr">"allowedPriceBookIds"</span><span class="hljs-punctuation">:</span> <span class="hljs-punctuation">[</span><span class="hljs-string">"abc123"</span><span class="hljs-punctuation">]</span><span class="hljs-punctuation">,</span>
       <span class="hljs-attr">"channelId"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"xyz789"</span><span class="hljs-punctuation">,</span>
       <span class="hljs-attr">"createdAt"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"xyz789"</span><span class="hljs-punctuation">,</span>
-      <span class="hljs-attr">"defaultPriceBookId"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"abc123"</span><span class="hljs-punctuation">,</span>
-      <span class="hljs-attr">"name"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"abc123"</span><span class="hljs-punctuation">,</span>
+      <span class="hljs-attr">"defaultPriceBookId"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"xyz789"</span><span class="hljs-punctuation">,</span>
+      <span class="hljs-attr">"name"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"xyz789"</span><span class="hljs-punctuation">,</span>
       <span class="hljs-attr">"policies"</span><span class="hljs-punctuation">:</span> <span class="hljs-punctuation">[</span><span class="hljs-string">PolicyResponse</span><span class="hljs-punctuation">]</span><span class="hljs-punctuation">,</span>
       <span class="hljs-attr">"policyIds"</span><span class="hljs-punctuation">:</span> <span class="hljs-punctuation">[</span><span class="hljs-string">"abc123"</span><span class="hljs-punctuation">]</span><span class="hljs-punctuation">,</span>
       <span class="hljs-attr">"scopes"</span><span class="hljs-punctuation">:</span> <span class="hljs-punctuation">[</span><span class="hljs-string">ChannelScopeResponse</span><span class="hljs-punctuation">]</span><span class="hljs-punctuation">,</span>
-      <span class="hljs-attr">"updatedAt"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"abc123"</span>
+      <span class="hljs-attr">"updatedAt"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"xyz789"</span>
     <span class="hljs-punctuation">}</span>
   <span class="hljs-punctuation">}</span>
 <span class="hljs-punctuation">}</span>
@@ -2736,8 +2831,8 @@ is <span class="hljs-keyword">an</span> all-<span class="hljs-keyword">or</span>
       <span class="hljs-attr">"actions"</span><span class="hljs-punctuation">:</span> <span class="hljs-punctuation">[</span><span class="hljs-string">ActionResponse</span><span class="hljs-punctuation">]</span><span class="hljs-punctuation">,</span>
       <span class="hljs-attr">"createdAt"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"abc123"</span><span class="hljs-punctuation">,</span>
       <span class="hljs-attr">"mandatory"</span><span class="hljs-punctuation">:</span> <span class="hljs-literal"><span class="hljs-keyword">false</span></span><span class="hljs-punctuation">,</span>
-      <span class="hljs-attr">"name"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"abc123"</span><span class="hljs-punctuation">,</span>
-      <span class="hljs-attr">"policyId"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"abc123"</span><span class="hljs-punctuation">,</span>
+      <span class="hljs-attr">"name"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"xyz789"</span><span class="hljs-punctuation">,</span>
+      <span class="hljs-attr">"policyId"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"xyz789"</span><span class="hljs-punctuation">,</span>
       <span class="hljs-attr">"updatedAt"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"abc123"</span>
     <span class="hljs-punctuation">}</span>
   <span class="hljs-punctuation">}</span>
@@ -2891,7 +2986,7 @@ is <span class="hljs-keyword">an</span> all-<span class="hljs-keyword">or</span>
                   <body><pre><code class="hljs language-json"><span class="hljs-punctuation">{</span>
   <span class="hljs-attr">"actionFilterOperator"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"EQUALS"</span><span class="hljs-punctuation">,</span>
   <span class="hljs-attr">"attribute"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"abc123"</span><span class="hljs-punctuation">,</span>
-  <span class="hljs-attr">"enabled"</span><span class="hljs-punctuation">:</span> <span class="hljs-literal"><span class="hljs-keyword">false</span></span><span class="hljs-punctuation">,</span>
+  <span class="hljs-attr">"enabled"</span><span class="hljs-punctuation">:</span> <span class="hljs-literal"><span class="hljs-keyword">true</span></span><span class="hljs-punctuation">,</span>
   <span class="hljs-attr">"value"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"xyz789"</span><span class="hljs-punctuation">,</span>
   <span class="hljs-attr">"valueSource"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"STATIC"</span><span class="hljs-punctuation">,</span>
   <span class="hljs-attr">"values"</span><span class="hljs-punctuation">:</span> <span class="hljs-punctuation">[</span><span class="hljs-string">"abc123"</span><span class="hljs-punctuation">]</span>
@@ -2967,11 +3062,11 @@ is <span class="hljs-keyword">an</span> all-<span class="hljs-keyword">or</span>
                   <head></head>
                   <body><pre><code class="hljs language-json"><span class="hljs-punctuation">{</span>
   <span class="hljs-attr">"actionFilterOperator"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"EQUALS"</span><span class="hljs-punctuation">,</span>
-  <span class="hljs-attr">"attribute"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"abc123"</span><span class="hljs-punctuation">,</span>
-  <span class="hljs-attr">"enabled"</span><span class="hljs-punctuation">:</span> <span class="hljs-literal"><span class="hljs-keyword">false</span></span><span class="hljs-punctuation">,</span>
+  <span class="hljs-attr">"attribute"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"xyz789"</span><span class="hljs-punctuation">,</span>
+  <span class="hljs-attr">"enabled"</span><span class="hljs-punctuation">:</span> <span class="hljs-literal"><span class="hljs-keyword">true</span></span><span class="hljs-punctuation">,</span>
   <span class="hljs-attr">"value"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"xyz789"</span><span class="hljs-punctuation">,</span>
   <span class="hljs-attr">"valueSource"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"STATIC"</span><span class="hljs-punctuation">,</span>
-  <span class="hljs-attr">"values"</span><span class="hljs-punctuation">:</span> <span class="hljs-punctuation">[</span><span class="hljs-string">"xyz789"</span><span class="hljs-punctuation">]</span>
+  <span class="hljs-attr">"values"</span><span class="hljs-punctuation">:</span> <span class="hljs-punctuation">[</span><span class="hljs-string">"abc123"</span><span class="hljs-punctuation">]</span>
 <span class="hljs-punctuation">}</span>
 </code></pre>
                   </body>
@@ -3337,15 +3432,15 @@ is <span class="hljs-keyword">an</span> all-<span class="hljs-keyword">or</span>
                 <html>
                   <head></head>
                   <body><pre><code class="hljs language-json"><span class="hljs-punctuation">{</span>
-  <span class="hljs-attr">"allowedPriceBookIds"</span><span class="hljs-punctuation">:</span> <span class="hljs-punctuation">[</span><span class="hljs-string">"xyz789"</span><span class="hljs-punctuation">]</span><span class="hljs-punctuation">,</span>
-  <span class="hljs-attr">"channelId"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"abc123"</span><span class="hljs-punctuation">,</span>
+  <span class="hljs-attr">"allowedPriceBookIds"</span><span class="hljs-punctuation">:</span> <span class="hljs-punctuation">[</span><span class="hljs-string">"abc123"</span><span class="hljs-punctuation">]</span><span class="hljs-punctuation">,</span>
+  <span class="hljs-attr">"channelId"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"xyz789"</span><span class="hljs-punctuation">,</span>
   <span class="hljs-attr">"createdAt"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"abc123"</span><span class="hljs-punctuation">,</span>
   <span class="hljs-attr">"defaultPriceBookId"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"xyz789"</span><span class="hljs-punctuation">,</span>
   <span class="hljs-attr">"name"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"xyz789"</span><span class="hljs-punctuation">,</span>
   <span class="hljs-attr">"policies"</span><span class="hljs-punctuation">:</span> <span class="hljs-punctuation">[</span><span class="hljs-string">PolicyResponse</span><span class="hljs-punctuation">]</span><span class="hljs-punctuation">,</span>
   <span class="hljs-attr">"policyIds"</span><span class="hljs-punctuation">:</span> <span class="hljs-punctuation">[</span><span class="hljs-string">"abc123"</span><span class="hljs-punctuation">]</span><span class="hljs-punctuation">,</span>
   <span class="hljs-attr">"scopes"</span><span class="hljs-punctuation">:</span> <span class="hljs-punctuation">[</span><span class="hljs-string">ChannelScopeResponse</span><span class="hljs-punctuation">]</span><span class="hljs-punctuation">,</span>
-  <span class="hljs-attr">"updatedAt"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"xyz789"</span>
+  <span class="hljs-attr">"updatedAt"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"abc123"</span>
 <span class="hljs-punctuation">}</span>
 </code></pre>
                   </body>
@@ -3388,7 +3483,7 @@ is <span class="hljs-keyword">an</span> all-<span class="hljs-keyword">or</span>
                 <h5>Example</h5>
                 <html>
                   <head></head>
-                  <body><pre><code class="hljs language-json"><span class="hljs-punctuation">{</span><span class="hljs-attr">"locale"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"xyz789"</span><span class="hljs-punctuation">}</span>
+                  <body><pre><code class="hljs language-json"><span class="hljs-punctuation">{</span><span class="hljs-attr">"locale"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"abc123"</span><span class="hljs-punctuation">}</span>
 </code></pre>
                   </body>
                 </html>
@@ -3500,9 +3595,9 @@ is <span class="hljs-keyword">an</span> all-<span class="hljs-keyword">or</span>
                   <head></head>
                   <body><pre><code class="hljs language-json"><span class="hljs-punctuation">{</span>
   <span class="hljs-attr">"allowedPriceBookIds"</span><span class="hljs-punctuation">:</span> <span class="hljs-punctuation">[</span><span class="hljs-string">"abc123"</span><span class="hljs-punctuation">]</span><span class="hljs-punctuation">,</span>
-  <span class="hljs-attr">"defaultPriceBookId"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"abc123"</span><span class="hljs-punctuation">,</span>
+  <span class="hljs-attr">"defaultPriceBookId"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"xyz789"</span><span class="hljs-punctuation">,</span>
   <span class="hljs-attr">"name"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"xyz789"</span><span class="hljs-punctuation">,</span>
-  <span class="hljs-attr">"policyIds"</span><span class="hljs-punctuation">:</span> <span class="hljs-punctuation">[</span><span class="hljs-string">"abc123"</span><span class="hljs-punctuation">]</span><span class="hljs-punctuation">,</span>
+  <span class="hljs-attr">"policyIds"</span><span class="hljs-punctuation">:</span> <span class="hljs-punctuation">[</span><span class="hljs-string">"xyz789"</span><span class="hljs-punctuation">]</span><span class="hljs-punctuation">,</span>
   <span class="hljs-attr">"scopes"</span><span class="hljs-punctuation">:</span> <span class="hljs-punctuation">[</span><span class="hljs-string">ChannelScopeRequest</span><span class="hljs-punctuation">]</span>
 <span class="hljs-punctuation">}</span>
 </code></pre>
@@ -3563,7 +3658,7 @@ is <span class="hljs-keyword">an</span> all-<span class="hljs-keyword">or</span>
                   <head></head>
                   <body><pre><code class="hljs language-json"><span class="hljs-punctuation">{</span>
   <span class="hljs-attr">"actions"</span><span class="hljs-punctuation">:</span> <span class="hljs-punctuation">[</span><span class="hljs-string">ActionRequest</span><span class="hljs-punctuation">]</span><span class="hljs-punctuation">,</span>
-  <span class="hljs-attr">"mandatory"</span><span class="hljs-punctuation">:</span> <span class="hljs-literal"><span class="hljs-keyword">true</span></span><span class="hljs-punctuation">,</span>
+  <span class="hljs-attr">"mandatory"</span><span class="hljs-punctuation">:</span> <span class="hljs-literal"><span class="hljs-keyword">false</span></span><span class="hljs-punctuation">,</span>
   <span class="hljs-attr">"name"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"abc123"</span>
 <span class="hljs-punctuation">}</span>
 </code></pre>
@@ -3591,7 +3686,7 @@ is <span class="hljs-keyword">an</span> all-<span class="hljs-keyword">or</span>
                 <h5>Example</h5>
                 <html>
                   <head></head>
-                  <body><pre><code class="hljs language-json"><span class="hljs-number">987</span>
+                  <body><pre><code class="hljs language-json"><span class="hljs-number">123</span>
 </code></pre>
                   </body>
                 </html>
@@ -3662,11 +3757,11 @@ is <span class="hljs-keyword">an</span> all-<span class="hljs-keyword">or</span>
                   <head></head>
                   <body><pre><code class="hljs language-json"><span class="hljs-punctuation">{</span>
   <span class="hljs-attr">"actions"</span><span class="hljs-punctuation">:</span> <span class="hljs-punctuation">[</span><span class="hljs-string">ActionResponse</span><span class="hljs-punctuation">]</span><span class="hljs-punctuation">,</span>
-  <span class="hljs-attr">"createdAt"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"abc123"</span><span class="hljs-punctuation">,</span>
-  <span class="hljs-attr">"mandatory"</span><span class="hljs-punctuation">:</span> <span class="hljs-literal"><span class="hljs-keyword">false</span></span><span class="hljs-punctuation">,</span>
+  <span class="hljs-attr">"createdAt"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"xyz789"</span><span class="hljs-punctuation">,</span>
+  <span class="hljs-attr">"mandatory"</span><span class="hljs-punctuation">:</span> <span class="hljs-literal"><span class="hljs-keyword">true</span></span><span class="hljs-punctuation">,</span>
   <span class="hljs-attr">"name"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"abc123"</span><span class="hljs-punctuation">,</span>
   <span class="hljs-attr">"policyId"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"abc123"</span><span class="hljs-punctuation">,</span>
-  <span class="hljs-attr">"updatedAt"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"xyz789"</span>
+  <span class="hljs-attr">"updatedAt"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"abc123"</span>
 <span class="hljs-punctuation">}</span>
 </code></pre>
                   </body>
@@ -3738,10 +3833,10 @@ is <span class="hljs-keyword">an</span> all-<span class="hljs-keyword">or</span>
                   <body><pre><code class="hljs language-json"><span class="hljs-punctuation">{</span>
   <span class="hljs-attr">"currency"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"xyz789"</span><span class="hljs-punctuation">,</span>
   <span class="hljs-attr">"id"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"xyz789"</span><span class="hljs-punctuation">,</span>
-  <span class="hljs-attr">"level"</span><span class="hljs-punctuation">:</span> <span class="hljs-number">123</span><span class="hljs-punctuation">,</span>
+  <span class="hljs-attr">"level"</span><span class="hljs-punctuation">:</span> <span class="hljs-number">987</span><span class="hljs-punctuation">,</span>
   <span class="hljs-attr">"modifiedAt"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"xyz789"</span><span class="hljs-punctuation">,</span>
-  <span class="hljs-attr">"name"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"abc123"</span><span class="hljs-punctuation">,</span>
-  <span class="hljs-attr">"parentIds"</span><span class="hljs-punctuation">:</span> <span class="hljs-punctuation">[</span><span class="hljs-string">"abc123"</span><span class="hljs-punctuation">]</span>
+  <span class="hljs-attr">"name"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"xyz789"</span><span class="hljs-punctuation">,</span>
+  <span class="hljs-attr">"parentIds"</span><span class="hljs-punctuation">:</span> <span class="hljs-punctuation">[</span><span class="hljs-string">"xyz789"</span><span class="hljs-punctuation">]</span>
 <span class="hljs-punctuation">}</span>
 </code></pre>
                   </body>
@@ -4055,7 +4150,7 @@ is <span class="hljs-keyword">an</span> all-<span class="hljs-keyword">or</span>
                       <td>
                         <span class="property-name"><code>defaultPriceBookId</code></span> - <span class="property-type"><a href="#definition-String"><code>String</code></a></span>
                       </td>
-                      <td> Default price book identifier for the channel. </td>
+                      <td> Default price book identifier for the channel. Providing an empty string removes the default price book. </td>
                     </tr>
                     <tr>
                       <td>
@@ -4156,7 +4251,7 @@ is <span class="hljs-keyword">an</span> all-<span class="hljs-keyword">or</span>
                   <head></head>
                   <body><pre><code class="hljs language-json"><span class="hljs-punctuation">{</span>
   <span class="hljs-attr">"actions"</span><span class="hljs-punctuation">:</span> <span class="hljs-punctuation">[</span><span class="hljs-string">ActionRequest</span><span class="hljs-punctuation">]</span><span class="hljs-punctuation">,</span>
-  <span class="hljs-attr">"mandatory"</span><span class="hljs-punctuation">:</span> <span class="hljs-literal"><span class="hljs-keyword">true</span></span><span class="hljs-punctuation">,</span>
+  <span class="hljs-attr">"mandatory"</span><span class="hljs-punctuation">:</span> <span class="hljs-literal"><span class="hljs-keyword">false</span></span><span class="hljs-punctuation">,</span>
   <span class="hljs-attr">"name"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"abc123"</span><span class="hljs-punctuation">,</span>
   <span class="hljs-attr">"policyId"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"xyz789"</span>
 <span class="hljs-punctuation">}</span>

--- a/static/graphql-api/merchandising-api/index.html
+++ b/static/graphql-api/merchandising-api/index.html
@@ -63,12 +63,14 @@
             <li><a href="#definition-Int">Int</a></li>
             <li><a href="#definition-JSON">JSON</a></li>
             <li><a href="#definition-MediaGalleryInterface">MediaGalleryInterface</a></li>
+            <li><a href="#definition-PageType">PageType</a></li>
             <li><a href="#definition-Price">Price</a></li>
             <li><a href="#definition-PriceAdjustment">PriceAdjustment</a></li>
             <li><a href="#definition-ProductInterface">ProductInterface</a></li>
             <li><a href="#definition-ProductLinksInterface">ProductLinksInterface</a></li>
             <li><a href="#definition-ProductSearchItem">ProductSearchItem</a></li>
             <li><a href="#definition-ProductSearchResponse">ProductSearchResponse</a></li>
+            <li><a href="#definition-ProductSearchSortInput">ProductSearchSortInput</a></li>
             <li><a href="#definition-ProductView">ProductView</a></li>
             <li><a href="#definition-ProductViewAttribute">ProductViewAttribute</a></li>
             <li><a href="#definition-ProductViewCurrency">ProductViewCurrency</a></li>
@@ -85,6 +87,8 @@
             <li><a href="#definition-ProductViewVariant">ProductViewVariant</a></li>
             <li><a href="#definition-ProductViewVariantResults">ProductViewVariantResults</a></li>
             <li><a href="#definition-ProductViewVideo">ProductViewVideo</a></li>
+            <li><a href="#definition-PurchaseHistory">PurchaseHistory</a></li>
+            <li><a href="#definition-QueryContextInput">QueryContextInput</a></li>
             <li><a href="#definition-RangeBucket">RangeBucket</a></li>
             <li><a href="#definition-RecommendationUnit">RecommendationUnit</a></li>
             <li><a href="#definition-Recommendations">Recommendations</a></li>
@@ -95,6 +99,7 @@
             <li><a href="#definition-StatsBucket">StatsBucket</a></li>
             <li><a href="#definition-String">String</a></li>
             <li><a href="#definition-SwatchType">SwatchType</a></li>
+            <li><a href="#definition-ViewHistory">ViewHistory</a></li>
           </ul>
         </div>
       </nav>
@@ -221,6 +226,12 @@ Authorization: Bearer &lt;YOUR_TOKEN_HERE&gt;</code></pre>
                   <tbody>
                     <tr>
                       <td>
+                        <span class="property-name"><code>context</code></span> - <span class="property-type"><a href="#definition-QueryContextInput"><code>QueryContextInput</code></a></span>
+                      </td>
+                      <td> The query context </td>
+                    </tr>
+                    <tr>
+                      <td>
                         <span class="property-name"><code>current_page</code></span> - <span class="property-type"><a href="#definition-Int"><code>Int</code></a></span>
                       </td>
                       <td> Specifies which page of results to return. The default value is 1. Default = <code>1</code> </td>
@@ -237,6 +248,12 @@ Authorization: Bearer &lt;YOUR_TOKEN_HERE&gt;</code></pre>
                       </td>
                       <td> Phrase to search for in product catalog </td>
                     </tr>
+                    <tr>
+                      <td>
+                        <span class="property-name"><code>sort</code></span> - <span class="property-type"><a href="#definition-ProductSearchSortInput"><code>[ProductSearchSortInput!]</code></a></span>
+                      </td>
+                      <td> Attributes and direction to sort on </td>
+                    </tr>
                   </tbody>
                 </table>
               </div>
@@ -248,14 +265,18 @@ Authorization: Bearer &lt;YOUR_TOKEN_HERE&gt;</code></pre>
                 <html>
                   <head></head>
                   <body><pre><code class="hljs language-gql"><span class="hljs-symbol"><span class="hljs-keyword">query</span> productSearch<span class="hljs-tag">(
+  <span class="hljs-code">$context</span>:<span class="hljs-type"> QueryContextInput,</span>
   <span class="hljs-code">$current_page</span>:<span class="hljs-type"> Int,</span>
   <span class="hljs-code">$page_size</span>:<span class="hljs-type"> Int,</span>
-  <span class="hljs-code">$phrase</span>:<span class="hljs-type"> String!</span>
+  <span class="hljs-code">$phrase</span>:<span class="hljs-type"> String!</span>,
+  <span class="hljs-code">$sort</span>: <span class="hljs-type">[ProductSearchSortInput!</span>]
 )</span> <span class="hljs-tag">{
   <span class="hljs-symbol">productSearch<span class="hljs-tag">(
+    context: <span class="hljs-code">$context</span>,
     current_page: <span class="hljs-code">$current_page</span>,
     page_size: <span class="hljs-code">$page_size</span>,
-    phrase: <span class="hljs-code">$phrase</span>
+    phrase: <span class="hljs-code">$phrase</span>,
+    sort: <span class="hljs-code">$sort</span>
   )</span> <span class="hljs-tag">{
     <span class="hljs-symbol">facets <span class="hljs-tag">{
       <span class="hljs-type">...AggregationFragment</span>
@@ -280,9 +301,11 @@ Authorization: Bearer &lt;YOUR_TOKEN_HERE&gt;</code></pre>
                 <html>
                   <head></head>
                   <body><pre><code class="hljs language-json"><span class="hljs-punctuation">{</span>
+  <span class="hljs-attr">"context"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">QueryContextInput</span><span class="hljs-punctuation">,</span>
   <span class="hljs-attr">"current_page"</span><span class="hljs-punctuation">:</span> <span class="hljs-number">1</span><span class="hljs-punctuation">,</span>
   <span class="hljs-attr">"page_size"</span><span class="hljs-punctuation">:</span> <span class="hljs-number">20</span><span class="hljs-punctuation">,</span>
-  <span class="hljs-attr">"phrase"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"abc123"</span>
+  <span class="hljs-attr">"phrase"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"abc123"</span><span class="hljs-punctuation">,</span>
+  <span class="hljs-attr">"sort"</span><span class="hljs-punctuation">:</span> <span class="hljs-punctuation">[</span><span class="hljs-string">ProductSearchSortInput</span><span class="hljs-punctuation">]</span>
 <span class="hljs-punctuation">}</span>
 </code></pre>
                   </body>
@@ -415,27 +438,27 @@ Authorization: Bearer &lt;YOUR_TOKEN_HERE&gt;</code></pre>
   <span class="hljs-attr">"data"</span><span class="hljs-punctuation">:</span> <span class="hljs-punctuation">{</span>
     <span class="hljs-attr">"products"</span><span class="hljs-punctuation">:</span> <span class="hljs-punctuation">[</span>
       <span class="hljs-punctuation">{</span>
-        <span class="hljs-attr">"addToCartAllowed"</span><span class="hljs-punctuation">:</span> <span class="hljs-literal"><span class="hljs-keyword">true</span></span><span class="hljs-punctuation">,</span>
-        <span class="hljs-attr">"inStock"</span><span class="hljs-punctuation">:</span> <span class="hljs-literal"><span class="hljs-keyword">false</span></span><span class="hljs-punctuation">,</span>
-        <span class="hljs-attr">"lowStock"</span><span class="hljs-punctuation">:</span> <span class="hljs-literal"><span class="hljs-keyword">true</span></span><span class="hljs-punctuation">,</span>
+        <span class="hljs-attr">"addToCartAllowed"</span><span class="hljs-punctuation">:</span> <span class="hljs-literal"><span class="hljs-keyword">false</span></span><span class="hljs-punctuation">,</span>
+        <span class="hljs-attr">"inStock"</span><span class="hljs-punctuation">:</span> <span class="hljs-literal"><span class="hljs-keyword">true</span></span><span class="hljs-punctuation">,</span>
+        <span class="hljs-attr">"lowStock"</span><span class="hljs-punctuation">:</span> <span class="hljs-literal"><span class="hljs-keyword">false</span></span><span class="hljs-punctuation">,</span>
         <span class="hljs-attr">"attributes"</span><span class="hljs-punctuation">:</span> <span class="hljs-punctuation">[</span><span class="hljs-string">ProductViewAttribute</span><span class="hljs-punctuation">]</span><span class="hljs-punctuation">,</span>
-        <span class="hljs-attr">"description"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"abc123"</span><span class="hljs-punctuation">,</span>
-        <span class="hljs-attr">"id"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"4"</span><span class="hljs-punctuation">,</span>
+        <span class="hljs-attr">"description"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"xyz789"</span><span class="hljs-punctuation">,</span>
+        <span class="hljs-attr">"id"</span><span class="hljs-punctuation">:</span> <span class="hljs-number">4</span><span class="hljs-punctuation">,</span>
         <span class="hljs-attr">"images"</span><span class="hljs-punctuation">:</span> <span class="hljs-punctuation">[</span><span class="hljs-string">ProductViewImage</span><span class="hljs-punctuation">]</span><span class="hljs-punctuation">,</span>
         <span class="hljs-attr">"videos"</span><span class="hljs-punctuation">:</span> <span class="hljs-punctuation">[</span><span class="hljs-string">ProductViewVideo</span><span class="hljs-punctuation">]</span><span class="hljs-punctuation">,</span>
         <span class="hljs-attr">"lastModifiedAt"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"2007-12-03T10:15:30Z"</span><span class="hljs-punctuation">,</span>
-        <span class="hljs-attr">"metaDescription"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"xyz789"</span><span class="hljs-punctuation">,</span>
+        <span class="hljs-attr">"metaDescription"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"abc123"</span><span class="hljs-punctuation">,</span>
         <span class="hljs-attr">"metaKeyword"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"abc123"</span><span class="hljs-punctuation">,</span>
         <span class="hljs-attr">"metaTitle"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"xyz789"</span><span class="hljs-punctuation">,</span>
         <span class="hljs-attr">"name"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"abc123"</span><span class="hljs-punctuation">,</span>
-        <span class="hljs-attr">"shortDescription"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"xyz789"</span><span class="hljs-punctuation">,</span>
+        <span class="hljs-attr">"shortDescription"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"abc123"</span><span class="hljs-punctuation">,</span>
         <span class="hljs-attr">"sku"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"xyz789"</span><span class="hljs-punctuation">,</span>
-        <span class="hljs-attr">"externalId"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"xyz789"</span><span class="hljs-punctuation">,</span>
+        <span class="hljs-attr">"externalId"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"abc123"</span><span class="hljs-punctuation">,</span>
         <span class="hljs-attr">"url"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"xyz789"</span><span class="hljs-punctuation">,</span>
-        <span class="hljs-attr">"urlKey"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"abc123"</span><span class="hljs-punctuation">,</span>
+        <span class="hljs-attr">"urlKey"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"xyz789"</span><span class="hljs-punctuation">,</span>
         <span class="hljs-attr">"links"</span><span class="hljs-punctuation">:</span> <span class="hljs-punctuation">[</span><span class="hljs-string">ProductViewLink</span><span class="hljs-punctuation">]</span><span class="hljs-punctuation">,</span>
-        <span class="hljs-attr">"queryType"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"abc123"</span><span class="hljs-punctuation">,</span>
-        <span class="hljs-attr">"visibility"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"abc123"</span>
+        <span class="hljs-attr">"queryType"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"xyz789"</span><span class="hljs-punctuation">,</span>
+        <span class="hljs-attr">"visibility"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"xyz789"</span>
       <span class="hljs-punctuation">}</span>
     <span class="hljs-punctuation">]</span>
   <span class="hljs-punctuation">}</span>
@@ -498,6 +521,24 @@ Authorization: Bearer &lt;YOUR_TOKEN_HERE&gt;</code></pre>
                       </td>
                       <td> SKU of the product currently being viewed on PDP </td>
                     </tr>
+                    <tr>
+                      <td>
+                        <span class="property-name"><code>pageType</code></span> - <span class="property-type"><a href="#definition-PageType"><code>PageType</code></a></span>
+                      </td>
+                      <td> Type of page on which recommendations are requested </td>
+                    </tr>
+                    <tr>
+                      <td>
+                        <span class="property-name"><code>userPurchaseHistory</code></span> - <span class="property-type"><a href="#definition-PurchaseHistory"><code>[PurchaseHistory]</code></a></span>
+                      </td>
+                      <td> User purchase history with timestamp </td>
+                    </tr>
+                    <tr>
+                      <td>
+                        <span class="property-name"><code>userViewHistory</code></span> - <span class="property-type"><a href="#definition-ViewHistory"><code>[ViewHistory]</code></a></span>
+                      </td>
+                      <td> User view history with timestamp </td>
+                    </tr>
                   </tbody>
                 </table>
               </div>
@@ -511,12 +552,18 @@ Authorization: Bearer &lt;YOUR_TOKEN_HERE&gt;</code></pre>
                   <body><pre><code class="hljs language-gql"><span class="hljs-symbol"><span class="hljs-keyword">query</span> recommendations<span class="hljs-tag">(
   <span class="hljs-code">$cartSkus</span>: <span class="hljs-type">[String]</span>,
   <span class="hljs-code">$category</span>:<span class="hljs-type"> String,</span>
-  <span class="hljs-code">$currentSku</span>:<span class="hljs-type"> String
-</span>)</span> <span class="hljs-tag">{
+  <span class="hljs-code">$currentSku</span>:<span class="hljs-type"> String,</span>
+  <span class="hljs-code">$pageType</span>:<span class="hljs-type"> PageType,</span>
+  <span class="hljs-code">$userPurchaseHistory</span>: <span class="hljs-type">[PurchaseHistory]</span>,
+  <span class="hljs-code">$userViewHistory</span>: <span class="hljs-type">[ViewHistory]</span>
+)</span> <span class="hljs-tag">{
   <span class="hljs-symbol">recommendations<span class="hljs-tag">(
     cartSkus: <span class="hljs-code">$cartSkus</span>,
     category: <span class="hljs-code">$category</span>,
-    currentSku: <span class="hljs-code">$currentSku</span>
+    currentSku: <span class="hljs-code">$currentSku</span>,
+    pageType: <span class="hljs-code">$pageType</span>,
+    userPurchaseHistory: <span class="hljs-code">$userPurchaseHistory</span>,
+    userViewHistory: <span class="hljs-code">$userViewHistory</span>
   )</span> <span class="hljs-tag">{
     <span class="hljs-symbol">results <span class="hljs-tag">{
       <span class="hljs-type">...RecommendationUnitFragment</span>
@@ -534,8 +581,11 @@ Authorization: Bearer &lt;YOUR_TOKEN_HERE&gt;</code></pre>
                   <head></head>
                   <body><pre><code class="hljs language-json"><span class="hljs-punctuation">{</span>
   <span class="hljs-attr">"cartSkus"</span><span class="hljs-punctuation">:</span> <span class="hljs-punctuation">[</span><span class="hljs-string">"abc123"</span><span class="hljs-punctuation">]</span><span class="hljs-punctuation">,</span>
-  <span class="hljs-attr">"category"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"xyz789"</span><span class="hljs-punctuation">,</span>
-  <span class="hljs-attr">"currentSku"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"abc123"</span>
+  <span class="hljs-attr">"category"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"abc123"</span><span class="hljs-punctuation">,</span>
+  <span class="hljs-attr">"currentSku"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"abc123"</span><span class="hljs-punctuation">,</span>
+  <span class="hljs-attr">"pageType"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"CMS"</span><span class="hljs-punctuation">,</span>
+  <span class="hljs-attr">"userPurchaseHistory"</span><span class="hljs-punctuation">:</span> <span class="hljs-punctuation">[</span><span class="hljs-string">PurchaseHistory</span><span class="hljs-punctuation">]</span><span class="hljs-punctuation">,</span>
+  <span class="hljs-attr">"userViewHistory"</span><span class="hljs-punctuation">:</span> <span class="hljs-punctuation">[</span><span class="hljs-string">ViewHistory</span><span class="hljs-punctuation">]</span>
 <span class="hljs-punctuation">}</span>
 </code></pre>
                   </body>
@@ -599,6 +649,18 @@ Authorization: Bearer &lt;YOUR_TOKEN_HERE&gt;</code></pre>
                     </tr>
                     <tr>
                       <td>
+                        <span class="property-name"><code>userPurchaseHistory</code></span> - <span class="property-type"><a href="#definition-PurchaseHistory"><code>[PurchaseHistory]</code></a></span>
+                      </td>
+                      <td> User purchase history with timestamp </td>
+                    </tr>
+                    <tr>
+                      <td>
+                        <span class="property-name"><code>userViewHistory</code></span> - <span class="property-type"><a href="#definition-ViewHistory"><code>[ViewHistory]</code></a></span>
+                      </td>
+                      <td> User view history with timestamp </td>
+                    </tr>
+                    <tr>
+                      <td>
                         <span class="property-name"><code>cartSkus</code></span> - <span class="property-type"><a href="#definition-String"><code>[String]</code></a></span>
                       </td>
                       <td> SKUs of products in the cart </td>
@@ -616,11 +678,15 @@ Authorization: Bearer &lt;YOUR_TOKEN_HERE&gt;</code></pre>
                   <body><pre><code class="hljs language-gql"><span class="hljs-symbol"><span class="hljs-keyword">query</span> recommendationsByUnitIds<span class="hljs-tag">(
   <span class="hljs-code">$unitIds</span>: <span class="hljs-type">[String!</span>]!,
   <span class="hljs-code">$currentSku</span>:<span class="hljs-type"> String,</span>
+  <span class="hljs-code">$userPurchaseHistory</span>: <span class="hljs-type">[PurchaseHistory]</span>,
+  <span class="hljs-code">$userViewHistory</span>: <span class="hljs-type">[ViewHistory]</span>,
   <span class="hljs-code">$cartSkus</span>: <span class="hljs-type">[String]</span>
 )</span> <span class="hljs-tag">{
   <span class="hljs-symbol">recommendationsByUnitIds<span class="hljs-tag">(
     unitIds: <span class="hljs-code">$unitIds</span>,
     currentSku: <span class="hljs-code">$currentSku</span>,
+    userPurchaseHistory: <span class="hljs-code">$userPurchaseHistory</span>,
+    userViewHistory: <span class="hljs-code">$userViewHistory</span>,
     cartSkus: <span class="hljs-code">$cartSkus</span>
   )</span> <span class="hljs-tag">{
     <span class="hljs-symbol">results <span class="hljs-tag">{
@@ -638,9 +704,11 @@ Authorization: Bearer &lt;YOUR_TOKEN_HERE&gt;</code></pre>
                 <html>
                   <head></head>
                   <body><pre><code class="hljs language-json"><span class="hljs-punctuation">{</span>
-  <span class="hljs-attr">"unitIds"</span><span class="hljs-punctuation">:</span> <span class="hljs-punctuation">[</span><span class="hljs-string">"xyz789"</span><span class="hljs-punctuation">]</span><span class="hljs-punctuation">,</span>
+  <span class="hljs-attr">"unitIds"</span><span class="hljs-punctuation">:</span> <span class="hljs-punctuation">[</span><span class="hljs-string">"abc123"</span><span class="hljs-punctuation">]</span><span class="hljs-punctuation">,</span>
   <span class="hljs-attr">"currentSku"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"xyz789"</span><span class="hljs-punctuation">,</span>
-  <span class="hljs-attr">"cartSkus"</span><span class="hljs-punctuation">:</span> <span class="hljs-punctuation">[</span><span class="hljs-string">"xyz789"</span><span class="hljs-punctuation">]</span>
+  <span class="hljs-attr">"userPurchaseHistory"</span><span class="hljs-punctuation">:</span> <span class="hljs-punctuation">[</span><span class="hljs-string">PurchaseHistory</span><span class="hljs-punctuation">]</span><span class="hljs-punctuation">,</span>
+  <span class="hljs-attr">"userViewHistory"</span><span class="hljs-punctuation">:</span> <span class="hljs-punctuation">[</span><span class="hljs-string">ViewHistory</span><span class="hljs-punctuation">]</span><span class="hljs-punctuation">,</span>
+  <span class="hljs-attr">"cartSkus"</span><span class="hljs-punctuation">:</span> <span class="hljs-punctuation">[</span><span class="hljs-string">"abc123"</span><span class="hljs-punctuation">]</span>
 <span class="hljs-punctuation">}</span>
 </code></pre>
                   </body>
@@ -762,7 +830,7 @@ Authorization: Bearer &lt;YOUR_TOKEN_HERE&gt;</code></pre>
                 <html>
                   <head></head>
                   <body><pre><code class="hljs language-json"><span class="hljs-punctuation">{</span>
-  <span class="hljs-attr">"optionIds"</span><span class="hljs-punctuation">:</span> <span class="hljs-punctuation">[</span><span class="hljs-string">"abc123"</span><span class="hljs-punctuation">]</span><span class="hljs-punctuation">,</span>
+  <span class="hljs-attr">"optionIds"</span><span class="hljs-punctuation">:</span> <span class="hljs-punctuation">[</span><span class="hljs-string">"xyz789"</span><span class="hljs-punctuation">]</span><span class="hljs-punctuation">,</span>
   <span class="hljs-attr">"sku"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"xyz789"</span>
 <span class="hljs-punctuation">}</span>
 </code></pre>
@@ -778,25 +846,25 @@ Authorization: Bearer &lt;YOUR_TOKEN_HERE&gt;</code></pre>
     <span class="hljs-attr">"refineProduct"</span><span class="hljs-punctuation">:</span> <span class="hljs-punctuation">{</span>
       <span class="hljs-attr">"addToCartAllowed"</span><span class="hljs-punctuation">:</span> <span class="hljs-literal"><span class="hljs-keyword">false</span></span><span class="hljs-punctuation">,</span>
       <span class="hljs-attr">"inStock"</span><span class="hljs-punctuation">:</span> <span class="hljs-literal"><span class="hljs-keyword">false</span></span><span class="hljs-punctuation">,</span>
-      <span class="hljs-attr">"lowStock"</span><span class="hljs-punctuation">:</span> <span class="hljs-literal"><span class="hljs-keyword">true</span></span><span class="hljs-punctuation">,</span>
+      <span class="hljs-attr">"lowStock"</span><span class="hljs-punctuation">:</span> <span class="hljs-literal"><span class="hljs-keyword">false</span></span><span class="hljs-punctuation">,</span>
       <span class="hljs-attr">"attributes"</span><span class="hljs-punctuation">:</span> <span class="hljs-punctuation">[</span><span class="hljs-string">ProductViewAttribute</span><span class="hljs-punctuation">]</span><span class="hljs-punctuation">,</span>
-      <span class="hljs-attr">"description"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"xyz789"</span><span class="hljs-punctuation">,</span>
-      <span class="hljs-attr">"id"</span><span class="hljs-punctuation">:</span> <span class="hljs-number">4</span><span class="hljs-punctuation">,</span>
+      <span class="hljs-attr">"description"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"abc123"</span><span class="hljs-punctuation">,</span>
+      <span class="hljs-attr">"id"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"4"</span><span class="hljs-punctuation">,</span>
       <span class="hljs-attr">"images"</span><span class="hljs-punctuation">:</span> <span class="hljs-punctuation">[</span><span class="hljs-string">ProductViewImage</span><span class="hljs-punctuation">]</span><span class="hljs-punctuation">,</span>
       <span class="hljs-attr">"videos"</span><span class="hljs-punctuation">:</span> <span class="hljs-punctuation">[</span><span class="hljs-string">ProductViewVideo</span><span class="hljs-punctuation">]</span><span class="hljs-punctuation">,</span>
       <span class="hljs-attr">"lastModifiedAt"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"2007-12-03T10:15:30Z"</span><span class="hljs-punctuation">,</span>
       <span class="hljs-attr">"metaDescription"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"abc123"</span><span class="hljs-punctuation">,</span>
-      <span class="hljs-attr">"metaKeyword"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"xyz789"</span><span class="hljs-punctuation">,</span>
-      <span class="hljs-attr">"metaTitle"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"abc123"</span><span class="hljs-punctuation">,</span>
+      <span class="hljs-attr">"metaKeyword"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"abc123"</span><span class="hljs-punctuation">,</span>
+      <span class="hljs-attr">"metaTitle"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"xyz789"</span><span class="hljs-punctuation">,</span>
       <span class="hljs-attr">"name"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"abc123"</span><span class="hljs-punctuation">,</span>
-      <span class="hljs-attr">"shortDescription"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"xyz789"</span><span class="hljs-punctuation">,</span>
+      <span class="hljs-attr">"shortDescription"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"abc123"</span><span class="hljs-punctuation">,</span>
       <span class="hljs-attr">"sku"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"abc123"</span><span class="hljs-punctuation">,</span>
       <span class="hljs-attr">"externalId"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"abc123"</span><span class="hljs-punctuation">,</span>
       <span class="hljs-attr">"url"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"xyz789"</span><span class="hljs-punctuation">,</span>
       <span class="hljs-attr">"urlKey"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"xyz789"</span><span class="hljs-punctuation">,</span>
       <span class="hljs-attr">"links"</span><span class="hljs-punctuation">:</span> <span class="hljs-punctuation">[</span><span class="hljs-string">ProductViewLink</span><span class="hljs-punctuation">]</span><span class="hljs-punctuation">,</span>
-      <span class="hljs-attr">"queryType"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"abc123"</span><span class="hljs-punctuation">,</span>
-      <span class="hljs-attr">"visibility"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"abc123"</span>
+      <span class="hljs-attr">"queryType"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"xyz789"</span><span class="hljs-punctuation">,</span>
+      <span class="hljs-attr">"visibility"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"xyz789"</span>
     <span class="hljs-punctuation">}</span>
   <span class="hljs-punctuation">}</span>
 <span class="hljs-punctuation">}</span>
@@ -899,8 +967,8 @@ Authorization: Bearer &lt;YOUR_TOKEN_HERE&gt;</code></pre>
                   <body><pre><code class="hljs language-json"><span class="hljs-punctuation">{</span>
   <span class="hljs-attr">"sku"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"abc123"</span><span class="hljs-punctuation">,</span>
   <span class="hljs-attr">"optionIds"</span><span class="hljs-punctuation">:</span> <span class="hljs-punctuation">[</span><span class="hljs-string">"abc123"</span><span class="hljs-punctuation">]</span><span class="hljs-punctuation">,</span>
-  <span class="hljs-attr">"pageSize"</span><span class="hljs-punctuation">:</span> <span class="hljs-number">123</span><span class="hljs-punctuation">,</span>
-  <span class="hljs-attr">"cursor"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"abc123"</span>
+  <span class="hljs-attr">"pageSize"</span><span class="hljs-punctuation">:</span> <span class="hljs-number">987</span><span class="hljs-punctuation">,</span>
+  <span class="hljs-attr">"cursor"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"xyz789"</span>
 <span class="hljs-punctuation">}</span>
 </code></pre>
                   </body>
@@ -914,7 +982,7 @@ Authorization: Bearer &lt;YOUR_TOKEN_HERE&gt;</code></pre>
   <span class="hljs-attr">"data"</span><span class="hljs-punctuation">:</span> <span class="hljs-punctuation">{</span>
     <span class="hljs-attr">"variants"</span><span class="hljs-punctuation">:</span> <span class="hljs-punctuation">{</span>
       <span class="hljs-attr">"variants"</span><span class="hljs-punctuation">:</span> <span class="hljs-punctuation">[</span><span class="hljs-string">ProductViewVariant</span><span class="hljs-punctuation">]</span><span class="hljs-punctuation">,</span>
-      <span class="hljs-attr">"cursor"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"xyz789"</span>
+      <span class="hljs-attr">"cursor"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"abc123"</span>
     <span class="hljs-punctuation">}</span>
   <span class="hljs-punctuation">}</span>
 <span class="hljs-punctuation">}</span>
@@ -1095,7 +1163,7 @@ Authorization: Bearer &lt;YOUR_TOKEN_HERE&gt;</code></pre>
                   <head></head>
                   <body><pre><code class="hljs language-json"><span class="hljs-punctuation">{</span>
   <span class="hljs-attr">"action_type"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"BOOST"</span><span class="hljs-punctuation">,</span>
-  <span class="hljs-attr">"rule_id"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"abc123"</span><span class="hljs-punctuation">,</span>
+  <span class="hljs-attr">"rule_id"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"xyz789"</span><span class="hljs-punctuation">,</span>
   <span class="hljs-attr">"rule_name"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"xyz789"</span>
 <span class="hljs-punctuation">}</span>
 </code></pre>
@@ -1307,7 +1375,7 @@ Authorization: Bearer &lt;YOUR_TOKEN_HERE&gt;</code></pre>
                 <h5>Example</h5>
                 <html>
                   <head></head>
-                  <body><pre><code class="hljs language-json"><span class="hljs-punctuation">{</span><span class="hljs-attr">"title"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"xyz789"</span><span class="hljs-punctuation">}</span>
+                  <body><pre><code class="hljs language-json"><span class="hljs-punctuation">{</span><span class="hljs-attr">"title"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"abc123"</span><span class="hljs-punctuation">}</span>
 </code></pre>
                   </body>
                 </html>
@@ -1372,8 +1440,8 @@ Authorization: Bearer &lt;YOUR_TOKEN_HERE&gt;</code></pre>
                   <head></head>
                   <body><pre><code class="hljs language-json"><span class="hljs-punctuation">{</span>
   <span class="hljs-attr">"count"</span><span class="hljs-punctuation">:</span> <span class="hljs-number">123</span><span class="hljs-punctuation">,</span>
-  <span class="hljs-attr">"id"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"4"</span><span class="hljs-punctuation">,</span>
-  <span class="hljs-attr">"path"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"abc123"</span><span class="hljs-punctuation">,</span>
+  <span class="hljs-attr">"id"</span><span class="hljs-punctuation">:</span> <span class="hljs-number">4</span><span class="hljs-punctuation">,</span>
+  <span class="hljs-attr">"path"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"xyz789"</span><span class="hljs-punctuation">,</span>
   <span class="hljs-attr">"title"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"xyz789"</span>
 <span class="hljs-punctuation">}</span>
 </code></pre>
@@ -1433,7 +1501,7 @@ Authorization: Bearer &lt;YOUR_TOKEN_HERE&gt;</code></pre>
                 <h5>Example</h5>
                 <html>
                   <head></head>
-                  <body><pre><code class="hljs language-json"><span class="hljs-punctuation">{</span><span class="hljs-attr">"id"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"4"</span><span class="hljs-punctuation">}</span>
+                  <body><pre><code class="hljs language-json"><span class="hljs-punctuation">{</span><span class="hljs-attr">"id"</span><span class="hljs-punctuation">:</span> <span class="hljs-number">4</span><span class="hljs-punctuation">}</span>
 </code></pre>
                   </body>
                 </html>
@@ -1608,23 +1676,23 @@ Authorization: Bearer &lt;YOUR_TOKEN_HERE&gt;</code></pre>
   <span class="hljs-attr">"available_sort_by"</span><span class="hljs-punctuation">:</span> <span class="hljs-punctuation">[</span><span class="hljs-string">"abc123"</span><span class="hljs-punctuation">]</span><span class="hljs-punctuation">,</span>
   <span class="hljs-attr">"canonical_url"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"xyz789"</span><span class="hljs-punctuation">,</span>
   <span class="hljs-attr">"children_count"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"xyz789"</span><span class="hljs-punctuation">,</span>
-  <span class="hljs-attr">"custom_layout_update_file"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"xyz789"</span><span class="hljs-punctuation">,</span>
-  <span class="hljs-attr">"default_sort_by"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"xyz789"</span><span class="hljs-punctuation">,</span>
-  <span class="hljs-attr">"description"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"abc123"</span><span class="hljs-punctuation">,</span>
-  <span class="hljs-attr">"display_mode"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"xyz789"</span><span class="hljs-punctuation">,</span>
+  <span class="hljs-attr">"custom_layout_update_file"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"abc123"</span><span class="hljs-punctuation">,</span>
+  <span class="hljs-attr">"default_sort_by"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"abc123"</span><span class="hljs-punctuation">,</span>
+  <span class="hljs-attr">"description"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"xyz789"</span><span class="hljs-punctuation">,</span>
+  <span class="hljs-attr">"display_mode"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"abc123"</span><span class="hljs-punctuation">,</span>
   <span class="hljs-attr">"filter_price_range"</span><span class="hljs-punctuation">:</span> <span class="hljs-number">123.45</span><span class="hljs-punctuation">,</span>
-  <span class="hljs-attr">"image"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"xyz789"</span><span class="hljs-punctuation">,</span>
+  <span class="hljs-attr">"image"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"abc123"</span><span class="hljs-punctuation">,</span>
   <span class="hljs-attr">"include_in_menu"</span><span class="hljs-punctuation">:</span> <span class="hljs-number">987</span><span class="hljs-punctuation">,</span>
   <span class="hljs-attr">"is_anchor"</span><span class="hljs-punctuation">:</span> <span class="hljs-number">123</span><span class="hljs-punctuation">,</span>
   <span class="hljs-attr">"landing_page"</span><span class="hljs-punctuation">:</span> <span class="hljs-number">987</span><span class="hljs-punctuation">,</span>
-  <span class="hljs-attr">"level"</span><span class="hljs-punctuation">:</span> <span class="hljs-number">987</span><span class="hljs-punctuation">,</span>
+  <span class="hljs-attr">"level"</span><span class="hljs-punctuation">:</span> <span class="hljs-number">123</span><span class="hljs-punctuation">,</span>
   <span class="hljs-attr">"meta_description"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"xyz789"</span><span class="hljs-punctuation">,</span>
   <span class="hljs-attr">"meta_keywords"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"abc123"</span><span class="hljs-punctuation">,</span>
-  <span class="hljs-attr">"meta_title"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"xyz789"</span><span class="hljs-punctuation">,</span>
-  <span class="hljs-attr">"name"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"xyz789"</span><span class="hljs-punctuation">,</span>
+  <span class="hljs-attr">"meta_title"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"abc123"</span><span class="hljs-punctuation">,</span>
+  <span class="hljs-attr">"name"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"abc123"</span><span class="hljs-punctuation">,</span>
   <span class="hljs-attr">"path"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"xyz789"</span><span class="hljs-punctuation">,</span>
   <span class="hljs-attr">"path_in_store"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"abc123"</span><span class="hljs-punctuation">,</span>
-  <span class="hljs-attr">"position"</span><span class="hljs-punctuation">:</span> <span class="hljs-number">123</span><span class="hljs-punctuation">,</span>
+  <span class="hljs-attr">"position"</span><span class="hljs-punctuation">:</span> <span class="hljs-number">987</span><span class="hljs-punctuation">,</span>
   <span class="hljs-attr">"product_count"</span><span class="hljs-punctuation">:</span> <span class="hljs-number">123</span><span class="hljs-punctuation">,</span>
   <span class="hljs-attr">"uid"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"4"</span><span class="hljs-punctuation">,</span>
   <span class="hljs-attr">"url_key"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"abc123"</span><span class="hljs-punctuation">,</span>
@@ -1751,15 +1819,15 @@ Authorization: Bearer &lt;YOUR_TOKEN_HERE&gt;</code></pre>
                 <html>
                   <head></head>
                   <body><pre><code class="hljs language-json"><span class="hljs-punctuation">{</span>
-  <span class="hljs-attr">"availableSortBy"</span><span class="hljs-punctuation">:</span> <span class="hljs-punctuation">[</span><span class="hljs-string">"abc123"</span><span class="hljs-punctuation">]</span><span class="hljs-punctuation">,</span>
-  <span class="hljs-attr">"children"</span><span class="hljs-punctuation">:</span> <span class="hljs-punctuation">[</span><span class="hljs-string">"xyz789"</span><span class="hljs-punctuation">]</span><span class="hljs-punctuation">,</span>
+  <span class="hljs-attr">"availableSortBy"</span><span class="hljs-punctuation">:</span> <span class="hljs-punctuation">[</span><span class="hljs-string">"xyz789"</span><span class="hljs-punctuation">]</span><span class="hljs-punctuation">,</span>
+  <span class="hljs-attr">"children"</span><span class="hljs-punctuation">:</span> <span class="hljs-punctuation">[</span><span class="hljs-string">"abc123"</span><span class="hljs-punctuation">]</span><span class="hljs-punctuation">,</span>
   <span class="hljs-attr">"defaultSortBy"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"xyz789"</span><span class="hljs-punctuation">,</span>
   <span class="hljs-attr">"id"</span><span class="hljs-punctuation">:</span> <span class="hljs-number">4</span><span class="hljs-punctuation">,</span>
-  <span class="hljs-attr">"level"</span><span class="hljs-punctuation">:</span> <span class="hljs-number">123</span><span class="hljs-punctuation">,</span>
+  <span class="hljs-attr">"level"</span><span class="hljs-punctuation">:</span> <span class="hljs-number">987</span><span class="hljs-punctuation">,</span>
   <span class="hljs-attr">"name"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"xyz789"</span><span class="hljs-punctuation">,</span>
-  <span class="hljs-attr">"parentId"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"xyz789"</span><span class="hljs-punctuation">,</span>
+  <span class="hljs-attr">"parentId"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"abc123"</span><span class="hljs-punctuation">,</span>
   <span class="hljs-attr">"path"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"abc123"</span><span class="hljs-punctuation">,</span>
-  <span class="hljs-attr">"roles"</span><span class="hljs-punctuation">:</span> <span class="hljs-punctuation">[</span><span class="hljs-string">"abc123"</span><span class="hljs-punctuation">]</span><span class="hljs-punctuation">,</span>
+  <span class="hljs-attr">"roles"</span><span class="hljs-punctuation">:</span> <span class="hljs-punctuation">[</span><span class="hljs-string">"xyz789"</span><span class="hljs-punctuation">]</span><span class="hljs-punctuation">,</span>
   <span class="hljs-attr">"urlKey"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"xyz789"</span><span class="hljs-punctuation">,</span>
   <span class="hljs-attr">"urlPath"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"abc123"</span><span class="hljs-punctuation">,</span>
   <span class="hljs-attr">"count"</span><span class="hljs-punctuation">:</span> <span class="hljs-number">123</span><span class="hljs-punctuation">,</span>
@@ -1872,14 +1940,14 @@ Authorization: Bearer &lt;YOUR_TOKEN_HERE&gt;</code></pre>
                 <html>
                   <head></head>
                   <body><pre><code class="hljs language-json"><span class="hljs-punctuation">{</span>
-  <span class="hljs-attr">"availableSortBy"</span><span class="hljs-punctuation">:</span> <span class="hljs-punctuation">[</span><span class="hljs-string">"xyz789"</span><span class="hljs-punctuation">]</span><span class="hljs-punctuation">,</span>
+  <span class="hljs-attr">"availableSortBy"</span><span class="hljs-punctuation">:</span> <span class="hljs-punctuation">[</span><span class="hljs-string">"abc123"</span><span class="hljs-punctuation">]</span><span class="hljs-punctuation">,</span>
   <span class="hljs-attr">"defaultSortBy"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"abc123"</span><span class="hljs-punctuation">,</span>
-  <span class="hljs-attr">"id"</span><span class="hljs-punctuation">:</span> <span class="hljs-number">4</span><span class="hljs-punctuation">,</span>
-  <span class="hljs-attr">"level"</span><span class="hljs-punctuation">:</span> <span class="hljs-number">123</span><span class="hljs-punctuation">,</span>
+  <span class="hljs-attr">"id"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"4"</span><span class="hljs-punctuation">,</span>
+  <span class="hljs-attr">"level"</span><span class="hljs-punctuation">:</span> <span class="hljs-number">987</span><span class="hljs-punctuation">,</span>
   <span class="hljs-attr">"name"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"xyz789"</span><span class="hljs-punctuation">,</span>
   <span class="hljs-attr">"path"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"xyz789"</span><span class="hljs-punctuation">,</span>
   <span class="hljs-attr">"roles"</span><span class="hljs-punctuation">:</span> <span class="hljs-punctuation">[</span><span class="hljs-string">"abc123"</span><span class="hljs-punctuation">]</span><span class="hljs-punctuation">,</span>
-  <span class="hljs-attr">"urlKey"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"xyz789"</span><span class="hljs-punctuation">,</span>
+  <span class="hljs-attr">"urlKey"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"abc123"</span><span class="hljs-punctuation">,</span>
   <span class="hljs-attr">"urlPath"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"abc123"</span>
 <span class="hljs-punctuation">}</span>
 </code></pre>
@@ -2082,24 +2150,24 @@ Authorization: Bearer &lt;YOUR_TOKEN_HERE&gt;</code></pre>
                   <body><pre><code class="hljs language-json"><span class="hljs-punctuation">{</span>
   <span class="hljs-attr">"addToCartAllowed"</span><span class="hljs-punctuation">:</span> <span class="hljs-literal"><span class="hljs-keyword">true</span></span><span class="hljs-punctuation">,</span>
   <span class="hljs-attr">"inStock"</span><span class="hljs-punctuation">:</span> <span class="hljs-literal"><span class="hljs-keyword">false</span></span><span class="hljs-punctuation">,</span>
-  <span class="hljs-attr">"lowStock"</span><span class="hljs-punctuation">:</span> <span class="hljs-literal"><span class="hljs-keyword">true</span></span><span class="hljs-punctuation">,</span>
+  <span class="hljs-attr">"lowStock"</span><span class="hljs-punctuation">:</span> <span class="hljs-literal"><span class="hljs-keyword">false</span></span><span class="hljs-punctuation">,</span>
   <span class="hljs-attr">"attributes"</span><span class="hljs-punctuation">:</span> <span class="hljs-punctuation">[</span><span class="hljs-string">ProductViewAttribute</span><span class="hljs-punctuation">]</span><span class="hljs-punctuation">,</span>
-  <span class="hljs-attr">"description"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"abc123"</span><span class="hljs-punctuation">,</span>
+  <span class="hljs-attr">"description"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"xyz789"</span><span class="hljs-punctuation">,</span>
   <span class="hljs-attr">"id"</span><span class="hljs-punctuation">:</span> <span class="hljs-number">4</span><span class="hljs-punctuation">,</span>
   <span class="hljs-attr">"images"</span><span class="hljs-punctuation">:</span> <span class="hljs-punctuation">[</span><span class="hljs-string">ProductViewImage</span><span class="hljs-punctuation">]</span><span class="hljs-punctuation">,</span>
   <span class="hljs-attr">"videos"</span><span class="hljs-punctuation">:</span> <span class="hljs-punctuation">[</span><span class="hljs-string">ProductViewVideo</span><span class="hljs-punctuation">]</span><span class="hljs-punctuation">,</span>
   <span class="hljs-attr">"lastModifiedAt"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"2007-12-03T10:15:30Z"</span><span class="hljs-punctuation">,</span>
-  <span class="hljs-attr">"metaDescription"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"xyz789"</span><span class="hljs-punctuation">,</span>
+  <span class="hljs-attr">"metaDescription"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"abc123"</span><span class="hljs-punctuation">,</span>
   <span class="hljs-attr">"metaKeyword"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"abc123"</span><span class="hljs-punctuation">,</span>
-  <span class="hljs-attr">"metaTitle"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"abc123"</span><span class="hljs-punctuation">,</span>
+  <span class="hljs-attr">"metaTitle"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"xyz789"</span><span class="hljs-punctuation">,</span>
   <span class="hljs-attr">"name"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"abc123"</span><span class="hljs-punctuation">,</span>
   <span class="hljs-attr">"options"</span><span class="hljs-punctuation">:</span> <span class="hljs-punctuation">[</span><span class="hljs-string">ProductViewOption</span><span class="hljs-punctuation">]</span><span class="hljs-punctuation">,</span>
   <span class="hljs-attr">"priceRange"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">ProductViewPriceRange</span><span class="hljs-punctuation">,</span>
-  <span class="hljs-attr">"shortDescription"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"abc123"</span><span class="hljs-punctuation">,</span>
+  <span class="hljs-attr">"shortDescription"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"xyz789"</span><span class="hljs-punctuation">,</span>
   <span class="hljs-attr">"sku"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"xyz789"</span><span class="hljs-punctuation">,</span>
-  <span class="hljs-attr">"externalId"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"xyz789"</span><span class="hljs-punctuation">,</span>
-  <span class="hljs-attr">"url"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"abc123"</span><span class="hljs-punctuation">,</span>
-  <span class="hljs-attr">"urlKey"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"abc123"</span><span class="hljs-punctuation">,</span>
+  <span class="hljs-attr">"externalId"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"abc123"</span><span class="hljs-punctuation">,</span>
+  <span class="hljs-attr">"url"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"xyz789"</span><span class="hljs-punctuation">,</span>
+  <span class="hljs-attr">"urlKey"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"xyz789"</span><span class="hljs-punctuation">,</span>
   <span class="hljs-attr">"links"</span><span class="hljs-punctuation">:</span> <span class="hljs-punctuation">[</span><span class="hljs-string">ProductViewLink</span><span class="hljs-punctuation">]</span><span class="hljs-punctuation">,</span>
   <span class="hljs-attr">"queryType"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"xyz789"</span><span class="hljs-punctuation">,</span>
   <span class="hljs-attr">"visibility"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"abc123"</span>
@@ -2189,10 +2257,10 @@ Authorization: Bearer &lt;YOUR_TOKEN_HERE&gt;</code></pre>
                 <html>
                   <head></head>
                   <body><pre><code class="hljs language-json"><span class="hljs-punctuation">{</span>
-  <span class="hljs-attr">"attribute"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"abc123"</span><span class="hljs-punctuation">,</span>
-  <span class="hljs-attr">"frontendInput"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"xyz789"</span><span class="hljs-punctuation">,</span>
+  <span class="hljs-attr">"attribute"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"xyz789"</span><span class="hljs-punctuation">,</span>
+  <span class="hljs-attr">"frontendInput"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"abc123"</span><span class="hljs-punctuation">,</span>
   <span class="hljs-attr">"label"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"abc123"</span><span class="hljs-punctuation">,</span>
-  <span class="hljs-attr">"numeric"</span><span class="hljs-punctuation">:</span> <span class="hljs-literal"><span class="hljs-keyword">true</span></span>
+  <span class="hljs-attr">"numeric"</span><span class="hljs-punctuation">:</span> <span class="hljs-literal"><span class="hljs-keyword">false</span></span>
 <span class="hljs-punctuation">}</span>
 </code></pre>
                   </body>
@@ -2275,7 +2343,7 @@ Authorization: Bearer &lt;YOUR_TOKEN_HERE&gt;</code></pre>
                   <head></head>
                   <body><pre><code class="hljs language-json"><span class="hljs-punctuation">{</span>
   <span class="hljs-attr">"attribute"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"abc123"</span><span class="hljs-punctuation">,</span>
-  <span class="hljs-attr">"matched_words"</span><span class="hljs-punctuation">:</span> <span class="hljs-punctuation">[</span><span class="hljs-string">"abc123"</span><span class="hljs-punctuation">]</span><span class="hljs-punctuation">,</span>
+  <span class="hljs-attr">"matched_words"</span><span class="hljs-punctuation">:</span> <span class="hljs-punctuation">[</span><span class="hljs-string">"xyz789"</span><span class="hljs-punctuation">]</span><span class="hljs-punctuation">,</span>
   <span class="hljs-attr">"value"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"abc123"</span>
 <span class="hljs-punctuation">}</span>
 </code></pre>
@@ -2303,7 +2371,7 @@ Authorization: Bearer &lt;YOUR_TOKEN_HERE&gt;</code></pre>
                 <h5>Example</h5>
                 <html>
                   <head></head>
-                  <body><pre><code class="hljs language-gql"><span class="hljs-symbol">"4"</span>
+                  <body><pre><code class="hljs language-json"><span class="hljs-number">4</span>
 </code></pre>
                   </body>
                 </html>
@@ -2415,11 +2483,93 @@ Authorization: Bearer &lt;YOUR_TOKEN_HERE&gt;</code></pre>
                 <html>
                   <head></head>
                   <body><pre><code class="hljs language-json"><span class="hljs-punctuation">{</span>
-  <span class="hljs-attr">"disabled"</span><span class="hljs-punctuation">:</span> <span class="hljs-literal"><span class="hljs-keyword">false</span></span><span class="hljs-punctuation">,</span>
-  <span class="hljs-attr">"label"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"abc123"</span><span class="hljs-punctuation">,</span>
+  <span class="hljs-attr">"disabled"</span><span class="hljs-punctuation">:</span> <span class="hljs-literal"><span class="hljs-keyword">true</span></span><span class="hljs-punctuation">,</span>
+  <span class="hljs-attr">"label"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"xyz789"</span><span class="hljs-punctuation">,</span>
   <span class="hljs-attr">"position"</span><span class="hljs-punctuation">:</span> <span class="hljs-number">123</span><span class="hljs-punctuation">,</span>
   <span class="hljs-attr">"url"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"abc123"</span>
 <span class="hljs-punctuation">}</span>
+</code></pre>
+                  </body>
+                </html>
+              </div>
+            </div>
+            <a href="#top">back to top</a>
+          </div>
+        </section>
+        <section id="definition-PageType" class="definition definition-enum" data-traverse-target="definition-PageType">
+          <div class="definition-group-name">
+            <a href="#group-Types">Types</a>
+          </div>
+          <h2 class="definition-heading">PageType</h2>
+          <div class="doc-row">
+            <div class="doc-copy">
+              <div class="definition-description doc-copy-section">
+                <h5>Description</h5>
+                <p>Type of page on which recommendations are requested</p>
+              </div>
+              <div class="definition-properties doc-copy-section">
+                <h5>Values</h5>
+                <table>
+                  <thead>
+                    <tr>
+                      <th>Enum Value</th>
+                      <th>Description</th>
+                    </tr>
+                  </thead>
+                  <tbody>
+                    <tr>
+                      <td>
+                        <p><code>CMS</code></p>
+                      </td>
+                      <td>
+                      </td>
+                    </tr>
+                    <tr>
+                      <td>
+                        <p><code>Cart</code></p>
+                      </td>
+                      <td>
+                      </td>
+                    </tr>
+                    <tr>
+                      <td>
+                        <p class="definition-deprecated"><code>Category</code></p>
+                      </td>
+                      <td>
+                        <span class="deprecation-reason definition-enum-deprecation-reason">This field is deprecated and will be removed.</span>
+                      </td>
+                    </tr>
+                    <tr>
+                      <td>
+                        <p><code>Checkout</code></p>
+                      </td>
+                      <td>
+                      </td>
+                    </tr>
+                    <tr>
+                      <td>
+                        <p><code>PageBuilder</code></p>
+                      </td>
+                      <td>
+                      </td>
+                    </tr>
+                    <tr>
+                      <td>
+                        <p><code>Product</code></p>
+                      </td>
+                      <td>
+                      </td>
+                    </tr>
+                  </tbody>
+                </table>
+              </div>
+            </div>
+            <div class="doc-examples">
+              <div class="example-section example-section-is-code">
+                <h5>Example</h5>
+                <html>
+                  <head></head>
+                  <body><pre><code class="hljs language-gql"><span class="hljs-symbol">"CMS"</span>
 </code></pre>
                   </body>
                 </html>
@@ -2520,7 +2670,7 @@ Authorization: Bearer &lt;YOUR_TOKEN_HERE&gt;</code></pre>
                 <h5>Example</h5>
                 <html>
                   <head></head>
-                  <body><pre><code class="hljs language-json"><span class="hljs-punctuation">{</span><span class="hljs-attr">"amount"</span><span class="hljs-punctuation">:</span> <span class="hljs-number">987.65</span><span class="hljs-punctuation">,</span> <span class="hljs-attr">"code"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"xyz789"</span><span class="hljs-punctuation">}</span>
+                  <body><pre><code class="hljs language-json"><span class="hljs-punctuation">{</span><span class="hljs-attr">"amount"</span><span class="hljs-punctuation">:</span> <span class="hljs-number">123.45</span><span class="hljs-punctuation">,</span> <span class="hljs-attr">"code"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"xyz789"</span><span class="hljs-punctuation">}</span>
 </code></pre>
                   </body>
                 </html>
@@ -2705,20 +2855,20 @@ Authorization: Bearer &lt;YOUR_TOKEN_HERE&gt;</code></pre>
                 <html>
                   <head></head>
                   <body><pre><code class="hljs language-json"><span class="hljs-punctuation">{</span>
-  <span class="hljs-attr">"canonical_url"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"xyz789"</span><span class="hljs-punctuation">,</span>
+  <span class="hljs-attr">"canonical_url"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"abc123"</span><span class="hljs-punctuation">,</span>
   <span class="hljs-attr">"categories"</span><span class="hljs-punctuation">:</span> <span class="hljs-punctuation">[</span><span class="hljs-string">CategoryInterface</span><span class="hljs-punctuation">]</span><span class="hljs-punctuation">,</span>
   <span class="hljs-attr">"country_of_manufacture"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"xyz789"</span><span class="hljs-punctuation">,</span>
   <span class="hljs-attr">"crosssell_products"</span><span class="hljs-punctuation">:</span> <span class="hljs-punctuation">[</span><span class="hljs-string">ProductInterface</span><span class="hljs-punctuation">]</span><span class="hljs-punctuation">,</span>
-  <span class="hljs-attr">"gift_message_available"</span><span class="hljs-punctuation">:</span> <span class="hljs-literal"><span class="hljs-keyword">true</span></span><span class="hljs-punctuation">,</span>
-  <span class="hljs-attr">"gift_wrapping_available"</span><span class="hljs-punctuation">:</span> <span class="hljs-literal"><span class="hljs-keyword">false</span></span><span class="hljs-punctuation">,</span>
-  <span class="hljs-attr">"is_returnable"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"abc123"</span><span class="hljs-punctuation">,</span>
+  <span class="hljs-attr">"gift_message_available"</span><span class="hljs-punctuation">:</span> <span class="hljs-literal"><span class="hljs-keyword">false</span></span><span class="hljs-punctuation">,</span>
+  <span class="hljs-attr">"gift_wrapping_available"</span><span class="hljs-punctuation">:</span> <span class="hljs-literal"><span class="hljs-keyword">true</span></span><span class="hljs-punctuation">,</span>
+  <span class="hljs-attr">"is_returnable"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"xyz789"</span><span class="hljs-punctuation">,</span>
   <span class="hljs-attr">"manufacturer"</span><span class="hljs-punctuation">:</span> <span class="hljs-number">987</span><span class="hljs-punctuation">,</span>
-  <span class="hljs-attr">"max_sale_qty"</span><span class="hljs-punctuation">:</span> <span class="hljs-number">123.45</span><span class="hljs-punctuation">,</span>
+  <span class="hljs-attr">"max_sale_qty"</span><span class="hljs-punctuation">:</span> <span class="hljs-number">987.65</span><span class="hljs-punctuation">,</span>
   <span class="hljs-attr">"media_gallery"</span><span class="hljs-punctuation">:</span> <span class="hljs-punctuation">[</span><span class="hljs-string">MediaGalleryInterface</span><span class="hljs-punctuation">]</span><span class="hljs-punctuation">,</span>
-  <span class="hljs-attr">"meta_description"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"abc123"</span><span class="hljs-punctuation">,</span>
+  <span class="hljs-attr">"meta_description"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"xyz789"</span><span class="hljs-punctuation">,</span>
   <span class="hljs-attr">"meta_keyword"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"abc123"</span><span class="hljs-punctuation">,</span>
   <span class="hljs-attr">"meta_title"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"xyz789"</span><span class="hljs-punctuation">,</span>
-  <span class="hljs-attr">"min_sale_qty"</span><span class="hljs-punctuation">:</span> <span class="hljs-number">123.45</span><span class="hljs-punctuation">,</span>
+  <span class="hljs-attr">"min_sale_qty"</span><span class="hljs-punctuation">:</span> <span class="hljs-number">987.65</span><span class="hljs-punctuation">,</span>
   <span class="hljs-attr">"name"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"xyz789"</span><span class="hljs-punctuation">,</span>
   <span class="hljs-attr">"new_from_date"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"xyz789"</span><span class="hljs-punctuation">,</span>
   <span class="hljs-attr">"new_to_date"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"xyz789"</span><span class="hljs-punctuation">,</span>
@@ -2729,9 +2879,9 @@ Authorization: Bearer &lt;YOUR_TOKEN_HERE&gt;</code></pre>
   <span class="hljs-attr">"related_products"</span><span class="hljs-punctuation">:</span> <span class="hljs-punctuation">[</span><span class="hljs-string">ProductInterface</span><span class="hljs-punctuation">]</span><span class="hljs-punctuation">,</span>
   <span class="hljs-attr">"sku"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"xyz789"</span><span class="hljs-punctuation">,</span>
   <span class="hljs-attr">"special_price"</span><span class="hljs-punctuation">:</span> <span class="hljs-number">987.65</span><span class="hljs-punctuation">,</span>
-  <span class="hljs-attr">"special_to_date"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"abc123"</span><span class="hljs-punctuation">,</span>
-  <span class="hljs-attr">"swatch_image"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"xyz789"</span><span class="hljs-punctuation">,</span>
-  <span class="hljs-attr">"uid"</span><span class="hljs-punctuation">:</span> <span class="hljs-number">4</span><span class="hljs-punctuation">,</span>
+  <span class="hljs-attr">"special_to_date"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"xyz789"</span><span class="hljs-punctuation">,</span>
+  <span class="hljs-attr">"swatch_image"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"abc123"</span><span class="hljs-punctuation">,</span>
+  <span class="hljs-attr">"uid"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"4"</span><span class="hljs-punctuation">,</span>
   <span class="hljs-attr">"upsell_products"</span><span class="hljs-punctuation">:</span> <span class="hljs-punctuation">[</span><span class="hljs-string">ProductInterface</span><span class="hljs-punctuation">]</span><span class="hljs-punctuation">,</span>
   <span class="hljs-attr">"url_key"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"xyz789"</span>
 <span class="hljs-punctuation">}</span>
@@ -2799,11 +2949,11 @@ Authorization: Bearer &lt;YOUR_TOKEN_HERE&gt;</code></pre>
                 <html>
                   <head></head>
                   <body><pre><code class="hljs language-json"><span class="hljs-punctuation">{</span>
-  <span class="hljs-attr">"link_type"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"xyz789"</span><span class="hljs-punctuation">,</span>
+  <span class="hljs-attr">"link_type"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"abc123"</span><span class="hljs-punctuation">,</span>
   <span class="hljs-attr">"linked_product_sku"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"abc123"</span><span class="hljs-punctuation">,</span>
-  <span class="hljs-attr">"linked_product_type"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"abc123"</span><span class="hljs-punctuation">,</span>
-  <span class="hljs-attr">"position"</span><span class="hljs-punctuation">:</span> <span class="hljs-number">123</span><span class="hljs-punctuation">,</span>
-  <span class="hljs-attr">"sku"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"xyz789"</span>
+  <span class="hljs-attr">"linked_product_type"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"xyz789"</span><span class="hljs-punctuation">,</span>
+  <span class="hljs-attr">"position"</span><span class="hljs-punctuation">:</span> <span class="hljs-number">987</span><span class="hljs-punctuation">,</span>
+  <span class="hljs-attr">"sku"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"abc123"</span>
 <span class="hljs-punctuation">}</span>
 </code></pre>
                   </body>
@@ -2935,10 +3085,55 @@ Authorization: Bearer &lt;YOUR_TOKEN_HERE&gt;</code></pre>
   <span class="hljs-attr">"facets"</span><span class="hljs-punctuation">:</span> <span class="hljs-punctuation">[</span><span class="hljs-string">Aggregation</span><span class="hljs-punctuation">]</span><span class="hljs-punctuation">,</span>
   <span class="hljs-attr">"items"</span><span class="hljs-punctuation">:</span> <span class="hljs-punctuation">[</span><span class="hljs-string">ProductSearchItem</span><span class="hljs-punctuation">]</span><span class="hljs-punctuation">,</span>
   <span class="hljs-attr">"page_info"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">SearchResultPageInfo</span><span class="hljs-punctuation">,</span>
-  <span class="hljs-attr">"related_terms"</span><span class="hljs-punctuation">:</span> <span class="hljs-punctuation">[</span><span class="hljs-string">"xyz789"</span><span class="hljs-punctuation">]</span><span class="hljs-punctuation">,</span>
-  <span class="hljs-attr">"suggestions"</span><span class="hljs-punctuation">:</span> <span class="hljs-punctuation">[</span><span class="hljs-string">"xyz789"</span><span class="hljs-punctuation">]</span><span class="hljs-punctuation">,</span>
+  <span class="hljs-attr">"related_terms"</span><span class="hljs-punctuation">:</span> <span class="hljs-punctuation">[</span><span class="hljs-string">"abc123"</span><span class="hljs-punctuation">]</span><span class="hljs-punctuation">,</span>
+  <span class="hljs-attr">"suggestions"</span><span class="hljs-punctuation">:</span> <span class="hljs-punctuation">[</span><span class="hljs-string">"abc123"</span><span class="hljs-punctuation">]</span><span class="hljs-punctuation">,</span>
   <span class="hljs-attr">"total_count"</span><span class="hljs-punctuation">:</span> <span class="hljs-number">987</span>
 <span class="hljs-punctuation">}</span>
+</code></pre>
+                  </body>
+                </html>
+              </div>
+            </div>
+            <a href="#top">back to top</a>
+          </div>
+        </section>
+        <section id="definition-ProductSearchSortInput" class="definition definition-input-object" data-traverse-target="definition-ProductSearchSortInput">
+          <div class="definition-group-name">
+            <a href="#group-Types">Types</a>
+          </div>
+          <h2 class="definition-heading">ProductSearchSortInput</h2>
+          <div class="doc-row">
+            <div class="doc-copy">
+              <div class="definition-description doc-copy-section">
+                <h5>Description</h5>
+                <p>The product attribute to sort on</p>
+              </div>
+              <div class="definition-properties doc-copy-section">
+                <h5>Fields</h5>
+                <table>
+                  <thead>
+                    <tr>
+                      <th>Input Field</th>
+                      <th>Description</th>
+                    </tr>
+                  </thead>
+                  <tbody>
+                    <tr>
+                      <td>
+                        <span class="property-name"><code>attribute</code></span> - <span class="property-type"><a href="#definition-String"><code>String!</code></a></span>
+                      </td>
+                      <td> The attribute code of a product attribute </td>
+                    </tr>
+                  </tbody>
+                </table>
+              </div>
+            </div>
+            <div class="doc-examples">
+              <div class="example-section example-section-is-code">
+                <h5>Example</h5>
+                <html>
+                  <head></head>
+                  <body><pre><code class="hljs language-json"><span class="hljs-punctuation">{</span><span class="hljs-attr">"attribute"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"xyz789"</span><span class="hljs-punctuation">}</span>
 </code></pre>
                   </body>
                 </html>
@@ -3149,27 +3344,27 @@ Authorization: Bearer &lt;YOUR_TOKEN_HERE&gt;</code></pre>
                 <html>
                   <head></head>
                   <body><pre><code class="hljs language-json"><span class="hljs-punctuation">{</span>
-  <span class="hljs-attr">"addToCartAllowed"</span><span class="hljs-punctuation">:</span> <span class="hljs-literal"><span class="hljs-keyword">false</span></span><span class="hljs-punctuation">,</span>
+  <span class="hljs-attr">"addToCartAllowed"</span><span class="hljs-punctuation">:</span> <span class="hljs-literal"><span class="hljs-keyword">true</span></span><span class="hljs-punctuation">,</span>
   <span class="hljs-attr">"inStock"</span><span class="hljs-punctuation">:</span> <span class="hljs-literal"><span class="hljs-keyword">false</span></span><span class="hljs-punctuation">,</span>
-  <span class="hljs-attr">"lowStock"</span><span class="hljs-punctuation">:</span> <span class="hljs-literal"><span class="hljs-keyword">true</span></span><span class="hljs-punctuation">,</span>
+  <span class="hljs-attr">"lowStock"</span><span class="hljs-punctuation">:</span> <span class="hljs-literal"><span class="hljs-keyword">false</span></span><span class="hljs-punctuation">,</span>
   <span class="hljs-attr">"attributes"</span><span class="hljs-punctuation">:</span> <span class="hljs-punctuation">[</span><span class="hljs-string">ProductViewAttribute</span><span class="hljs-punctuation">]</span><span class="hljs-punctuation">,</span>
-  <span class="hljs-attr">"description"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"xyz789"</span><span class="hljs-punctuation">,</span>
-  <span class="hljs-attr">"id"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"4"</span><span class="hljs-punctuation">,</span>
+  <span class="hljs-attr">"description"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"abc123"</span><span class="hljs-punctuation">,</span>
+  <span class="hljs-attr">"id"</span><span class="hljs-punctuation">:</span> <span class="hljs-number">4</span><span class="hljs-punctuation">,</span>
   <span class="hljs-attr">"images"</span><span class="hljs-punctuation">:</span> <span class="hljs-punctuation">[</span><span class="hljs-string">ProductViewImage</span><span class="hljs-punctuation">]</span><span class="hljs-punctuation">,</span>
   <span class="hljs-attr">"videos"</span><span class="hljs-punctuation">:</span> <span class="hljs-punctuation">[</span><span class="hljs-string">ProductViewVideo</span><span class="hljs-punctuation">]</span><span class="hljs-punctuation">,</span>
   <span class="hljs-attr">"lastModifiedAt"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"2007-12-03T10:15:30Z"</span><span class="hljs-punctuation">,</span>
-  <span class="hljs-attr">"metaDescription"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"abc123"</span><span class="hljs-punctuation">,</span>
-  <span class="hljs-attr">"metaKeyword"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"abc123"</span><span class="hljs-punctuation">,</span>
+  <span class="hljs-attr">"metaDescription"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"xyz789"</span><span class="hljs-punctuation">,</span>
+  <span class="hljs-attr">"metaKeyword"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"xyz789"</span><span class="hljs-punctuation">,</span>
   <span class="hljs-attr">"metaTitle"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"xyz789"</span><span class="hljs-punctuation">,</span>
-  <span class="hljs-attr">"name"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"xyz789"</span><span class="hljs-punctuation">,</span>
+  <span class="hljs-attr">"name"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"abc123"</span><span class="hljs-punctuation">,</span>
   <span class="hljs-attr">"shortDescription"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"abc123"</span><span class="hljs-punctuation">,</span>
   <span class="hljs-attr">"sku"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"xyz789"</span><span class="hljs-punctuation">,</span>
   <span class="hljs-attr">"externalId"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"abc123"</span><span class="hljs-punctuation">,</span>
-  <span class="hljs-attr">"url"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"abc123"</span><span class="hljs-punctuation">,</span>
-  <span class="hljs-attr">"urlKey"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"abc123"</span><span class="hljs-punctuation">,</span>
+  <span class="hljs-attr">"url"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"xyz789"</span><span class="hljs-punctuation">,</span>
+  <span class="hljs-attr">"urlKey"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"xyz789"</span><span class="hljs-punctuation">,</span>
   <span class="hljs-attr">"links"</span><span class="hljs-punctuation">:</span> <span class="hljs-punctuation">[</span><span class="hljs-string">ProductViewLink</span><span class="hljs-punctuation">]</span><span class="hljs-punctuation">,</span>
   <span class="hljs-attr">"queryType"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"xyz789"</span><span class="hljs-punctuation">,</span>
-  <span class="hljs-attr">"visibility"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"xyz789"</span>
+  <span class="hljs-attr">"visibility"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"abc123"</span>
 <span class="hljs-punctuation">}</span>
 </code></pre>
                   </body>
@@ -3231,7 +3426,7 @@ Authorization: Bearer &lt;YOUR_TOKEN_HERE&gt;</code></pre>
                   <head></head>
                   <body><pre><code class="hljs language-json"><span class="hljs-punctuation">{</span>
   <span class="hljs-attr">"label"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"abc123"</span><span class="hljs-punctuation">,</span>
-  <span class="hljs-attr">"name"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"xyz789"</span><span class="hljs-punctuation">,</span>
+  <span class="hljs-attr">"name"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"abc123"</span><span class="hljs-punctuation">,</span>
   <span class="hljs-attr">"roles"</span><span class="hljs-punctuation">:</span> <span class="hljs-punctuation">[</span><span class="hljs-string">"abc123"</span><span class="hljs-punctuation">]</span><span class="hljs-punctuation">,</span>
   <span class="hljs-attr">"value"</span><span class="hljs-punctuation">:</span> <span class="hljs-punctuation">{</span><span class="hljs-punctuation">}</span>
 <span class="hljs-punctuation">}</span>
@@ -4519,8 +4714,8 @@ Authorization: Bearer &lt;YOUR_TOKEN_HERE&gt;</code></pre>
                   <head></head>
                   <body><pre><code class="hljs language-json"><span class="hljs-punctuation">{</span>
   <span class="hljs-attr">"label"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"xyz789"</span><span class="hljs-punctuation">,</span>
-  <span class="hljs-attr">"roles"</span><span class="hljs-punctuation">:</span> <span class="hljs-punctuation">[</span><span class="hljs-string">"xyz789"</span><span class="hljs-punctuation">]</span><span class="hljs-punctuation">,</span>
-  <span class="hljs-attr">"url"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"xyz789"</span>
+  <span class="hljs-attr">"roles"</span><span class="hljs-punctuation">:</span> <span class="hljs-punctuation">[</span><span class="hljs-string">"abc123"</span><span class="hljs-punctuation">]</span><span class="hljs-punctuation">,</span>
+  <span class="hljs-attr">"url"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"abc123"</span>
 <span class="hljs-punctuation">}</span>
 </code></pre>
                   </body>
@@ -4690,7 +4885,7 @@ Authorization: Bearer &lt;YOUR_TOKEN_HERE&gt;</code></pre>
   <span class="hljs-attr">"id"</span><span class="hljs-punctuation">:</span> <span class="hljs-number">4</span><span class="hljs-punctuation">,</span>
   <span class="hljs-attr">"multi"</span><span class="hljs-punctuation">:</span> <span class="hljs-literal"><span class="hljs-keyword">false</span></span><span class="hljs-punctuation">,</span>
   <span class="hljs-attr">"required"</span><span class="hljs-punctuation">:</span> <span class="hljs-literal"><span class="hljs-keyword">true</span></span><span class="hljs-punctuation">,</span>
-  <span class="hljs-attr">"title"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"abc123"</span><span class="hljs-punctuation">,</span>
+  <span class="hljs-attr">"title"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"xyz789"</span><span class="hljs-punctuation">,</span>
   <span class="hljs-attr">"values"</span><span class="hljs-punctuation">:</span> <span class="hljs-punctuation">[</span><span class="hljs-string">ProductViewOptionValue</span><span class="hljs-punctuation">]</span>
 <span class="hljs-punctuation">}</span>
 </code></pre>
@@ -4774,7 +4969,7 @@ Authorization: Bearer &lt;YOUR_TOKEN_HERE&gt;</code></pre>
                 <html>
                   <head></head>
                   <body><pre><code class="hljs language-json"><span class="hljs-punctuation">{</span>
-  <span class="hljs-attr">"id"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"4"</span><span class="hljs-punctuation">,</span>
+  <span class="hljs-attr">"id"</span><span class="hljs-punctuation">:</span> <span class="hljs-number">4</span><span class="hljs-punctuation">,</span>
   <span class="hljs-attr">"title"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"xyz789"</span><span class="hljs-punctuation">,</span>
   <span class="hljs-attr">"inStock"</span><span class="hljs-punctuation">:</span> <span class="hljs-literal"><span class="hljs-keyword">false</span></span>
 <span class="hljs-punctuation">}</span>
@@ -4833,7 +5028,7 @@ Authorization: Bearer &lt;YOUR_TOKEN_HERE&gt;</code></pre>
                   <head></head>
                   <body><pre><code class="hljs language-json"><span class="hljs-punctuation">{</span>
   <span class="hljs-attr">"id"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"4"</span><span class="hljs-punctuation">,</span>
-  <span class="hljs-attr">"title"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"xyz789"</span><span class="hljs-punctuation">,</span>
+  <span class="hljs-attr">"title"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"abc123"</span><span class="hljs-punctuation">,</span>
   <span class="hljs-attr">"inStock"</span><span class="hljs-punctuation">:</span> <span class="hljs-literal"><span class="hljs-keyword">false</span></span>
 <span class="hljs-punctuation">}</span>
 </code></pre>
@@ -4908,9 +5103,9 @@ Authorization: Bearer &lt;YOUR_TOKEN_HERE&gt;</code></pre>
   <span class="hljs-attr">"id"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"4"</span><span class="hljs-punctuation">,</span>
   <span class="hljs-attr">"isDefault"</span><span class="hljs-punctuation">:</span> <span class="hljs-literal"><span class="hljs-keyword">true</span></span><span class="hljs-punctuation">,</span>
   <span class="hljs-attr">"product"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">SimpleProductView</span><span class="hljs-punctuation">,</span>
-  <span class="hljs-attr">"quantity"</span><span class="hljs-punctuation">:</span> <span class="hljs-number">123.45</span><span class="hljs-punctuation">,</span>
+  <span class="hljs-attr">"quantity"</span><span class="hljs-punctuation">:</span> <span class="hljs-number">987.65</span><span class="hljs-punctuation">,</span>
   <span class="hljs-attr">"title"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"xyz789"</span><span class="hljs-punctuation">,</span>
-  <span class="hljs-attr">"inStock"</span><span class="hljs-punctuation">:</span> <span class="hljs-literal"><span class="hljs-keyword">true</span></span>
+  <span class="hljs-attr">"inStock"</span><span class="hljs-punctuation">:</span> <span class="hljs-literal"><span class="hljs-keyword">false</span></span>
 <span class="hljs-punctuation">}</span>
 </code></pre>
                   </body>
@@ -5038,7 +5233,7 @@ Authorization: Bearer &lt;YOUR_TOKEN_HERE&gt;</code></pre>
                   <body><pre><code class="hljs language-json"><span class="hljs-punctuation">{</span>
   <span class="hljs-attr">"final"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">Price</span><span class="hljs-punctuation">,</span>
   <span class="hljs-attr">"regular"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">Price</span><span class="hljs-punctuation">,</span>
-  <span class="hljs-attr">"roles"</span><span class="hljs-punctuation">:</span> <span class="hljs-punctuation">[</span><span class="hljs-string">"xyz789"</span><span class="hljs-punctuation">]</span>
+  <span class="hljs-attr">"roles"</span><span class="hljs-punctuation">:</span> <span class="hljs-punctuation">[</span><span class="hljs-string">"abc123"</span><span class="hljs-punctuation">]</span>
 <span class="hljs-punctuation">}</span>
 </code></pre>
                   </body>
@@ -5137,7 +5332,7 @@ Authorization: Bearer &lt;YOUR_TOKEN_HERE&gt;</code></pre>
                 <html>
                   <head></head>
                   <body><pre><code class="hljs language-json"><span class="hljs-punctuation">{</span>
-  <span class="hljs-attr">"selections"</span><span class="hljs-punctuation">:</span> <span class="hljs-punctuation">[</span><span class="hljs-string">"xyz789"</span><span class="hljs-punctuation">]</span><span class="hljs-punctuation">,</span>
+  <span class="hljs-attr">"selections"</span><span class="hljs-punctuation">:</span> <span class="hljs-punctuation">[</span><span class="hljs-string">"abc123"</span><span class="hljs-punctuation">]</span><span class="hljs-punctuation">,</span>
   <span class="hljs-attr">"product"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">ProductView</span>
 <span class="hljs-punctuation">}</span>
 </code></pre>
@@ -5186,7 +5381,7 @@ Authorization: Bearer &lt;YOUR_TOKEN_HERE&gt;</code></pre>
                   <head></head>
                   <body><pre><code class="hljs language-json"><span class="hljs-punctuation">{</span>
   <span class="hljs-attr">"variants"</span><span class="hljs-punctuation">:</span> <span class="hljs-punctuation">[</span><span class="hljs-string">ProductViewVariant</span><span class="hljs-punctuation">]</span><span class="hljs-punctuation">,</span>
-  <span class="hljs-attr">"cursor"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"xyz789"</span>
+  <span class="hljs-attr">"cursor"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"abc123"</span>
 <span class="hljs-punctuation">}</span>
 </code></pre>
                   </body>
@@ -5249,9 +5444,106 @@ Authorization: Bearer &lt;YOUR_TOKEN_HERE&gt;</code></pre>
                   <body><pre><code class="hljs language-json"><span class="hljs-punctuation">{</span>
   <span class="hljs-attr">"preview"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">ProductViewImage</span><span class="hljs-punctuation">,</span>
   <span class="hljs-attr">"url"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"xyz789"</span><span class="hljs-punctuation">,</span>
-  <span class="hljs-attr">"description"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"abc123"</span><span class="hljs-punctuation">,</span>
-  <span class="hljs-attr">"title"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"xyz789"</span>
+  <span class="hljs-attr">"description"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"xyz789"</span><span class="hljs-punctuation">,</span>
+  <span class="hljs-attr">"title"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"abc123"</span>
 <span class="hljs-punctuation">}</span>
+</code></pre>
+                  </body>
+                </html>
+              </div>
+            </div>
+            <a href="#top">back to top</a>
+          </div>
+        </section>
+        <section id="definition-PurchaseHistory" class="definition definition-input-object" data-traverse-target="definition-PurchaseHistory">
+          <div class="definition-group-name">
+            <a href="#group-Types">Types</a>
+          </div>
+          <h2 class="definition-heading">PurchaseHistory</h2>
+          <div class="doc-row">
+            <div class="doc-copy">
+              <div class="definition-description doc-copy-section">
+                <h5>Description</h5>
+                <p>User purchase history</p>
+              </div>
+              <div class="definition-properties doc-copy-section">
+                <h5>Fields</h5>
+                <table>
+                  <thead>
+                    <tr>
+                      <th>Input Field</th>
+                      <th>Description</th>
+                    </tr>
+                  </thead>
+                  <tbody>
+                    <tr>
+                      <td>
+                        <span class="property-name"><code>date</code></span> - <span class="property-type"><a href="#definition-DateTime"><code>DateTime</code></a></span>
+                      </td>
+                      <td>
+                      </td>
+                    </tr>
+                    <tr>
+                      <td>
+                        <span class="property-name"><code>items</code></span> - <span class="property-type"><a href="#definition-String"><code>[String]!</code></a></span>
+                      </td>
+                      <td>
+                      </td>
+                    </tr>
+                  </tbody>
+                </table>
+              </div>
+            </div>
+            <div class="doc-examples">
+              <div class="example-section example-section-is-code">
+                <h5>Example</h5>
+                <html>
+                  <head></head>
+                  <body><pre><code class="hljs language-json"><span class="hljs-punctuation">{</span>
+  <span class="hljs-attr">"date"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"2007-12-03T10:15:30Z"</span><span class="hljs-punctuation">,</span>
+  <span class="hljs-attr">"items"</span><span class="hljs-punctuation">:</span> <span class="hljs-punctuation">[</span><span class="hljs-string">"xyz789"</span><span class="hljs-punctuation">]</span>
+<span class="hljs-punctuation">}</span>
+</code></pre>
+                  </body>
+                </html>
+              </div>
+            </div>
+            <a href="#top">back to top</a>
+          </div>
+        </section>
+        <section id="definition-QueryContextInput" class="definition definition-input-object" data-traverse-target="definition-QueryContextInput">
+          <div class="definition-group-name">
+            <a href="#group-Types">Types</a>
+          </div>
+          <h2 class="definition-heading">QueryContextInput</h2>
+          <div class="doc-row">
+            <div class="doc-copy">
+              <div class="definition-properties doc-copy-section">
+                <h5>Fields</h5>
+                <table>
+                  <thead>
+                    <tr>
+                      <th>Input Field</th>
+                      <th>Description</th>
+                    </tr>
+                  </thead>
+                  <tbody>
+                    <tr>
+                      <td>
+                        <span class="property-name"><code>customerGroup</code></span> - <span class="property-type"><a href="#definition-String"><code>String!</code></a></span>
+                      </td>
+                      <td> The customer group code. Field reserved for future use. Currently, passing this field will have no impact on search results, that is, the search results will be for "Not logged in" customer </td>
+                    </tr>
+                  </tbody>
+                </table>
+              </div>
+            </div>
+            <div class="doc-examples">
+              <div class="example-section example-section-is-code">
+                <h5>Example</h5>
+                <html>
+                  <head></head>
+                  <body><pre><code class="hljs language-json"><span class="hljs-punctuation">{</span><span class="hljs-attr">"customerGroup"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"xyz789"</span><span class="hljs-punctuation">}</span>
 </code></pre>
                   </body>
                 </html>
@@ -5311,8 +5603,8 @@ Authorization: Bearer &lt;YOUR_TOKEN_HERE&gt;</code></pre>
                 <html>
                   <head></head>
                   <body><pre><code class="hljs language-json"><span class="hljs-punctuation">{</span>
-  <span class="hljs-attr">"count"</span><span class="hljs-punctuation">:</span> <span class="hljs-number">987</span><span class="hljs-punctuation">,</span>
-  <span class="hljs-attr">"from"</span><span class="hljs-punctuation">:</span> <span class="hljs-number">987.65</span><span class="hljs-punctuation">,</span>
+  <span class="hljs-attr">"count"</span><span class="hljs-punctuation">:</span> <span class="hljs-number">123</span><span class="hljs-punctuation">,</span>
+  <span class="hljs-attr">"from"</span><span class="hljs-punctuation">:</span> <span class="hljs-number">123.45</span><span class="hljs-punctuation">,</span>
   <span class="hljs-attr">"title"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"abc123"</span><span class="hljs-punctuation">,</span>
   <span class="hljs-attr">"to"</span><span class="hljs-punctuation">:</span> <span class="hljs-number">987.65</span>
 <span class="hljs-punctuation">}</span>
@@ -5396,12 +5688,12 @@ Authorization: Bearer &lt;YOUR_TOKEN_HERE&gt;</code></pre>
                   <head></head>
                   <body><pre><code class="hljs language-json"><span class="hljs-punctuation">{</span>
   <span class="hljs-attr">"displayOrder"</span><span class="hljs-punctuation">:</span> <span class="hljs-number">123</span><span class="hljs-punctuation">,</span>
-  <span class="hljs-attr">"pageType"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"xyz789"</span><span class="hljs-punctuation">,</span>
+  <span class="hljs-attr">"pageType"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"abc123"</span><span class="hljs-punctuation">,</span>
   <span class="hljs-attr">"productsView"</span><span class="hljs-punctuation">:</span> <span class="hljs-punctuation">[</span><span class="hljs-string">ProductView</span><span class="hljs-punctuation">]</span><span class="hljs-punctuation">,</span>
   <span class="hljs-attr">"storefrontLabel"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"xyz789"</span><span class="hljs-punctuation">,</span>
   <span class="hljs-attr">"totalProducts"</span><span class="hljs-punctuation">:</span> <span class="hljs-number">987</span><span class="hljs-punctuation">,</span>
-  <span class="hljs-attr">"typeId"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"xyz789"</span><span class="hljs-punctuation">,</span>
-  <span class="hljs-attr">"unitId"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"abc123"</span><span class="hljs-punctuation">,</span>
+  <span class="hljs-attr">"typeId"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"abc123"</span><span class="hljs-punctuation">,</span>
+  <span class="hljs-attr">"unitId"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"xyz789"</span><span class="hljs-punctuation">,</span>
   <span class="hljs-attr">"unitName"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"xyz789"</span>
 <span class="hljs-punctuation">}</span>
 </code></pre>
@@ -5506,7 +5798,11 @@ Authorization: Bearer &lt;YOUR_TOKEN_HERE&gt;</code></pre>
                 <h5>Example</h5>
                 <html>
                   <head></head>
-                  <body><pre><code class="hljs language-json"><span class="hljs-punctuation">{</span><span class="hljs-attr">"count"</span><span class="hljs-punctuation">:</span> <span class="hljs-number">987</span><span class="hljs-punctuation">,</span> <span class="hljs-attr">"id"</span><span class="hljs-punctuation">:</span> <span class="hljs-number">4</span><span class="hljs-punctuation">,</span> <span class="hljs-attr">"title"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"abc123"</span><span class="hljs-punctuation">}</span>
+                  <body><pre><code class="hljs language-json"><span class="hljs-punctuation">{</span>
+  <span class="hljs-attr">"count"</span><span class="hljs-punctuation">:</span> <span class="hljs-number">123</span><span class="hljs-punctuation">,</span>
+  <span class="hljs-attr">"id"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"4"</span><span class="hljs-punctuation">,</span>
+  <span class="hljs-attr">"title"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"abc123"</span>
+<span class="hljs-punctuation">}</span>
 </code></pre>
                   </body>
                 </html>
@@ -5560,7 +5856,7 @@ Authorization: Bearer &lt;YOUR_TOKEN_HERE&gt;</code></pre>
                 <h5>Example</h5>
                 <html>
                   <head></head>
-                  <body><pre><code class="hljs language-json"><span class="hljs-punctuation">{</span><span class="hljs-attr">"current_page"</span><span class="hljs-punctuation">:</span> <span class="hljs-number">123</span><span class="hljs-punctuation">,</span> <span class="hljs-attr">"page_size"</span><span class="hljs-punctuation">:</span> <span class="hljs-number">987</span><span class="hljs-punctuation">,</span> <span class="hljs-attr">"total_pages"</span><span class="hljs-punctuation">:</span> <span class="hljs-number">987</span><span class="hljs-punctuation">}</span>
+                  <body><pre><code class="hljs language-json"><span class="hljs-punctuation">{</span><span class="hljs-attr">"current_page"</span><span class="hljs-punctuation">:</span> <span class="hljs-number">987</span><span class="hljs-punctuation">,</span> <span class="hljs-attr">"page_size"</span><span class="hljs-punctuation">:</span> <span class="hljs-number">987</span><span class="hljs-punctuation">,</span> <span class="hljs-attr">"total_pages"</span><span class="hljs-punctuation">:</span> <span class="hljs-number">987</span><span class="hljs-punctuation">}</span>
 </code></pre>
                   </body>
                 </html>
@@ -5756,26 +6052,26 @@ Authorization: Bearer &lt;YOUR_TOKEN_HERE&gt;</code></pre>
                   <body><pre><code class="hljs language-json"><span class="hljs-punctuation">{</span>
   <span class="hljs-attr">"addToCartAllowed"</span><span class="hljs-punctuation">:</span> <span class="hljs-literal"><span class="hljs-keyword">true</span></span><span class="hljs-punctuation">,</span>
   <span class="hljs-attr">"inStock"</span><span class="hljs-punctuation">:</span> <span class="hljs-literal"><span class="hljs-keyword">false</span></span><span class="hljs-punctuation">,</span>
-  <span class="hljs-attr">"lowStock"</span><span class="hljs-punctuation">:</span> <span class="hljs-literal"><span class="hljs-keyword">true</span></span><span class="hljs-punctuation">,</span>
+  <span class="hljs-attr">"lowStock"</span><span class="hljs-punctuation">:</span> <span class="hljs-literal"><span class="hljs-keyword">false</span></span><span class="hljs-punctuation">,</span>
   <span class="hljs-attr">"attributes"</span><span class="hljs-punctuation">:</span> <span class="hljs-punctuation">[</span><span class="hljs-string">ProductViewAttribute</span><span class="hljs-punctuation">]</span><span class="hljs-punctuation">,</span>
-  <span class="hljs-attr">"description"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"abc123"</span><span class="hljs-punctuation">,</span>
-  <span class="hljs-attr">"id"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"4"</span><span class="hljs-punctuation">,</span>
+  <span class="hljs-attr">"description"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"xyz789"</span><span class="hljs-punctuation">,</span>
+  <span class="hljs-attr">"id"</span><span class="hljs-punctuation">:</span> <span class="hljs-number">4</span><span class="hljs-punctuation">,</span>
   <span class="hljs-attr">"images"</span><span class="hljs-punctuation">:</span> <span class="hljs-punctuation">[</span><span class="hljs-string">ProductViewImage</span><span class="hljs-punctuation">]</span><span class="hljs-punctuation">,</span>
   <span class="hljs-attr">"videos"</span><span class="hljs-punctuation">:</span> <span class="hljs-punctuation">[</span><span class="hljs-string">ProductViewVideo</span><span class="hljs-punctuation">]</span><span class="hljs-punctuation">,</span>
   <span class="hljs-attr">"lastModifiedAt"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"2007-12-03T10:15:30Z"</span><span class="hljs-punctuation">,</span>
-  <span class="hljs-attr">"metaDescription"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"xyz789"</span><span class="hljs-punctuation">,</span>
-  <span class="hljs-attr">"metaKeyword"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"abc123"</span><span class="hljs-punctuation">,</span>
-  <span class="hljs-attr">"metaTitle"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"abc123"</span><span class="hljs-punctuation">,</span>
+  <span class="hljs-attr">"metaDescription"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"abc123"</span><span class="hljs-punctuation">,</span>
+  <span class="hljs-attr">"metaKeyword"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"xyz789"</span><span class="hljs-punctuation">,</span>
+  <span class="hljs-attr">"metaTitle"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"xyz789"</span><span class="hljs-punctuation">,</span>
   <span class="hljs-attr">"name"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"xyz789"</span><span class="hljs-punctuation">,</span>
   <span class="hljs-attr">"price"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">ProductViewPrice</span><span class="hljs-punctuation">,</span>
-  <span class="hljs-attr">"shortDescription"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"abc123"</span><span class="hljs-punctuation">,</span>
-  <span class="hljs-attr">"sku"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"xyz789"</span><span class="hljs-punctuation">,</span>
+  <span class="hljs-attr">"shortDescription"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"xyz789"</span><span class="hljs-punctuation">,</span>
+  <span class="hljs-attr">"sku"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"abc123"</span><span class="hljs-punctuation">,</span>
   <span class="hljs-attr">"externalId"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"abc123"</span><span class="hljs-punctuation">,</span>
   <span class="hljs-attr">"url"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"xyz789"</span><span class="hljs-punctuation">,</span>
   <span class="hljs-attr">"urlKey"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"xyz789"</span><span class="hljs-punctuation">,</span>
   <span class="hljs-attr">"links"</span><span class="hljs-punctuation">:</span> <span class="hljs-punctuation">[</span><span class="hljs-string">ProductViewLink</span><span class="hljs-punctuation">]</span><span class="hljs-punctuation">,</span>
-  <span class="hljs-attr">"queryType"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"xyz789"</span><span class="hljs-punctuation">,</span>
-  <span class="hljs-attr">"visibility"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"abc123"</span>
+  <span class="hljs-attr">"queryType"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"abc123"</span><span class="hljs-punctuation">,</span>
+  <span class="hljs-attr">"visibility"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"xyz789"</span>
 <span class="hljs-punctuation">}</span>
 </code></pre>
                   </body>
@@ -5836,10 +6132,10 @@ Authorization: Bearer &lt;YOUR_TOKEN_HERE&gt;</code></pre>
                 <html>
                   <head></head>
                   <body><pre><code class="hljs language-json"><span class="hljs-punctuation">{</span>
-  <span class="hljs-attr">"attribute"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"abc123"</span><span class="hljs-punctuation">,</span>
+  <span class="hljs-attr">"attribute"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"xyz789"</span><span class="hljs-punctuation">,</span>
   <span class="hljs-attr">"frontendInput"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"xyz789"</span><span class="hljs-punctuation">,</span>
   <span class="hljs-attr">"label"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"xyz789"</span><span class="hljs-punctuation">,</span>
-  <span class="hljs-attr">"numeric"</span><span class="hljs-punctuation">:</span> <span class="hljs-literal"><span class="hljs-keyword">true</span></span>
+  <span class="hljs-attr">"numeric"</span><span class="hljs-punctuation">:</span> <span class="hljs-literal"><span class="hljs-keyword">false</span></span>
 <span class="hljs-punctuation">}</span>
 </code></pre>
                   </body>
@@ -5895,8 +6191,8 @@ Authorization: Bearer &lt;YOUR_TOKEN_HERE&gt;</code></pre>
                 <html>
                   <head></head>
                   <body><pre><code class="hljs language-json"><span class="hljs-punctuation">{</span>
-  <span class="hljs-attr">"max"</span><span class="hljs-punctuation">:</span> <span class="hljs-number">123.45</span><span class="hljs-punctuation">,</span>
-  <span class="hljs-attr">"min"</span><span class="hljs-punctuation">:</span> <span class="hljs-number">987.65</span><span class="hljs-punctuation">,</span>
+  <span class="hljs-attr">"max"</span><span class="hljs-punctuation">:</span> <span class="hljs-number">987.65</span><span class="hljs-punctuation">,</span>
+  <span class="hljs-attr">"min"</span><span class="hljs-punctuation">:</span> <span class="hljs-number">123.45</span><span class="hljs-punctuation">,</span>
   <span class="hljs-attr">"title"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"xyz789"</span>
 <span class="hljs-punctuation">}</span>
 </code></pre>
@@ -5924,7 +6220,7 @@ Authorization: Bearer &lt;YOUR_TOKEN_HERE&gt;</code></pre>
                 <h5>Example</h5>
                 <html>
                   <head></head>
-                  <body><pre><code class="hljs language-gql"><span class="hljs-symbol">"xyz789"</span>
+                  <body><pre><code class="hljs language-gql"><span class="hljs-symbol">"abc123"</span>
 </code></pre>
                   </body>
                 </html>
@@ -5988,6 +6284,62 @@ Authorization: Bearer &lt;YOUR_TOKEN_HERE&gt;</code></pre>
                 <html>
                   <head></head>
                   <body><pre><code class="hljs language-gql"><span class="hljs-symbol">"TEXT"</span>
+</code></pre>
+                  </body>
+                </html>
+              </div>
+            </div>
+            <a href="#top">back to top</a>
+          </div>
+        </section>
+        <section id="definition-ViewHistory" class="definition definition-input-object" data-traverse-target="definition-ViewHistory">
+          <div class="definition-group-name">
+            <a href="#group-Types">Types</a>
+          </div>
+          <h2 class="definition-heading">ViewHistory</h2>
+          <div class="doc-row">
+            <div class="doc-copy">
+              <div class="definition-description doc-copy-section">
+                <h5>Description</h5>
+                <p>User view history</p>
+              </div>
+              <div class="definition-properties doc-copy-section">
+                <h5>Fields</h5>
+                <table>
+                  <thead>
+                    <tr>
+                      <th>Input Field</th>
+                      <th>Description</th>
+                    </tr>
+                  </thead>
+                  <tbody>
+                    <tr>
+                      <td>
+                        <span class="property-name"><code>date</code></span> - <span class="property-type"><a href="#definition-DateTime"><code>DateTime</code></a></span>
+                      </td>
+                      <td>
+                      </td>
+                    </tr>
+                    <tr>
+                      <td>
+                        <span class="property-name"><code>sku</code></span> - <span class="property-type"><a href="#definition-String"><code>String!</code></a></span>
+                      </td>
+                      <td>
+                      </td>
+                    </tr>
+                  </tbody>
+                </table>
+              </div>
+            </div>
+            <div class="doc-examples">
+              <div class="example-section example-section-is-code">
+                <h5>Example</h5>
+                <html>
+                  <head></head>
+                  <body><pre><code class="hljs language-json"><span class="hljs-punctuation">{</span>
+  <span class="hljs-attr">"date"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"2007-12-03T10:15:30Z"</span><span class="hljs-punctuation">,</span>
+  <span class="hljs-attr">"sku"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"xyz789"</span>
+<span class="hljs-punctuation">}</span>
 </code></pre>
                   </body>
                 </html>


### PR DESCRIPTION
## Purpose of this pull request

Generate an API reference for Adobe Commerce Optimizer Merchandising Services that includes only the following GraphQL queries to retrieve data from a composable catalog.

[attributeMetadata](https://jira.corp.adobe.com/browse/COMOPT-998#query-attributeMetadata)
[productSearch](https://jira.corp.adobe.com/browse/COMOPT-998#query-productSearch)
[products](https://jira.corp.adobe.com/browse/COMOPT-998#query-products)
[recommendations](https://jira.corp.adobe.com/browse/COMOPT-998#query-recommendations)
[recommendationsByUnitIds](https://jira.corp.adobe.com/browse/COMOPT-998#query-recommendationsByUnitIds)
[refineProduct](https://jira.corp.adobe.com/browse/COMOPT-998#query-refineProduct)
[variants](https://jira.corp.adobe.com/browse/COMOPT-998#query-variants)

## Affected pages

https://developer.adobe.com/commerce/services/reference/graphql/


