### PR TITLE
DCAT-2626: Add categories doc

### DIFF
--- a/src/pages/optimizer/data-ingestion/index.md
+++ b/src/pages/optimizer/data-ingestion/index.md
@@ -32,6 +32,10 @@ You can also define custom metadata for additional product attributes. For examp
 
 For details, see <a href="https://developer.adobe.com/commerce/services/reference/rest/#tag/Metadata" target="_blank" rel="noopener noreferrer">Metadata API</a> in the *Data Ingestion API Reference*.
 
+## Categories
+
+Categories are used to organize products into a hierarchical structure, making it easier for customers to navigate and find products in the storefront. Categories can be nested, allowing you to create subcategories within main categories. For details on creating categories and category hierarchies using slug-based paths, see [Categories](https://developer.adobe.com/commerce/services/reference/rest/) resource in the API reference.
+
 ## Products
 
 A product is any item or service offered for sale through online channels. Products can be physical goods, digital downloads, or services. They are the core elements of your catalog. Product types are different categories of products that you can create and manage in your catalog. Merchandising Services simplifies product types to two use cases:

--- a/static/rest/data-ingestion-schema-v1.yaml
+++ b/static/rest/data-ingestion-schema-v1.yaml
@@ -31,7 +31,7 @@ tags:
       You can also define the search type for a product attribute, such as autocomplete or exact match.
   - name: Categories
     description: |
-      Manage categories with hierarchical structure and localization support.
+      Manage categories in a hierarchical structure with localization support.
       Categories organize products into logical groups and support nested hierarchies using slug-based paths.
 
       Category management includes:
@@ -40,7 +40,8 @@ tags:
       - Deleting categories from the catalog
       - Associating categories with product families for enhanced organization
 
-      Categories use a slug-based hierarchy format (e.g., 'men/clothing/pants') to represent parent-child relationships.
+      Categories use a slug-based hierarchy format to represent parent-child relationships, for example, "men/clothing/pants'.
+
   - name: Products
     description: Create and manage product data including simple products, configurable products, and their variants. Control product visibility, attributes, images, and pricing
   - name: Price Books
@@ -228,7 +229,7 @@ paths:
                   [
                     {
                       "code": "sku",
-                      "source": { "locale": "en" },
+                      "source": { "locale": "en-US" },
                       "label": "Product Name",
                       "dataType": "TEXT",
                       "visibleIn":
@@ -246,7 +247,7 @@ paths:
                     },
                     {
                       "code": "name",
-                      "source": { "locale": "en" },
+                      "source": { "locale": "en-US" },
                       "label": "Product Name",
                       "dataType": "TEXT",
                       "visibleIn":
@@ -264,7 +265,7 @@ paths:
                     },
                     {
                       "code": "description",
-                      "source": { "locale": "en" },
+                      "source": { "locale": "en-US" },
                       "label": "Product Description",
                       "dataType": "TEXT",
                       "visibleIn": ["PRODUCT_DETAIL"],
@@ -276,7 +277,7 @@ paths:
                     },
                     {
                       "code": "shortDescription",
-                      "source": { "locale": "en" },
+                      "source": { "locale": "en-US" },
                       "label": "Product Short Description",
                       "dataType": "TEXT",
                       "visibleIn": ["PRODUCT_DETAIL"],
@@ -288,7 +289,7 @@ paths:
                     },
                     {
                       "code": "price",
-                      "source": { "locale": "en" },
+                      "source": { "locale": "en-US" },
                       "label": "Price",
                       "dataType": "DECIMAL",
                       "visibleIn":
@@ -348,7 +349,7 @@ paths:
                   [
                     {
                       "code": "name",
-                      "source": { "locale": "en" },
+                      "source": { "locale": "en-US" },
                       "label": "Updated - Product Name",
                       "visibleIn": [
                         "PRODUCT_DETAIL",
@@ -393,7 +394,7 @@ paths:
                 value: [
                   {
                     "code": "name",
-                    "source": { "locale": "en" }
+                    "source": { "locale": "en-US" }
                   }
                 ]
 
@@ -409,10 +410,10 @@ paths:
 
         When creating categories:
           - Each category requires a unique `slug` and `source`.
-          - Use the `slug` field with hierarchical format like 'men/clothing/pants' to create parent-child relationships
-          - Category `slug` must follow the pattern with only lowercase letters, numbers, and hyphens.
+          - Use the `slug` field in a hierarchical format like men/clothing/pants' to create parent-child relationships
+          - The category `slug` string can contain only lowercase letters, numbers, and hyphens.
           - Use the `name` field to define the display name for the category.
-          - Use the `families` field to optionally associate categories with product families for enhanced organization.
+          - Use the optional `families` field to associate categories with product families for enhanced organization.
 
         To update existing categories, use the update operation.
 
@@ -449,19 +450,19 @@ paths:
                   [
                     {
                       "slug": "men",
-                      "source": { "locale": "en" },
+                      "source": { "locale": "en-US" },
                       "name": "Men",
                       "families": ["apparel", "accessories"]
                     },
                     {
                       "slug": "men/clothing",
-                      "source": { "locale": "en" },
+                      "source": { "locale": "en-US" },
                       "name": "Men's Clothing",
                       "families": ["apparel"]
                     },
                     {
                       "slug": "men/clothing/pants",
-                      "source": { "locale": "en" },
+                      "source": { "locale": "en-US" },
                       "name": "Men's Pants",
                       "families": ["apparel"]
                     }
@@ -509,7 +510,7 @@ paths:
                   [
                     {
                       "slug": "men/clothing",
-                      "source": { "locale": "en" },
+                      "source": { "locale": "en-US" },
                       "name": "Men's Apparel",
                       "families": ["clothing", "fashion"]
                     }
@@ -525,15 +526,15 @@ paths:
         <h3>Cascading Deletion</h3>
 
         When you delete a category:
-        * **Child categories**: All child categories in the hierarchy are automatically deleted
+        * **Child categories**: All child categories in the hierarchy are deleted automatically
         * **Hierarchy Impact**: The entire branch below the deleted category is removed
 
         <h3>Recovery Options</h3>
 
         If a category is deleted by mistake:
         * **Time Window**: You have up to one week to restore deleted categories
-        * **Restoration Method**: Recreate the top-level deleted category using <strong>[update operation](#operation/createCategories)</strong>
-        * **State Recovery**: Categories are restored to their state when deleted
+        * **Restoration Method**: Recreate the top-level deleted category using the [update operation](#operation/createCategories)
+        * **State Recovery**: Categories are restored to their exact state from the time of deletion, including all metadata, family associations, and hierarchy relationships
         * **Hierarchy Reconstruction**: The entire hierarchy is rebuilt from the restoration payload
 
       operationId: deleteCategories
@@ -566,11 +567,11 @@ paths:
                 value: [
                   {
                     "slug": "men/clothing/pants",
-                    "source": { "locale": "en" }
+                    "source": { "locale": "en-US" }
                   },
                   {
                     "slug": "women/shoes/boots",
-                    "source": { "locale": "en" }
+                    "source": { "locale": "en-US" }
                   }
                 ]
 
@@ -706,7 +707,7 @@ paths:
                   [
                     {
                       "sku": "red-pants",
-                      "source": { "locale": "en" },
+                      "source": { "locale": "en-US" },
                       "name": "red pants",
                       "slug": "red-pants.html",
                       "status": "ENABLED",
@@ -758,7 +759,7 @@ paths:
                   [
                     {
                       "sku": "pants",
-                      "source": { "locale": "en" },
+                      "source": { "locale": "en-US" },
                       "name": "Yoga pants",
                       "slug": "zeppelin-yoga-pant",
                       "status": "ENABLED",
@@ -805,7 +806,7 @@ paths:
                     },
                     {
                       "sku": "pants-red-32",
-                      "source": { "locale": "en" },
+                      "source": { "locale": "en-US" },
                       "name": "Zeppelin Yoga Pant Red 32 size",
                       "slug": "pants-red-32",
                       "status": "ENABLED",
@@ -832,7 +833,7 @@ paths:
                     },
                     {
                       "sku": "pants-red-44",
-                      "source": { "locale": "en" },
+                      "source": { "locale": "en-US" },
                       "name": "Zeppelin Yoga Pant Red 44 size",
                       "slug": "pants-red-44",
                       "status": "ENABLED",
@@ -859,7 +860,7 @@ paths:
                     },
                     {
                       "sku": "pants-green-32",
-                      "source": { "locale": "en" },
+                      "source": { "locale": "en-US" },
                       "name": "Zeppelin Yoga Pant Green 32 size",
                       "slug": "pants-green-32",
                       "status": "ENABLED",
@@ -886,7 +887,7 @@ paths:
                     },
                     {
                       "sku": "pants-green-44",
-                      "source": { "locale": "en" },
+                      "source": { "locale": "en-US" },
                       "name": "Zeppelin Yoga Pant green 44 size",
                       "slug": "pants-green-44",
                       "status": "ENABLED",
@@ -921,7 +922,7 @@ paths:
                   [
                     {
                       "sku": "bundle-outfit",
-                      "source": { "locale": "en" },
+                      "source": { "locale": "en-US" },
                       "name": "Bundle Outfit",
                       "slug": "bundle-outfit",
                       "status": "ENABLED",
@@ -988,7 +989,7 @@ paths:
                     },
                     {
                       "sku": "top-red",
-                      "source": { "locale": "en" },
+                      "source": { "locale": "en-US" },
                       "name": "Red Top",
                       "slug": "top-red",
                       "status": "ENABLED",
@@ -1002,7 +1003,7 @@ paths:
                     },
                     {
                       "sku": "top-blue",
-                      "source": { "locale": "en" },
+                      "source": { "locale": "en-US" },
                       "name": "Blue Top",
                       "slug": "top-blue",
                       "status": "ENABLED",
@@ -1016,7 +1017,7 @@ paths:
                     },
                     {
                       "sku": "bottom-black",
-                      "source": { "locale": "en" },
+                      "source": { "locale": "en-US" },
                       "name": "Black Bottom",
                       "slug": "bottom-black",
                       "status": "ENABLED",
@@ -1030,7 +1031,7 @@ paths:
                     },
                     {
                       "sku": "bottom-white",
-                      "source": { "locale": "en" },
+                      "source": { "locale": "en-US" },
                       "name": "White Bottom",
                       "slug": "bottom-white",
                       "status": "ENABLED",
@@ -1044,7 +1045,7 @@ paths:
                     },
                     {
                       "sku": "socks",
-                      "source": { "locale": "en" },
+                      "source": { "locale": "en-US" },
                       "name": "Socks",
                       "slug": "socks",
                       "status": "ENABLED",
@@ -1058,7 +1059,7 @@ paths:
                     },
                     {
                       "sku": "headband",
-                      "source": { "locale": "en" },
+                      "source": { "locale": "en-US" },
                       "name": "Headband",
                       "slug": "headband",
                       "status": "ENABLED",
@@ -1118,7 +1119,7 @@ paths:
                   [
                     {
                       "sku": "red-pants",
-                      "source": { "locale": "en" },
+                      "source": { "locale": "en-US" },
                       "name": "Red pants - discounts!",
                       "metaTags": { "title": "Updated - Red" },
                       "attributes":
@@ -1144,7 +1145,7 @@ paths:
                   [
                     {
                       "sku": "pants-red-32",
-                      "source": { "locale": "en" },
+                      "source": { "locale": "en-US" },
                       "attributes":
                         [
                           {
@@ -1170,7 +1171,7 @@ paths:
                   [
                     {
                       "sku": "bundle-outfit",
-                      "source": { "locale": "en" },
+                      "source": { "locale": "en-US" },
                       "bundles":
                         [
                           {
@@ -1276,7 +1277,7 @@ paths:
                   [
                     {
                       "sku": "red-pants",
-                      "source": { "locale": "en" }
+                      "source": { "locale": "en-US" }
                     }
                   ]
   /v1/catalog/price-books:
@@ -1325,7 +1326,7 @@ paths:
           required: true
           schema:
             type: string
-          description: Authorization Bearer token
+            description: Authorization Bearer token
         - name: Content-Encoding
           in: header
           required: false
@@ -1445,7 +1446,7 @@ paths:
           required: true
           schema:
             type: string
-          description: Authorization Bearer token.
+            description: Authorization Bearer token.
         - name: Content-Encoding
           in: header
           required: false
@@ -1596,7 +1597,7 @@ paths:
           required: true
           schema:
             type: string
-          description: Authorization Bearer token.
+            description: Authorization Bearer token.
         - name: Content-Encoding
           in: header
           required: false
@@ -1951,12 +1952,13 @@ components:
         application/json;charset=UTF-8:
           schema:
             $ref: "#/components/schemas/ProcessFeedResponse"
+
     InvalidItemsResponse:
       x-summary: Request rejected
       description: |
         Some of the received items are invalid. Check the "message" and "errors" fields for details.
 
-        Common validation errors include:
+        Common causes of validation errors include:
 
         * **Invalid SKU**: SKU does not exist in the catalog
         * **Invalid Price Book**: Price book ID does not exist
@@ -1964,6 +1966,8 @@ components:
         * **Invalid Tier Quantities**: Quantities not in ascending order or less than 2
         * **Configurable Product Price**: Attempting to set price for configurable product SKU
         * **Invalid Price Format**: Non-numeric or negative price values
+        * **Incorrect Category Slug**: Invalid category slug format
+        * **Incorrect hierarchy configuration**: Misconfiguration of price book parent-child relationship
       content:
         application/json;charset=UTF-8:
           schema:
@@ -2000,6 +2004,7 @@ components:
       required: true
       schema:
         type: string
+        description: Authorization Bearer token
     ContentType:
       name: Content-Type
       in: header
@@ -2201,7 +2206,7 @@ components:
           pattern: "^[a-z0-9-]+(?:\\/[a-z0-9-]+)*$"
           description: |
             Category slug using hierarchical format with forward slashes to represent parent-child relationships.
-            Must use only lowercase letters, numbers, and hyphens.
+            String can contain only lowercase letters, numbers, and hyphens.
             Examples: 'men', 'men/clothing', 'men/clothing/pants'
           example: "men/clothing/pants"
         source:
@@ -2237,7 +2242,7 @@ components:
           pattern: "^[a-z0-9-]+(?:\\/[a-z0-9-]+)*$"
           description: |
             Category slug using hierarchical format with forward slashes to represent parent-child relationships.
-            Must use only lowercase letters, numbers, and hyphens.
+            String can contain only lowercase letters, numbers, and hyphens.
             Examples: 'men', 'men/clothing', 'men/clothing/pants'
           example: "men/clothing/pants"
         source:
@@ -2255,8 +2260,9 @@ components:
             type: string
           description: |
             Optional array of product family identifiers that this category is associated with.
-            Used for enhanced product organization and filtering.
-            Note: This field uses replace strategy - the entire array will be replaced with the new values.
+            Used for enhanced product organization and filtering. For example, for a clothing category,
+            you can associate it with the "apparel" family.
+            Note: This field uses the replace strategy to replace the entire array with the new values.
           example: ["apparel", "clothing"]
       additionalProperties: false
     FeedCategoryDelete:
@@ -2749,7 +2755,7 @@ components:
           example: 20.0
     Source:
       title: Catalog source
-      description: Source of the entity. For example it's locale "English"
+      description: Source of the entity, for example, "en-US" for US English.
       type: object
       required:
         - locale


### PR DESCRIPTION
## Purpose of this pull request

This pull request (PR) add documention for Categories MVP based on https://jira.corp.adobe.com/browse/DCAT-2626

[DCAT-2626](https://jira.corp.adobe.com/browse/DCAT-2626)

## Affected pages

- https://developer.adobe.com/commerce/services/optimizer/data-ingestion/
- https://developer.adobe.com/commerce/services/reference/rest/

## Links to source code

https://git.corp.adobe.com/magento-datalake/feeds-ingestion-service/pull/389

<!--
If you are fixing a GitHub issue, using the GitHub keyword format (https://help.github.com/en/articles/closing-issues-using-keywords#closing-an-issue-in-a-different-repository) closes the issue when this pull request is merged. Example: `Fixes #1234`.
`main` is the default branch. Merged pull requests to `main` go live on the site automatically. Any requested changes to content on the `main` branch must be related to the released codebase. Any content related to future releases goes in the `develop` branch.
See Contribution guidelines (https://github.com/AdobeDocs/commerce-services/blob/main/.github/CONTRIBUTING.md) for more information.
-->
