### PR TITLE
DCAT-2640: Allow merge strategy for array-type fields

### DIFF
--- a/static/rest/data-ingestion-schema-v1.yaml
+++ b/static/rest/data-ingestion-schema-v1.yaml
@@ -1208,7 +1208,7 @@ paths:
                   * The value of the existing `cost` attribute is replaced with new value
                   
                   The previously created `states` attribute is preserved.
-                  Note: Don't forget to <a href="#operation/createProductMetadata">create product attribute metadata</a> for the `warehouse` attribute if it doesn't exist yet.
+                  Note: Don't forget to create the product attribute metadata (<a href="#operation/createProductMetadata">link</a> for the `warehouse` attribute if it doesn't exist yet.
                 value:
                   [
                     {


### PR DESCRIPTION
## Purpose of this pull request

Updates the Data Ingestion API reference to with instructions and examples for performing partial entity updates for object list types using the merge strategy.

[JIRA-2639](https://jira.corp.adobe.com/browse/DCAT-2639)

## Affected pages

- https://developer.adobe.com/commerce/services/reference/rest/





