### PR TITLE
DCAT-3257: Adding category feed position field for sorting

### DIFF
--- a/static/rest/data-ingestion-schema-v1.yaml
+++ b/static/rest/data-ingestion-schema-v1.yaml
@@ -2444,7 +2444,7 @@ components:
         position:
           type: integer
           format: int32
-          description: Sort order of the category
+          description: Sort order for the category
         metaTags:
           $ref: "#/components/schemas/ProductMetaAttribute"
         images:
@@ -2498,7 +2498,7 @@ components:
         position:
           type: integer
           format: int32
-          description: Sort order of the category
+          description: Sort order for the category
         metaTags:
           $ref: "#/components/schemas/ProductMetaAttribute"
         images:

--- a/static/rest/data-ingestion-schema-v1.yaml
+++ b/static/rest/data-ingestion-schema-v1.yaml
@@ -426,6 +426,7 @@ paths:
           - Use the `name` field to define the display name for the category.
           - Use the optional `description` field to provide a full-text description of the category.
           - Use the optional `families` field to associate categories with product families for enhanced organization.
+          - Use the optional `position` field to assign a numeric sort order to the category.
           - Use the optional `metaTags` field to define SEO meta tags (title, description, keywords) for the category.
           - Use the optional `images` field to associate images with the category.
 
@@ -470,6 +471,7 @@ paths:
                       "name": "Men",
                       "description": "Men's clothing, shoes, and accessories",
                       "families": ["apparel", "accessories"],
+                      "position": 1,
                       "metaTags": {
                         "title": "Men's Collection",
                         "description": "Shop men's clothing, shoes, and accessories",
@@ -2439,6 +2441,10 @@ components:
             Optional array of product family identifiers that this category is associated with.
             Used for enhanced product organization and filtering.
           example: ["apparel", "clothing"]
+        position:
+          type: integer
+          format: int32
+          description: Sort order of the category
         metaTags:
           $ref: "#/components/schemas/ProductMetaAttribute"
         images:
@@ -2489,6 +2495,10 @@ components:
             you can associate it with the "apparel" family.
             Note: This field uses the replace strategy to replace the entire array with the new values.
           example: ["apparel", "clothing"]
+        position:
+          type: integer
+          format: int32
+          description: Sort order of the category
         metaTags:
           $ref: "#/components/schemas/ProductMetaAttribute"
         images:


### PR DESCRIPTION
## Purpose of this pull request

This pull request (PR) is the add the position field for sorting to the category feed record

JIRA: DCAT-3257

## Affected pages

* https://developer.adobe.com/commerce/services/reference/rest/#tag/Categories

## Links to Magento Open Source code

whatsnew
Documented the new `position` field for the [Categories REST API](https://developer.adobe.com/commerce/services/reference/rest/#operation/createCategories). This field is used to assign a numeric sort order to a category.